### PR TITLE
chore: refactor local dev lifecycle and isolate docker environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# ==============================================================================
+# PILLARBOX ENVIRONMENT CONFIGURATION
+# Copy this file to .env and change the values for your local setup.
+# ==============================================================================
+
+# --- Application ---
+
+# Enables hot-reloading and development-specific networking
+DEVELOPMENT=true
+
+# --- Database Configuration ---
+
+# The full JDBC connection string for the PostgreSQL database.
+DATABASE_URL=jdbc:postgresql://localhost:5432/pillarbox
+
+# The username used to connect to the database (defined in your Docker/Postgres setup).
+DATABASE_USER=dev_user
+
+# The password for the database user. (Keep this secure in production!)
+DATABASE_PASSWORD=dev_password

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ gradle-app.setting
 
 # Java heap dump
 *.hprof
+
+# Environment file
+.env

--- a/README.md
+++ b/README.md
@@ -14,17 +14,49 @@ media management within the [Pillarbox](https://pillarbox.ch) ecosystem.
   [post-installation][docker-post-install] steps to allow your user to run Docker commands without
   relying on `sudo`.
 
-### Development Commands
+### Local Development
 
-| Task      | Command                        |
-|-----------|--------------------------------|
-| **Build** | `./gradlew build`              |
-| **Run**   | `./gradlew run`                |
-| **Test**  | `./gradlew test`               |
-| **Lint**  | `./gradlew ktlintCheck detekt` |
+Use the convenience script to orchestrate the local environment. This script starts the Docker
+containers, launches the background compiler for hot-reloading, and runs the Ktor application.
+
+```bash
+# Standard start (cleans up Docker on exit)
+./start
+
+# Keep Docker containers running after exiting the app
+./start --keep
+```
+
+If you prefer to manage the infrastructure and application lifecycles independently, you can
+execute the steps separately:
+
+| Step  | Action                   | Command                       |
+|-------|--------------------------|-------------------------------|
+| **1** | **Start Infrastructure** | `docker compose up -d --wait` |
+| **2** | **Start Application**    | `./gradlew run`               |
+| **3** | **Cleanup**              | `docker compose down`         |
+
+### Environment Configuration
+
+The application supports externalized configuration via a .env file. This allows you to override
+database credentials or point to remote environments without modifying the source code:
+
+1. **Initialize the env file:** `cp .env.example .env`
+2. **Customize:** Edit `.env` to match your local or remote setup.
 
 > [!TIP]
-> Running `./gradlew run` automatically starts the required infrastructure via Docker Compose.
+> Check the [.env.example](.env.example) for all the supported variables.
+
+### 3. Build & Quality Tools
+
+Use these commands for standard development lifecycle tasks.
+
+| Goal            | Command                        |
+|-----------------|--------------------------------|
+| **Build**       | `./gradlew build`              |
+| **Run Tests**   | `./gradlew test`               |
+| **Linting**     | `./gradlew ktlintCheck detekt` |
+| **Format Code** | `./gradlew ktlintFormat`       |
 
 ## Documentation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,25 +122,23 @@ configurations
     }
   }
 
