### PR TITLE
fix: enable Docker image publishing to ECR

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -80,6 +80,12 @@
       }
     ],
     [
+      "@semantic-release/exec",
+      {
+        "successCmd": "echo ${nextRelease.version} > VERSION"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "assets": [


### PR DESCRIPTION
## Description

Update the semantic-release configuration to output the version number. This is required by the  GitHub workflow to trigger the Docker publishing step. This change has been intentionally delayed until the ECR is ready.

See SRGSSR/pillarbox-monitoring-infra#76

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
