### PR TITLE
feat(persistence): initialize persistence layer

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -80,13 +80,6 @@
       }
     ],
     [
-      "@semantic-release/exec",
-      {
-        "prepareCmd": "./gradlew clean release -Pversion=${nextRelease.version} && echo ${nextRelease.version} > scripts/osctl/.version && (cd scripts/osctl && zip -r ../../osctl.zip .)",
-        "successCmd": "echo ${nextRelease.version} > VERSION"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "assets": [
@@ -100,10 +93,6 @@
           {
             "path": "README.md",
             "label": "Readme"
-          },
-          {
-            "path": "osctl.zip",
-            "label": "OpenSearch CLI Tools"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -2,31 +2,69 @@
 
 ![Pillarbox logo](docs/README-images/logo.jpg)
 
-Pillarbox Demo Backend is a Kotlin-based Koin & Ktor service designed to act as the lightweight
-backbone for media management.
-
-This service provides a simple REST API to publish, organize, and retrieve media assets using a
-simplified format. It is built to serve the Pillarbox demo ecosystem.
+Pillarbox Demo Backend is a Kotlin-based service designed to act as the lightweight backbone for
+media management within the [Pillarbox](https://pillarbox.ch) ecosystem.
 
 ## Quick Guide
 
 **Prerequisites and Requirements**
 
 - **JDK 24** or higher
+- **Docker & Docker Compose**: Required for running the local environment.
 
-**Setup**
+### Development Commands
 
-1. Build the Application:
-   ```bash
-   ./gradlew clean build -x test
-   ```
+| Task      | Command                        |
+|-----------|--------------------------------|
+| **Build** | `./gradlew build`              |
+| **Run**   | `./gradlew run`                |
+| **Test**  | `./gradlew test`               |
+| **Lint**  | `./gradlew ktlintCheck detekt` |
 
-2. Run the Application:
+> [!TIP]
+> Running `./gradlew run` automatically starts the required infrastructure via Docker Compose.
 
-- Using Gradle:
-  ```bash
-  ./gradlew run
-  ```
+## Documentation
+
+This project is a Kotlin-based application built with [Ktor][ktor] and [Koin][koin],
+using [Exposed][exposed] and [Flyway][flyway] to manage data persistence in a PostgreSQL database.
+
+### Core Functionality
+
+The service bridges the gap between media management and player consumption through versioned
+endpoints:
+
+1. **Management API**: A CRUD interface to publish and organize media metadata using a rich domain
+   model.
+2. **Player API**: A specialized endpoint that serves media in a format optimized for Pillarbox
+   players. This API implements selection logic for streams and DRM based on client preferences.
+
+All player-facing responses are strictly validated against
+the [Pillarbox Standard Metadata Schema][pillarbox-schema].
+
+### Data Flow
+
+The following diagram illustrates how the Management and Player APIs interact with the persistence
+layer:
+
+```mermaid
+sequenceDiagram
+  participant Admin as Management Client
+  participant App as Pillarbox Backend
+  participant DB as Database
+  participant Player as Pillarbox Player
+  Note over Admin, DB: Media Publication
+  Admin ->> App: Publish Media
+  App ->> DB: Persist Domain Model
+  DB -->> App: Success
+  App -->> Admin: Created
+  Note over Player, DB: Media Consumption
+  Player ->> App: Request Playback
+  App ->> DB: Fetch Domain Model
+  DB -->> App: Data retrieved
+  App ->> App: Adapt to Player Format
+  App -->> Player: Return Optimized Media
+```
 
 ### Continuous Integration
 
@@ -38,7 +76,8 @@ This project automates its own development workflow using GitHub Actions:
 
 2. **Release Workflow**
    When changes are pushed to `main`, this workflow handles versioning and releases with
-   `semantic-release`. It automatically bumps the version, generates release notes, creates a tag.
+   `semantic-release`. It automatically bumps the version, generates release notes, creates a tag,
+   and publishes a Docker image to Amazon ECR
 
 ## Contributing
 
@@ -80,4 +119,8 @@ Refer to our [Contribution Guide](docs/CONTRIBUTING.md) for more detailed inform
 
 This project is licensed under the [MIT License](LICENSE).
 
-[main-entry-point]: src/main/kotlin/ch/srgssr/pillarbox/backend/PillarboxBackendApplication.kt
+[ktor]: https://ktor.io/
+[koin]: https://insert-koin.io/
+[exposed]: https://jetbrains.github.io/Exposed/
+[flyway]: https://flywaydb.org/
+[pillarbox-schema]: src/test/resources/schemas/pillarbox-standard-metadata-schema.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,20 +27,22 @@ repositories {
 
 dependencies {
   // Dependencies
+  implementation(libs.bundles.exposed)
+  implementation(libs.bundles.flyway)
   implementation(libs.bundles.koin)
   implementation(libs.bundles.kotlinx)
   implementation(libs.bundles.ktor.server)
+  implementation(libs.hikaricp)
   implementation(libs.logback.classic)
+  implementation(libs.postgresql)
 
   // Test Dependencies
+  testImplementation(libs.bundles.ktor.test)
+  testImplementation(libs.h2)
+  testImplementation(libs.json.schema.validator)
   testImplementation(libs.kotest.assertions.ktor)
-  testImplementation(libs.kotest.extensions.koin) {
-    exclude(group = "io.insert-koin", module = "koin-core")
-    exclude(group = "io.insert-koin", module = "koin-test")
-  }
   testImplementation(libs.kotest.runner.junit5)
   testImplementation(libs.kotlinx.coroutines.test)
-  testImplementation(libs.ktor.server.test.host)
   testImplementation(libs.mockk)
 }
 
@@ -119,3 +121,26 @@ configurations
       }
     }
   }
+
+val startEnvironment =
+  tasks.register<Exec>("startEnvironment") {
+    group = "environment"
+    description = "Starts the Docker Compose environment for local development"
+    commandLine("docker", "compose", "up", "-d", "--wait")
+  }
+
+tasks.register<Exec>("stopEnvironment") {
+  group = "environment"
+  description = "Stops the Docker Compose environment"
+  commandLine("docker", "compose", "down")
+}
+
+tasks.withType<JavaExec>().configureEach {
+  environment("DATABASE_URL", "jdbc:postgresql://localhost:5432/pillarbox")
+  environment("DATABASE_USER", "dev_user")
+  environment("DATABASE_PASSWORD", "dev_password")
+}
+
+tasks.run {
+  dependsOn(startEnvironment)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: pillarbox
+      POSTGRES_USER: dev_user
+      POSTGRES_PASSWORD: dev_password
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U dev_user -d pillarbox"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,11 @@ shadow = "9.3.1"
 versions-plugin = "0.53.0"
 
 # Libs
+exposed = "1.0.0"
+flyway = "12.0.0"
+h2 = "2.4.240"
+hikaricp = "7.0.2"
+json-schema-validator = "3.0.0"
 koin = "4.1.1"
 kotest = "6.1.3"
 kotlinx-coroutines = "1.10.2"
@@ -16,8 +21,16 @@ kotlinx-serialization-json = "1.10.0"
 ktor = "3.4.0"
 logback = "1.5.32"
 mockk = "1.14.9"
+postgresql = "42.7.9"
 
 [libraries]
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
+flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
+hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
 koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
@@ -28,17 +41,32 @@ ktor-server-content-negotation = { module = "io.ktor:ktor-server-content-negotia
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # Tests
-koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+h2 = { module = "com.h2database:h2", version.ref = "h2" }
+json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "json-schema-validator" }
 kotest-assertions-ktor = { module = "io.kotest:kotest-assertions-ktor", version.ref = "kotest" }
-kotest-extensions-koin = { module = "io.kotest:kotest-extensions-koin", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [bundles]
+exposed = [
+  "exposed-core",
+  "exposed-dao",
+  "exposed-jdbc",
+  "exposed-json"
+]
+
+flyway = [
+  "flyway-core",
+  "flyway-postgresql"
+]
+
 koin = [
   "koin-core",
   "koin-ktor",
@@ -50,6 +78,12 @@ ktor-server = [
   "ktor-server-netty",
   "ktor-server-content-negotation",
   "ktor-serialization-kotlinx-json"
+]
+
+ktor-test = [
+  "ktor-server-test-host",
+  "ktor-client-content-negotiation",
+  "ktor-client-serialization-kotlinx-json"
 ]
 
 kotlinx = [

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -1,5 +1,7 @@
 package ch.srgssr.pillarbox.backend
 
+import ch.srgssr.pillarbox.backend.db.databaseModule
+import ch.srgssr.pillarbox.backend.db.toDatabaseConfig
 import ch.srgssr.pillarbox.backend.entrypoint.web.media
 import ch.srgssr.pillarbox.backend.entrypoint.web.playerMedia
 import ch.srgssr.pillarbox.backend.io.jsonModule
@@ -27,6 +29,7 @@ fun Application.module() {
   install(Koin) {
     slf4jLogger()
     modules(
+      databaseModule(environment.config.toDatabaseConfig()),
       persistenceModule(),
       jsonModule(),
     )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DataSourceMigration.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DataSourceMigration.kt
@@ -1,0 +1,20 @@
+package ch.srgssr.pillarbox.backend.db
+
+import org.flywaydb.core.Flyway
+import javax.sql.DataSource
+
+/**
+ * Executes database schema migrations using Flyway.e
+ *
+ * This extension function initializes Flyway with the current [DataSource] and
+ * applies all pending migration scripts found in the default location (`db/migration`).
+ *
+ * @throws org.flywaydb.core.api.FlywayException If the migration fails.
+ */
+fun DataSource.runMigration() {
+  Flyway
+    .configure()
+    .dataSource(this)
+    .load()
+    .migrate()
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseConfig.kt
@@ -1,0 +1,83 @@
+package ch.srgssr.pillarbox.backend.db
+
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.config.ApplicationConfigurationException
+
+/**
+ * Configuration parameters for the database connection pool (HikariCP).
+ *
+ * @property driverClassName The fully qualified name of the JDBC driver class (e.g., "org.postgresql.Driver").
+ * @property jdbcUrl The connection string for the database.
+ * @property username Database authentication username.
+ * @property password Database authentication password.
+ * @property poolSize Maximum number of connections in the pool. Defaults to 10.
+ * @property connectionTimeout Maximum time (in ms) to wait for a connection from the pool. Defaults to 30s.
+ * @property idleTimeout Maximum time (in ms) a connection is allowed to sit idle in the pool. Defaults to 10m.
+ * @property dataSourceProperties Additional vendor-specific properties passed to the JDBC driver.
+ */
+data class DatabaseConfig(
+  val autoCreate: Boolean = false,
+  val driverClassName: String,
+  val jdbcUrl: String,
+  val username: String,
+  val password: String,
+  val poolSize: Int = 10,
+  val connectionTimeout: Long = 30000,
+  val idleTimeout: Long = 600000,
+  val dataSourceProperties: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Maps an [ApplicationConfig] to a [DatabaseConfig] instance.
+ *
+ * It expects a `database` block in the configuration. e.g.:
+ * ```hocon
+ * database {
+ *    driverClassName = "org.postgresql.Driver"
+ *    jdbcUrl = "jdbc:postgresql://localhost:5432/db"
+ *    username = "user"
+ *    password = "password"
+ *    properties {
+ *      ssl = "true"
+ *    }
+ * }
+ * ```
+ *
+ * @throws ApplicationConfigurationException If required fields are missing.
+ *
+ * @return A populated [DatabaseConfig].
+ */
+fun ApplicationConfig.toDatabaseConfig(): DatabaseConfig {
+  val db = config("database")
+  val customProps = mutableMapOf<String, String>()
+
+  db.configOrNull("properties")?.keys()?.forEach { key ->
+    customProps[key] = db.property("properties.$key").getString()
+  }
+
+  return DatabaseConfig(
+    autoCreate = db.property("autoCreate").getString().toBoolean(),
+    driverClassName = db.property("driverClassName").getString(),
+    jdbcUrl = db.property("jdbcUrl").getString(),
+    username = db.property("username").getString(),
+    password = db.property("password").getString(),
+    poolSize = db.propertyOrNull("poolSize")?.getString()?.toInt() ?: 10,
+    connectionTimeout = db.propertyOrNull("connectionTimeout")?.getString()?.toLong() ?: 30000,
+    idleTimeout = db.propertyOrNull("idleTimeout")?.getString()?.toLong() ?: 60000,
+    dataSourceProperties = customProps,
+  )
+}
+
+/**
+ * Safely retrieves a sub-configuration block.
+ *
+ * @param path The configuration path to retrieve.
+ *
+ * @return The [ApplicationConfig] at the path, or `null` if the path does not exist.
+ */
+fun ApplicationConfig.configOrNull(path: String): ApplicationConfig? =
+  try {
+    config(path)
+  } catch (_: ApplicationConfigurationException) {
+    null
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
@@ -1,0 +1,64 @@
+package ch.srgssr.pillarbox.backend.db
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.core.logger.Level.DEBUG
+import org.koin.dsl.module
+import javax.sql.DataSource
+
+/**
+ * Defines the Koin module for database infrastructure.
+ *
+ * This module provides:
+ *   1. A [DataSource] (HikariCP) configured using the provided [dbConfig].
+ *   2. An Exposed [Database] instance, which automatically triggers [runMigration] on the
+ *      data source before establishing the connection.
+ *
+ * @param dbConfig The configuration parameters for the database.
+ *
+ * @return A Koin [Module] containing the database infrastructure definitions.
+ */
+fun databaseModule(dbConfig: DatabaseConfig) =
+  module {
+    single<DataSource> {
+      HikariDataSource(
+        HikariConfig().apply {
+          driverClassName = dbConfig.driverClassName
+          jdbcUrl = dbConfig.jdbcUrl
+          username = dbConfig.username
+          password = dbConfig.password
+
+          maximumPoolSize = dbConfig.poolSize
+          connectionTimeout = dbConfig.connectionTimeout
+          idleTimeout = dbConfig.idleTimeout
+
+          // Apply JDBC properties
+          dbConfig.dataSourceProperties.forEach { (key, value) ->
+            addDataSourceProperty(key, value)
+          }
+
+          validate()
+        },
+      )
+    }
+
+    single {
+      val dataSource = get<DataSource>()
+      val db = Database.connect(dataSource)
+
+      if (dbConfig.autoCreate) {
+        val allTables = getAll<Table>().toTypedArray()
+
+        transaction(db) {
+          SchemaUtils.create(*allTables)
+        }
+      } else {
+        dataSource.runMigration()
+      }
+      db
+    }
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/ExposedRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/ExposedRepository.kt
@@ -1,0 +1,125 @@
+package ch.srgssr.pillarbox.backend.db
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flow
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.Transaction
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
+import org.jetbrains.exposed.v1.jdbc.upsert
+
+/**
+ * Abstract repository providing a bridge between domain entities [T] and the [Table] storage.
+ *
+ * This class handles common CRUD operations using the Exposed framework and ensures that these
+ * operations are performed within the appropriate transaction context.
+ *
+ * @param T The domain model type.
+ * @param ID The type of the unique identifier (e.g., String, Int, UUID).
+ * @property db The [Database] instance to execute queries against.
+ * @property table The Exposed [Table] definition.
+ * @property idColumn The specific [Column] used as the primary lookup key.
+ */
+abstract class ExposedRepository<T, ID>(
+  private val db: Database,
+  private val table: Table,
+  private val idColumn: Column<ID>,
+) {
+  /**
+   * Maps a database [ResultRow] back into the domain entity [T].
+   */
+  protected abstract fun ResultRow.decode(): T
+
+  /**
+   * Maps a domain entity [T] onto the [UpdateBuilder] for persistence.
+   */
+  protected abstract fun Table.encode(
+    builder: UpdateBuilder<*>,
+    item: T,
+  )
+
+  /**
+   * Executes a database [block] within a suspended transaction.
+   *
+   *  @param readOnly If true, optimizes the transaction for read operations.
+   */
+  protected suspend fun <R> query(
+    readOnly: Boolean = false,
+    block: suspend Transaction.() -> R,
+  ): R = suspendTransaction(db = db, readOnly = readOnly) { block() }
+
+  /**
+   * Finds a specific resource by its unique identifier.
+   *
+   * @param id The unique identifier of the entity.
+   *
+   * @return The entity [T] if found, or null if no match exists.
+   */
+  open suspend fun find(id: ID): T? =
+    query(readOnly = true) {
+      table
+        .selectAll()
+        .where { idColumn eq id }
+        .map { it.decode() } // Uses the internal hook
+        .singleOrNull()
+    }
+
+  /**
+   * Retrieves a paginated stream of all available resources.
+   *
+   * @param limit The maximum number of items to return.
+   * @param offset The number of items to skip for pagination.
+   *
+   * @return A [Flow] emitting the collection of [T] objects.
+   */
+  open fun getAll(
+    limit: Int = 100,
+    offset: Long = 0,
+  ): Flow<T> =
+    channelFlow {
+      query(readOnly = true) {
+        table
+          .selectAll()
+          .limit(limit)
+          .offset(offset)
+          .forEach { row ->
+            send(row.decode())
+          }
+      }
+    }
+
+  /**
+   * Persists or overwrites a resource using an upsert operation.
+   *
+   * @param idValue The unique identifier to associate with this entity.
+   *
+   * @param item The entity to save.
+   */
+  open suspend fun save(
+    idValue: ID,
+    item: T,
+  ) = query {
+    table.upsert {
+      encode(it, item)
+    }
+  }
+
+  /**
+   * Deletes a resource from the persistence layer.
+   *
+   * @param id The unique identifier of the entity to delete.
+   *
+   * @return true if the entity was successfully deleted, false if it did not exist.
+   */
+  open suspend fun delete(id: ID) =
+    query {
+      table.deleteWhere { idColumn eq id } > 0
+    }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
@@ -1,7 +1,9 @@
 package ch.srgssr.pillarbox.backend.persistence
 
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
+import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
 import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.Table
 import org.koin.dsl.module
 
 /**
@@ -12,5 +14,6 @@ import org.koin.dsl.module
  */
 fun persistenceModule() =
   module {
-    single { MediaRepository() }
+    single<Table> { MediaTable }
+    single { MediaRepository(get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
@@ -1,77 +1,79 @@
 package ch.srgssr.pillarbox.backend.persistence.media
 
+import ch.srgssr.pillarbox.backend.db.ExposedRepository
 import ch.srgssr.pillarbox.backend.domain.model.Media
-import kotlinx.coroutines.flow.Flow
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.update
 
 /**
- * Repository responsible for the persistence and retrieval of [Media] entities.
+ * Repository responsible for the persistence and retrieval of [Media] entities using Exposed.
  *
- * This class serves as the bridge between the domain layer and the data storage.
+ * This implementation maps the [Media] domain model to the [MediaTable] schema and
+ * provides specialized methods for media-specific data manipulations.
+ *
+ * @param db The [Database] instance used for all transactions.
  */
-@SuppressWarnings("UNUSED_PARAMETER")
-class MediaRepository {
+class MediaRepository(
+  db: Database,
+) : ExposedRepository<Media, String>(db = db, table = MediaTable, idColumn = MediaTable.id) {
   /**
-   * Retrieves a paginated stream of all available media resources.
-   *
-   * @param limit The maximum number of items to return.
-   * @param offset The number of items to skip for pagination.
-   *
-   * @return A [Flow] emitting the collection of [Media] objects.
+   * Decodes a [ResultRow] from the [MediaTable] into a [Media] domain object.
    */
-  suspend fun getAll(
-    limit: Int,
-    offset: Long,
-  ): Flow<Media> {
-    TODO("Not yet implemented")
-  }
+  override fun ResultRow.decode() =
+    Media(
+      id = this[MediaTable.id],
+      tags = this[MediaTable.tags],
+      sources = this[MediaTable.sources],
+      drmConfigs = this[MediaTable.drmConfigs],
+      metadata = this[MediaTable.metadata],
+    )
 
   /**
-   * Finds a specific media resource by its unique identifier.
-   *
-   * @param id The unique identifier of the media.
-   * @return The [Media] object if found, or null if no match exists.
+   * Encodes a [Media] domain object into an [UpdateBuilder] for inserts or upserts.
    */
-  suspend fun find(id: String): Media? {
-    TODO("Not yet implemented")
-  }
-
-  /**
-   * Persists or overwrites a media resource.
-   *
-   * @param id The unique identifier to associate with this media.
-   * @param media The media entity to save.
-   */
-  suspend fun save(
-    id: String,
-    media: Media,
+  override fun Table.encode(
+    builder: UpdateBuilder<*>,
+    item: Media,
   ) {
-    TODO("Not yet implemented")
+    builder[MediaTable.id] = item.id
+    builder[MediaTable.tags] = item.tags
+    builder[MediaTable.sources] = item.sources
+    builder[MediaTable.drmConfigs] = item.drmConfigs
+    builder[MediaTable.metadata] = item.metadata
   }
 
   /**
    * Atomically updates the tags of a specific media resource.
    *
-   * This method retrieves the existing tags, applies the [transform] function,
-   * and persists the result.
+   * This method retrieves the current tags within a transaction, applies the [transform]
+   * function, and persists the updated list back to the database.
    *
    * @param id The unique identifier of the media to update.
    * @param transform A lambda that receives the current list of tags and returns the new list.
-   * @return The updated list of tags if the media was found and updated, or null if the media does not exist.
+   *
+   * @return The updated list of tags if the media was found and updated, or `null` if the media does not exist.
    */
   suspend fun updateTags(
     id: String,
     transform: (List<String>) -> List<String>,
-  ): List<String>? {
-    TODO("Not yet implemented")
-  }
+  ): List<String>? =
+    query {
+      val currentTags =
+        MediaTable
+          .select(MediaTable.tags)
+          .where { MediaTable.id eq id }
+          .singleOrNull()
+          ?.get(MediaTable.tags) ?: return@query null
 
-  /**
-   * Deletes a media resource from the persistence layer.
-   *
-   * @param id The unique identifier of the media to delete.
-   * @return true if the media was successfully deleted, false if it did not exist.
-   */
-  suspend fun delete(id: String): Boolean {
-    TODO("Not yet implemented")
-  }
+      val updatedTags = transform(currentTags)
+
+      MediaTable.update({ MediaTable.id eq id }) { it[tags] = updatedTags }
+
+      updatedTags
+    }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaTable.kt
@@ -1,0 +1,48 @@
+package ch.srgssr.pillarbox.backend.persistence.media
+
+import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
+import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.domain.model.MediaSource
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.json.jsonb
+
+/**
+ * Exposed table definition for persisting media content.
+ *
+ * This table stores information about media items and their associated sources and metadata.
+ */
+object MediaTable : Table("pb_media") {
+  /**
+   * Unique identifier for the media item.
+   */
+  val id = varchar("id", 255)
+
+  /**
+   * A list of labels or categories associated with the media.
+   */
+  val tags = array<String>("tags")
+
+  /**
+   * Digital Rights Management configurations.
+   * Stored as a JSONB list of [DrmConfig] objects.
+   */
+  val drmConfigs = jsonb<List<DrmConfig>>("drm_configs", Json.Default)
+
+  /**
+   * List of available delivery sources.
+   * Stored as a JSONB list of [MediaSource] objects.
+   */
+  val sources = jsonb<List<MediaSource>>("sources", Json.Default)
+
+  /**
+   * Descriptive information about the media.
+   * Stored as a single JSONB [MediaMetadata] object.
+   */
+  val metadata = jsonb<MediaMetadata>("metadata", Json.Default)
+
+  /**
+   * Primary key definition using the [id] column.
+   */
+  override val primaryKey = PrimaryKey(id)
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,3 +8,22 @@ ktor {
     modules = [ch.srgssr.pillarbox.backend.ApplicationKt.module]
   }
 }
+
+database {
+  autoCreate = false
+  driverClassName = "org.postgresql.Driver"
+  jdbcUrl = ${?DATABASE_URL}
+  username = ${?DATABASE_USER}
+  password = ${?DATABASE_PASSWORD}
+
+  poolSize = 10
+  connectionTimeout = 30000
+
+  properties {
+    cachePrepStmts = "true"
+    prepStmtCacheSize = "250"
+    prepStmtCacheSqlLimit = "2048"
+    useServerPrepStmts = "true"
+    reWriteBatchedInserts = "true"
+  }
+}

--- a/src/main/resources/db/migration/V1__Initial_Schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_Schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS pb_media (
+  id VARCHAR(255) PRIMARY KEY,
+  tags TEXT[] NOT NULL,
+  sources JSONB NOT NULL,
+  drm_configs JSONB NOT NULL,
+  metadata JSONB NOT NULL
+  );

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
@@ -1,21 +1,136 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web
 
-import ch.srgssr.pillarbox.backend.module
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagActionV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagOperationV1
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
 import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.testing.testApplication
+import io.ktor.http.contentType
 
 class MediaRouteTest :
   ShouldSpec({
-    should("Return internal server error on unimplemented REST call") {
-      testApplication {
-        application { module() }
-
+    should("return an empty list if no media is stored") {
+      testApplicationContext {
         val response = client.get("/v1/media")
 
-        response shouldHaveStatus HttpStatusCode.InternalServerError
+        response shouldHaveStatus HttpStatusCode.OK
+
+        val mediaList = response.body<List<MediaResponseV1>>()
+
+        mediaList.shouldBeEmpty()
+      }
+    }
+
+    should("create a media, update the tags and delete it") {
+      testApplicationContext {
+        val fixture = mediaFixture { id = "test-media-id" }
+        val request = fixture.toMediaRequestV1()
+
+        // Create the media
+        client.post("/v1/media") {
+          contentType(ContentType.Application.Json)
+          setBody(request)
+        } shouldHaveStatus HttpStatusCode.Created
+
+        // Update tags
+        val tagUpdate =
+          TagBatchUpdateRequestV1(
+            operations =
+              listOf(
+                TagOperationV1(TagActionV1.ADD, listOf("test-tag")),
+              ),
+          )
+
+        client.patch("/v1/media/${fixture.id}/tags") {
+          contentType(ContentType.Application.Json)
+          setBody(tagUpdate)
+        } shouldHaveStatus HttpStatusCode.OK
+
+        // Verify tags
+        val response = client.get("/v1/media/${fixture.id}")
+        response.body<MediaResponseV1>().tags shouldContain "test-tag"
+
+        // Delete the Media
+        client.delete("/v1/media/${fixture.id}") shouldHaveStatus HttpStatusCode.NoContent
+        client.get("/v1/media/${fixture.id}") shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return paginated media correctly") {
+      testApplicationContext {
+        val totalMedia = 19
+        for (i in 0..totalMedia) {
+          val fixture = mediaFixture { id = "media-$i" }
+          client.post("/v1/media") {
+            contentType(ContentType.Application.Json)
+            setBody(fixture.toMediaRequestV1())
+          } shouldHaveStatus HttpStatusCode.Created
+        }
+
+        client.getMediaPageV1(limit = 5, offset = 0).let { page ->
+          page.size shouldBe 5
+          page.first().id shouldBe "media-0"
+        }
+
+        client.getMediaPageV1(limit = 1, offset = 5).let { page ->
+          page.size shouldBe 1
+          page.first().id shouldBe "media-5"
+        }
+
+        client.getMediaPageV1(limit = 1, offset = 20).size shouldBe 0
+      }
+    }
+
+    should("return NOT_FOUND when patching tags of a non-existent media") {
+      testApplicationContext {
+        val tagUpdate =
+          TagBatchUpdateRequestV1(
+            operations =
+              listOf(
+                TagOperationV1(TagActionV1.ADD, listOf("some-tag")),
+              ),
+          )
+
+        client.patch("/v1/media/does-not-exist/tags") {
+          contentType(ContentType.Application.Json)
+          setBody(tagUpdate)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return NOT_FOUND when deleting a non-existent media") {
+      testApplicationContext {
+        client.delete("/v1/media/does-not-exist") shouldHaveStatus HttpStatusCode.NotFound
       }
     }
   })
+
+/**
+ * Extension to fetch media with pagination parameters.
+ */
+suspend fun HttpClient.getMediaPageV1(
+  limit: Int,
+  offset: Int,
+): List<MediaResponseV1> =
+  get("/v1/media") {
+    url {
+      parameters.append("limit", limit.toString())
+      parameters.append("offset", offset.toString())
+    }
+  }.body()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
@@ -1,0 +1,110 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web
+
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.PlayerMediaResponseV1
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.shouldMatchSchema
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+
+class PlayerMediaRouteTest :
+  ShouldSpec({
+    should("return an empty list if no media is stored") {
+      testApplicationContext {
+        val response = client.get("/v1/player/media")
+
+        response shouldHaveStatus HttpStatusCode.OK
+
+        val mediaList = response.body<List<MediaResponseV1>>()
+
+        mediaList.shouldBeEmpty()
+      }
+    }
+
+    should("serve a media matching the standard player specification") {
+      testApplicationContext {
+        val mediaId = "test-player-media-id"
+        val mediaFixture =
+          mediaFixture {
+            id = mediaId
+            withDash()
+            withHls()
+            withWidevine()
+            withSubtitles()
+            withIntro()
+            withChapters()
+          }
+
+        client.post("/v1/media") {
+          contentType(ContentType.Application.Json)
+          setBody(mediaFixture.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val response =
+          client.get("/v1/player/media/$mediaId") {
+            header("X-Accept-Stream-Type", "application/x-mpegURL")
+            header("X-Accept-DRM", "com.widevine.alpha")
+          }
+
+        response shouldMatchSchema "schemas/pillarbox-standard-metadata-schema.json"
+      }
+    }
+
+    should("return NOT_FOUND when retrieving a non-existent media") {
+      testApplicationContext {
+        client.get("/v1/player/media/does-not-exist") shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return paginated media correctly") {
+      testApplicationContext {
+        val totalMedia = 19
+        for (i in 0..totalMedia) {
+          val fixture = mediaFixture { id = "media-$i" }
+          client.post("/v1/media") {
+            contentType(ContentType.Application.Json)
+            setBody(fixture.toMediaRequestV1())
+          } shouldHaveStatus HttpStatusCode.Created
+        }
+
+        client.getPlayerMediaPageV1(limit = 5, offset = 0).let { page ->
+          page.size shouldBe 5
+          page.first().identifier shouldBe "media-0"
+        }
+
+        client.getPlayerMediaPageV1(limit = 1, offset = 5).let { page ->
+          page.size shouldBe 1
+          page.first().identifier shouldBe "media-5"
+        }
+
+        client.getPlayerMediaPageV1(limit = 1, offset = 20).size shouldBe 0
+      }
+    }
+  })
+
+/**
+ * Extension to fetch media with pagination parameters.
+ */
+suspend fun HttpClient.getPlayerMediaPageV1(
+  limit: Int,
+  offset: Int,
+): List<PlayerMediaResponseV1> =
+  get("/v1/player/media") {
+    url {
+      parameters.append("limit", limit.toString())
+      parameters.append("offset", offset.toString())
+    }
+  }.body()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/JsonSchemaMatcher.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/JsonSchemaMatcher.kt
@@ -1,0 +1,47 @@
+package ch.srgssr.pillarbox.backend.test
+
+import com.networknt.schema.InputFormat
+import com.networknt.schema.SchemaLocation
+import com.networknt.schema.SchemaRegistry
+import com.networknt.schema.SpecificationVersion
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.runBlocking
+
+class JsonSchemaMatcher(
+  private val schemaPath: String,
+) : Matcher<HttpResponse> {
+  companion object {
+    private val registry: SchemaRegistry =
+      SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_2020_12)
+  }
+
+  override fun test(value: HttpResponse): MatcherResult {
+    val jsonString = runBlocking { value.bodyAsText() }
+
+    val schema = registry.getSchema(SchemaLocation.of("classpath:$schemaPath"))
+    val result =
+      schema.validate(jsonString, InputFormat.JSON) { context ->
+        context.executionConfig { config ->
+          config.formatAssertionsEnabled(true)
+        }
+      }
+
+    return MatcherResult(
+      passed = result.isEmpty(),
+      failureMessageFn = {
+        val details = result.joinToString("\n") { "[${it.instanceLocation}] ${it.message}" }
+        "Response did not match schema at $schemaPath:\n$details"
+      },
+      negatedFailureMessageFn = { "Response should NOT have matched schema $schemaPath" },
+    )
+  }
+}
+
+infix fun HttpResponse.shouldMatchSchema(path: String): HttpResponse {
+  this should JsonSchemaMatcher(path)
+  return this
+}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
@@ -1,30 +1,59 @@
 package ch.srgssr.pillarbox.backend.test
 
+import ch.srgssr.pillarbox.backend.domain.model.Chapter
 import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
+import ch.srgssr.pillarbox.backend.domain.model.SubtitleTrack
+import ch.srgssr.pillarbox.backend.domain.model.TimeRange
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaRequestV1
 
 object MediaLibrary {
-  // --- Sources ---
+  // Sources
   val Dash = MediaSource(url = "https://stream.com/dash/index.mpd", mimeType = "application/dash+xml")
   val Hls = MediaSource(url = "https://stream.com/hls/master.m3u8", mimeType = "application/x-mpegURL")
   val Mp4 = MediaSource(url = "https://stream.com/video.mp4", mimeType = "video/mp4")
 
-  // --- DRM Systems ---
+  // DRM Configs
   val Widevine = DrmConfig(keySystem = "com.widevine.alpha", licenseUrl = "https://wv.license.com")
   val PlayReady = DrmConfig(keySystem = "com.microsoft.playready", licenseUrl = "https://pr.license.com")
   val FairPlay = DrmConfig(keySystem = "com.apple.fps", licenseUrl = "https://fp.license.com")
   val ClearKey = DrmConfig(keySystem = "org.w3.clearkey", licenseUrl = "https://ck.license.com")
+
+  // Metadata
+  val EnglishSubtitles =
+    SubtitleTrack(
+      label = "English",
+      kind = "subtitles",
+      language = "en",
+      url = "https://stream.com/en.vtt",
+    )
+
+  val IntroRange =
+    TimeRange(
+      startTime = 0L,
+      endTime = 30000L,
+      type = "intro",
+    )
+
+  val FirstChapter =
+    Chapter(
+      title = "Opening",
+      startTime = 0L,
+      endTime = 60000L,
+    )
 }
 
 class MediaBuilder {
   var id: String = "test-media-id"
   private val sources = mutableListOf<MediaSource>()
   private val drmConfigs = mutableListOf<DrmConfig>()
+  private val subtitles = mutableListOf<SubtitleTrack>()
+  private val chapters = mutableListOf<Chapter>()
+  private val timeRanges = mutableListOf<TimeRange>()
   var metadata = MediaMetadata(title = "Default Test Title")
 
-  // Helper methods for easy "pulling" from library
   fun withDash() = apply { sources.add(MediaLibrary.Dash) }
 
   fun withHls() = apply { sources.add(MediaLibrary.Hls) }
@@ -39,13 +68,33 @@ class MediaBuilder {
 
   fun withClearKey() = apply { drmConfigs.add(MediaLibrary.ClearKey) }
 
+  fun withSubtitles() = apply { subtitles.add(MediaLibrary.EnglishSubtitles) }
+
+  fun withIntro() = apply { timeRanges.add(MediaLibrary.IntroRange) }
+
+  fun withChapters() = apply { chapters.add(MediaLibrary.FirstChapter) }
+
   fun build() =
     Media(
       id = id,
       sources = sources.ifEmpty { listOf(MediaLibrary.Dash) }, // Sane default
       drmConfigs = drmConfigs,
-      metadata = metadata,
+      metadata =
+        metadata.copy(
+          subtitles = subtitles.ifEmpty { null },
+          chapters = chapters.ifEmpty { null },
+          timeRanges = timeRanges.ifEmpty { null },
+        ),
     )
 }
 
 fun mediaFixture(block: MediaBuilder.() -> Unit = {}) = MediaBuilder().apply(block).build()
+
+fun Media.toMediaRequestV1() =
+  MediaRequestV1(
+    id = id,
+    tags = tags,
+    sources = sources,
+    drmConfigs = drmConfigs,
+    metadata = metadata,
+  )

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -1,0 +1,57 @@
+package ch.srgssr.pillarbox.backend.test
+
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.koin.core.context.GlobalContext
+
+/**
+ * Executes an integration test within a managed Ktor application environment.
+ *
+ * This utility automates the integration testing by:
+ *    1. Loading the standard `application.conf` to configure the server and database.
+ *    2. Providing a pre-configured [HttpClient] with JSON support for API calls.
+ *    3. Ensuring database isolation between tests by dropping and recreating all
+ *       registered [Table] schemas after each test execution.
+ *
+ * @param block The test logic to execute, provides access to the [ApplicationTestBuilder]
+ *              and a pre-configured `client` with JSON support.
+ */
+fun testApplicationContext(block: suspend ApplicationTestBuilder.() -> Unit) =
+  testApplication {
+    environment {
+      config = ApplicationConfig("application.conf")
+    }
+
+    client =
+      createClient {
+        install(ContentNegotiation) {
+          json(
+            Json {
+              explicitNulls = false
+            },
+          )
+        }
+      }
+
+    try {
+      block()
+    } finally {
+      val allTables =
+        GlobalContext
+          .get()
+          .getAll<Table>()
+          .toList()
+          .toTypedArray()
+      transaction {
+        SchemaUtils.drop(*allTables)
+        SchemaUtils.create(*allTables)
+      }
+    }
+  }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,0 +1,8 @@
+database {
+  autoCreate = true
+  driverClassName = "org.h2.Driver"
+  jdbcUrl = "jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+  username = "sa"
+  password = ""
+  poolSize = 5
+}

--- a/src/test/resources/schemas/pillarbox-standard-metadata-schema.json
+++ b/src/test/resources/schemas/pillarbox-standard-metadata-schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "identifier": { "type": "string" },
+    "title": { "type": "string" },
+    "subtitle": { "type": "string" },
+    "description": { "type": "string" },
+    "posterUrl": { "type": "string", "format": "uri" },
+    "seasonNumber": { "type": "integer" },
+    "episodeNumber": { "type": "integer" },
+    "viewport": { "type": "string" },
+    "source": {
+      "type": "object",
+      "properties": {
+        "url": { "type": "string", "format": "uri" },
+        "type": { "type": "string" },
+        "mimeType": { "type": "string" },
+        "videoFragmentFormat": { "type": "string" },
+        "audioFragmentsFormat": { "type": "string" }
+      },
+      "required": ["url"]
+    },
+    "drm": {
+      "type": "object",
+      "properties": {
+        "keySystem": { "type": "string" },
+        "licenseUrl": { "type": "string", "format": "uri" },
+        "certificateUrl": { "type": "string", "format": "uri" },
+        "multisession": { "type": "boolean" }
+      },
+      "required": ["keySystem", "licenseUrl"]
+    },
+    "subtitles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string" },
+          "kind": { "type": "string" },
+          "language": { "type": "string" },
+          "url": { "type": "string", "format": "uri" }
+        },
+        "required": ["label", "kind", "language", "url"]
+      }
+    },
+    "chapters": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "identifier": { "type": "string" },
+          "title": { "type": "string" },
+          "posterUrl": { "type": "string", "format": "uri" },
+          "startTime": { "type": "number" },
+          "endTime": { "type": "number" }
+        },
+        "required": ["title", "startTime", "endTime"]
+      }
+    },
+    "timeRanges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "startTime": { "type": "number" },
+          "endTime": { "type": "number" },
+          "type": { "type": "string" }
+        },
+        "required": ["startTime", "endTime", "type"]
+      }
+    },
+    "customData": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
## Description

Establish the persistence layer of the application.

## Changes Made

- Implement SQL persistence using Exposed, HikariCP, and PostgreSQL.
- Add Flyway integration for database schema versioning and migrations.
- Orchestrate local development environment with Docker Compose.
- Add integration test suite using JSON Schema validation for the standard pillarbox media metadata format.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