-val startEnvironment =
-  tasks.register<Exec>("startEnvironment") {
-    group = "environment"
-    description = "Starts the Docker Compose environment for local development"
-    commandLine("docker", "compose", "up", "-d", "--wait")
-  }
+tasks.named<JavaExec>("run") {
+  val envFile = rootProject.file(".env")
+  val localEnv =
+    Properties().apply {
+      if (envFile.exists()) {
+        envFile.inputStream().use { load(it) }
+      }
+    }
 
-tasks.register<Exec>("stopEnvironment") {
-  group = "environment"
-  description = "Stops the Docker Compose environment"
-  commandLine("docker", "compose", "down")
-}
+  fun getEnv(
+    key: String,
+    default: String,
+  ): String = System.getenv(key) ?: localEnv.getProperty(key) ?: default
 
-tasks.withType<JavaExec>().configureEach {
-  environment("DATABASE_URL", "jdbc:postgresql://localhost:5432/pillarbox")
-  environment("DATABASE_USER", "dev_user")
-  environment("DATABASE_PASSWORD", "dev_password")
-}
-
-tasks.run {
-  dependsOn(startEnvironment)
+  val isDev = getEnv("DEVELOPMENT", "true").toBoolean()
+  systemProperty("io.ktor.development", isDev)
+  environment("DATABASE_URL", getEnv("DATABASE_URL", "jdbc:postgresql://localhost:5432/pillarbox"))
+  environment("DATABASE_USER", getEnv("DATABASE_USER", "dev_user"))
+  environment("DATABASE_PASSWORD", getEnv("DATABASE_PASSWORD", "dev_password"))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: pillarbox-demo-backend
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -12,3 +14,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 512m

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -5,13 +5,17 @@ import ch.srgssr.pillarbox.backend.db.toDatabaseConfig
 import ch.srgssr.pillarbox.backend.entrypoint.web.media
 import ch.srgssr.pillarbox.backend.entrypoint.web.playerMedia
 import ch.srgssr.pillarbox.backend.io.jsonModule
+import ch.srgssr.pillarbox.backend.ktor.plugins.configureDevelopmentDefaults
+import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.persistence.persistenceModule
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
 import io.ktor.server.netty.EngineMain
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
+import org.koin.core.context.stopKoin
 import org.koin.ktor.ext.get
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
@@ -26,14 +30,18 @@ fun main(args: Array<String>): Unit = EngineMain.main(args)
 
 fun Application.module() {
   // Initialize Dependency Injection
+  val config = environment.config
+
   install(Koin) {
     slf4jLogger()
     modules(
-      databaseModule(environment.config.toDatabaseConfig()),
+      databaseModule(config.toDatabaseConfig()),
       persistenceModule(),
       jsonModule(),
     )
   }
+
+  configureDevelopmentDefaults()
 
   // Configure JSON serialization/deserialization for HTTP calls
   install(ContentNegotiation) {
@@ -44,5 +52,9 @@ fun Application.module() {
   routing {
     media(get())
     playerMedia(get())
+  }
+
+  monitor.subscribe(ApplicationStopped) {
+    stopKoin()
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseConfig.kt
@@ -63,7 +63,7 @@ fun ApplicationConfig.toDatabaseConfig(): DatabaseConfig {
     password = db.property("password").getString(),
     poolSize = db.propertyOrNull("poolSize")?.getString()?.toInt() ?: 10,
     connectionTimeout = db.propertyOrNull("connectionTimeout")?.getString()?.toLong() ?: 30000,
-    idleTimeout = db.propertyOrNull("idleTimeout")?.getString()?.toLong() ?: 60000,
+    idleTimeout = db.propertyOrNull("idleTimeout")?.getString()?.toLong() ?: 600000,
     dataSourceProperties = customProps,
   )
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
@@ -8,6 +8,7 @@ import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.logger.Level.DEBUG
 import org.koin.dsl.module
+import org.koin.dsl.onClose
 import javax.sql.DataSource
 
 /**
@@ -44,6 +45,9 @@ fun databaseModule(dbConfig: DatabaseConfig) =
           validate()
         },
       )
+    } onClose {
+      it?.connection?.close()
+      println("[Pillarbox] HikariPool closed.")
     }
 
     single {

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/ktor/plugins/DevelopmentUtils.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/ktor/plugins/DevelopmentUtils.kt
@@ -1,0 +1,25 @@
+package ch.srgssr.pillarbox.backend.ktor.plugins
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.application.install
+import io.ktor.server.application.log
+
+/**
+ * Optimizes server networking for the local development environment.
+ * In development, hot-reloads cause the application context to restart frequently.
+ * This function ensures that client connections are handled in a way that prevents
+ * state conflicts between reloads.
+ */
+fun Application.configureDevelopmentDefaults() {
+  if (developmentMode) {
+    install(
+      createApplicationPlugin("DevNetworkingPlugin") {
+        onCall { call ->
+          call.response.headers.append("Connection", "close")
+        }
+      },
+    )
+    log.info("Development networking optimized (Keep-Alive disabled)")
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,6 +2,7 @@ ktor {
   deployment {
     port = 8080
     watch = [classes, resources]
+    watchDelay = 500
   }
 
   application {
@@ -15,9 +16,6 @@ database {
   jdbcUrl = ${?DATABASE_URL}
   username = ${?DATABASE_USER}
   password = ${?DATABASE_PASSWORD}
-
-  poolSize = 10
-  connectionTimeout = 30000
 
   properties {
     cachePrepStmts = "true"

--- a/start
+++ b/start
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+warn() { echo -e "\033[33m$1\033[0m"; }
+error() { echo -e "\033[31m$1\033[0m"; }
+
+# Usage function
+usage() {
+  warn "Usage: $0 [options]"
+  echo ""
+  echo "Options:"
+  echo "  -k, --keep      Keep Docker containers running after the script exits"
+  echo "  -h, --help      Show this help message"
+  echo ""
+  echo "Example:"
+  echo "  $0 --keep       Launch app and keep the Docker containers up on exit"
+  echo ""
+  exit 1
+}
+
+KEEP_DOCKER=false
+
+# Parse Arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -k|--keep) KEEP_DOCKER=true ;;
+        -h|--help) usage ;;
+        *) error "Unknown option: $1"; usage ;;
+    esac
+    shift
+done
+
+cleanup() {
+    trap '' SIGINT SIGTERM EXIT
+
+    if [ -n "$COMPILER_PID" ]; then
+        warn "[Pillarbox] Stopping background compiler..."
+        kill "$COMPILER_PID" 2>/dev/null
+    fi
+
+    if [ "$KEEP_DOCKER" = true ]; then
+        warn "[Pillarbox] Keeping Docker containers running. Shutting down Gradle..."
+    else
+        warn "[Pillarbox] Shutting down local environment..."
+        docker compose down
+    fi
+    exit
+}
+
+trap cleanup SIGINT SIGTERM EXIT
+
+echo "[Pillarbox] Starting Docker containers..."
+docker compose up -d --wait
+
+echo "[Pillarbox] Starting Continuous Compilation..."
+./gradlew -t classes -x test -x check --console=plain &
+COMPILER_PID=$!
+
+echo "[Pillarbox] Launching Ktor Application..."
+./gradlew run --console=plain


### PR DESCRIPTION
## Description

Resolves #7 by moving environment orchestration from Gradle to a dedicated start script.

## Changes Made

- Added a `start` script to orchestrate Docker and App lifecycle.
- Implemented SIGINT trap to ensure that `docker compose down` is called on exit.
- Decoupled infrastructure from Gradle to allow for manual Docker Compose management.
- Added project naming to `docker-compose.yml` to isolate containers and volumes.
- Implemented `.env` file support in Gradle.
- Updated README with a structured local development guide.


## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [ ] ~~I have added tests that prove my fix is effective or that my feature works.~~
