### PR TITLE
feat(auth): introduce authentication layer with OIDC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,33 @@ DATABASE_USER=dev_user
 
 # The password for the database user. (Keep this secure in production!)
 DATABASE_PASSWORD=dev_password
+
+
+# --- OIDC / Keycloak Configuration ---
+
+# The Base URL of the Identity Provider. For Keycloak, this MUST include the realm path.
+# This URL is used to fetch the OIDC discovery document at startup.
+AUTH_ISSUER=http://localhost:8081/realms/pillarbox
+
+# The Client ID registered in the Auth Provider.
+AUTH_CLIENT_ID=pillarbox-api
+
+# The Client Secret for the application.
+# Mandatory for Confidential Clients. Leave empty for Public Clients.
+AUTH_CLIENT_SECRET=
+
+# --- Session Configuration ---
+
+# The secret key used to sign the session cookie.
+# You can generate one with: openssl rand -base64 32
+SESSION_COOKIE_SECRET=zDwJnYIgtu4f2/YM5PwKtdeC90yS0mTcfmfXvHMctKM=
+
+# Whether the session cookie requires HTTPS.
+# Set to 'false' for local development on http://localhost, 'true' for production.
+SESSION_SECURE=false
+
+# Session TTL in seconds (e.g., 28800 = 8 hours)
+SESSION_TIMEOUT=28800
+
+# Frequency of background OIDC token verification in seconds (e.g., 600 = 10 minutes)
+SESSION_VALIDATION_INTERVAL=600

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ database credentials or point to remote environments without modifying the sourc
 > [!TIP]
 > Check the [.env.example](.env.example) for all the supported variables.
 
-### 3. Build & Quality Tools
+### Build & Quality Tools
 
 Use these commands for standard development lifecycle tasks.
 
@@ -57,6 +57,11 @@ Use these commands for standard development lifecycle tasks.
 | **Run Tests**   | `./gradlew test`               |
 | **Linting**     | `./gradlew ktlintCheck detekt` |
 | **Format Code** | `./gradlew ktlintFormat`       |
+
+### Usage
+
+To get started with the console and API, please refer to
+the [Development & API Usage Guide](docs/DEVELOPMENT.md).
 
 ## Documentation
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   implementation(libs.bundles.flyway)
   implementation(libs.bundles.koin)
   implementation(libs.bundles.kotlinx)
+  implementation(libs.bundles.ktor.client)
   implementation(libs.bundles.ktor.server)
   implementation(libs.hikaricp)
   implementation(libs.logback.classic)
@@ -43,6 +44,7 @@ dependencies {
   testImplementation(libs.kotest.assertions.ktor)
   testImplementation(libs.kotest.runner.junit5)
   testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(libs.mock.oauth2.server)
   testImplementation(libs.mockk)
 }
 
@@ -141,4 +143,11 @@ tasks.named<JavaExec>("run") {
   environment("DATABASE_URL", getEnv("DATABASE_URL", "jdbc:postgresql://localhost:5432/pillarbox"))
   environment("DATABASE_USER", getEnv("DATABASE_USER", "dev_user"))
   environment("DATABASE_PASSWORD", getEnv("DATABASE_PASSWORD", "dev_password"))
+  environment("AUTH_ISSUER", getEnv("AUTH_ISSUER", "http://localhost:8081/realms/pillarbox"))
+  environment("AUTH_CLIENT_ID", getEnv("AUTH_CLIENT_ID", "pillarbox-api"))
+  environment("AUTH_CLIENT_SECRET", getEnv("AUTH_CLIENT_SECRET", ""))
+  environment("SESSION_COOKIE_SECRET", getEnv("SESSION_COOKIE_SECRET", "dev-secret-at-least-32-chars-long-!!!"))
+  environment("SESSION_SECURE", getEnv("SESSION_SECURE", "false"))
+  environment("SESSION_TIMEOUT", getEnv("SESSION_TIMEOUT", "28800"))
+  environment("SESSION_VALIDATION_INTERVAL", getEnv("SESSION_VALIDATION_INTERVAL", "600"))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,26 @@ services:
       resources:
         limits:
           memory: 512m
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.5
+    command: start-dev --http-port 8081 --import-realm
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
+      KC_HEALTH_ENABLED: "true"
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./keycloak:/opt/keycloak/data/import/:ro
+    healthcheck:
+      test: [ "CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000 && echo -e 'GET /health/live HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n' >&3 && cat <&3 | grep -q '200 OK'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 1024m

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,86 @@
+# Development & API Usage Guide
+
+This document provides a comprehensive guide on how to interact with the Pillarbox Backend.
+
+Once the application is running, you can interact with it via the web console or the REST API.
+
+## Web Console
+
+For a visual management experience, use the built-in console.
+
+* **URL**: [http://localhost:8080/console](http://localhost:8080/console)
+* **Username / Password**: `dev/password`
+
+## REST API
+
+The REST API is divided into two primary functional areas:
+
+1. [Management API (Protected)](#management-api-protected): Used for CRUD operations on media metadata, protected by OAuth2.
+2. [Player API (Public)](#player-api-public): Playback requests with support for dynamic stream and DRM negotiation.
+
+### Management API (Protected)
+
+To access protected endpoints, you must first authenticate with the Keycloak server
+(running on port `8081` by default).
+
+```bash
+TOKEN=$(curl -s -X POST "http://localhost:8081/realms/pillarbox/protocol/openid-connect/token" \
+  -d "username=dev" \
+  -d "password=password" \
+  -d "grant_type=password" \
+  -d "client_id=pillarbox-api" | jq -r '.access_token')
+```
+
+Use the `$TOKEN` to authorize POST requests to the management API.
+
+```bash
+curl -v --request POST \
+  --url http://localhost:8080/v1/media \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  --data '{...}'
+```
+
+All endpoints below require the `Authorization: Bearer $TOKEN` header. You can find all the
+definitions in [MediaRoute.kt][media-route-kt].
+
+| Method     | Endpoint              | Description                                             |
+|------------|-----------------------|---------------------------------------------------------|
+| **GET**    | `/v1/media`           | List all media (supports `limit` and `offset` queries). |
+| **GET**    | `/v1/media/{id}`      | Retrieve a specific media entity by ID.                 |
+| **POST**   | `/v1/media`           | Create or fully update a media entity.                  |
+| **PATCH**  | `/v1/media/{id}/tags` | Batch update tags for a specific media entity.          |
+| **DELETE** | `/v1/media/{id}`      | Remove a media entity from the repository.              |
+
+### Player API (Public)
+
+The playback endpoints do not require a token and are open to all clients.
+
+```bash
+curl --request GET \
+  --url http://localhost:8080/v1/player/media/urn:pillarbox:video:12345 \
+  --header 'X-Accept-Stream-Type: application/dash+xml' \
+  --header 'X-Accept-DRM: widevine'
+```
+
+Unlike the management API, these endpoints are **publicly accessible** (no Bearer token required)
+They support content negotiation via custom headers. You can find all the definitions
+in [PlayerMediaRoute.kt][player-media-route-kt].
+
+| Method  | Endpoint                | Description                                |
+|---------|-------------------------|--------------------------------------------|
+| **GET** | `/v1/player/media`      | List all available playback entities.      |
+| **GET** | `/v1/player/media/{id}` | Retrieve a specific playback entity by ID. |
+
+#### Content Negotiation Headers
+
+The player API uses headers to filter the best source for a specific device. If these headers are
+omitted, the API returns a media item without a source.
+
+| Header                 | Example Value          | Description                                                         |
+|------------------------|------------------------|---------------------------------------------------------------------|
+| `X-Accept-Stream-Type` | `application/dash+xml` | Filters for a specific MIME type (e.g., DASH, HLS).                 |
+| `X-Accept-DRM`         | `WIDEVINE`             | Filters for a specific DRM key system (e.g., WIDEVINE, PLAY_READY). |
+
+[media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+[player-media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ shadow = "9.3.1"
 versions-plugin = "0.53.0"
 
 # Libs
-exposed = "1.0.0"
+exposed = "1.1.1"
 flyway = "12.0.0"
 h2 = "2.4.240"
 hikaricp = "7.0.2"
@@ -20,6 +20,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-serialization-json = "1.10.0"
 ktor = "3.4.0"
 logback = "1.5.32"
+mock-oauth2-server = "3.0.1"
 mockk = "1.14.9"
 postgresql = "42.7.9"
 
@@ -28,6 +29,7 @@ exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "e
 exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
 exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
 exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "exposed" }
+exposed-kotlin-datetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetime", version.ref = "exposed" }
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
@@ -36,9 +38,18 @@ koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }
 koin-logger = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
 kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-htmx = { module = "io.ktor:ktor-htmx ", version.ref = "ktor" }
+ktor-htmx-html = { module = "io.ktor:ktor-htmx-html ", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
-ktor-server-content-negotation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
+ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
+ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-html-builder = { module = "io.ktor:ktor-server-html-builder ", version.ref = "ktor" }
+ktor-server-htmx = { module = "io.ktor:ktor-server-htmx ", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
@@ -49,9 +60,8 @@ json-schema-validator = { module = "com.networknt:json-schema-validator", versio
 kotest-assertions-ktor = { module = "io.kotest:kotest-assertions-ktor", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
-ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
-ktor-client-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+mock-oauth2-server = { module = "no.nav.security:mock-oauth2-server", version.ref = "mock-oauth2-server"}
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 [bundles]
@@ -59,7 +69,8 @@ exposed = [
   "exposed-core",
   "exposed-dao",
   "exposed-jdbc",
-  "exposed-json"
+  "exposed-json",
+  "exposed-kotlin-datetime"
 ]
 
 flyway = [
@@ -73,17 +84,28 @@ koin = [
   "koin-logger"
 ]
 
+ktor-client = [
+  "ktor-client-cio",
+  "ktor-client-content-negotiation",
+  "ktor-client-core",
+  "ktor-serialization-kotlinx-json",
+]
+
 ktor-server = [
+  "ktor-htmx",
+  "ktor-htmx-html",
+  "ktor-serialization-kotlinx-json",
+  "ktor-server-auth",
+  "ktor-server-auth-jwt",
+  "ktor-server-content-negotiation",
   "ktor-server-core",
-  "ktor-server-netty",
-  "ktor-server-content-negotation",
-  "ktor-serialization-kotlinx-json"
+  "ktor-server-html-builder",
+  "ktor-server-htmx",
+  "ktor-server-netty"
 ]
 
 ktor-test = [
-  "ktor-server-test-host",
-  "ktor-client-content-negotiation",
-  "ktor-client-serialization-kotlinx-json"
+  "ktor-server-test-host"
 ]
 
 kotlinx = [

--- a/keycloak/pillarbox-realm.json
+++ b/keycloak/pillarbox-realm.json
@@ -1,0 +1,52 @@
+{
+  "realm": "pillarbox",
+  "enabled": true,
+  "roles": {
+    "realm": [
+      { "name": "user" },
+      { "name": "admin" }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "pillarbox-api",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "redirectUris": ["http://localhost:8080/*"],
+      "webOrigins": ["http://localhost:8080"],
+      "protocolMappers": [
+        {
+          "name": "audience-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "config": {
+            "included.client.audience": "pillarbox-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "dev",
+      "enabled": true,
+      "email": "dev@example.com",
+      "firstName": "Dev",
+      "lastName": "User",
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "password",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["user"]
+    }
+  ]
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -1,21 +1,27 @@
 package ch.srgssr.pillarbox.backend
 
+import ch.srgssr.pillarbox.backend.auth.authenticationModule
+import ch.srgssr.pillarbox.backend.auth.configureOidc
+import ch.srgssr.pillarbox.backend.auth.installSession
 import ch.srgssr.pillarbox.backend.db.databaseModule
-import ch.srgssr.pillarbox.backend.db.toDatabaseConfig
+import ch.srgssr.pillarbox.backend.entrypoint.web.dashboard
+import ch.srgssr.pillarbox.backend.entrypoint.web.login
 import ch.srgssr.pillarbox.backend.entrypoint.web.media
 import ch.srgssr.pillarbox.backend.entrypoint.web.playerMedia
+import ch.srgssr.pillarbox.backend.io.httpClientModule
 import ch.srgssr.pillarbox.backend.io.jsonModule
 import ch.srgssr.pillarbox.backend.ktor.plugins.configureDevelopmentDefaults
-import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.persistence.persistenceModule
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
 import io.ktor.server.netty.EngineMain
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.routing.routing
 import org.koin.core.context.stopKoin
+import org.koin.dsl.module
 import org.koin.ktor.ext.get
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
@@ -29,29 +35,39 @@ import org.koin.logger.slf4jLogger
 fun main(args: Array<String>): Unit = EngineMain.main(args)
 
 fun Application.module() {
-  // Initialize Dependency Injection
-  val config = environment.config
-
   install(Koin) {
     slf4jLogger()
     modules(
-      databaseModule(config.toDatabaseConfig()),
+      module { single { environment.config } },
+      databaseModule(),
       persistenceModule(),
       jsonModule(),
+      httpClientModule(),
+      authenticationModule(),
     )
   }
 
-  configureDevelopmentDefaults()
-
-  // Configure JSON serialization/deserialization for HTTP calls
-  install(ContentNegotiation) {
-    json(this@module.get())
+  install(Authentication) {
+    configureOidc(
+      authConfig = this@module.get(),
+      httpClient = this@module.get(),
+      sessionManager = this@module.get(),
+      policy = this@module.get(),
+    )
   }
+
+  installSession(get())
+
+  install(ContentNegotiation) { json(this@module.get()) }
+
+  configureDevelopmentDefaults()
 
   // Setup HTTP Routing
   routing {
+    login(get())
     media(get())
     playerMedia(get())
+    dashboard()
   }
 
   monitor.subscribe(ApplicationStopped) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthConfig.kt
@@ -1,0 +1,53 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import io.ktor.server.config.ApplicationConfig
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
+
+/**
+ * Configuration parameters for the Authentication provider.
+ *
+ * @property issuer The base URL of the identity provider.
+ * @property clientId The unique identifier for the application (audience).
+ * @property clientSecret The secret key used for server-side token exchange.
+ * @property realm The authentication realm used in the challenge header.
+ */
+data class AuthConfig(
+  val issuer: String,
+  val clientId: String,
+  val clientSecret: String,
+  val realm: String,
+) {
+  /**
+   * The standard URL where the OIDC discovery metadata can be found.
+   */
+  val discoveryUrl = "$issuer/.well-known/openid-configuration"
+  val userInfoUrl = "$issuer/protocol/openid-connect/userinfo"
+}
+
+/**
+ * Represents the OpenID Connect discovery document.
+ */
+@Serializable
+data class OpenIDDiscovery(
+  @SerialName("authorization_endpoint") val authorizationEndpoint: String,
+  @SerialName("token_endpoint") val tokenEndpoint: String,
+  @SerialName("jwks_uri") val jwksUri: String,
+)
+
+/**
+ * Extracts [AuthConfig] from the application's configuration file.
+ *
+ * @return A populated [AuthConfig] instance.
+ */
+fun ApplicationConfig.toAuthConfig(): AuthConfig {
+  val auth = config("oidc")
+
+  return AuthConfig(
+    issuer = auth.property("issuer").getString(),
+    clientId = auth.property("client_id").getString(),
+    clientSecret = auth.propertyOrNull("secret")?.getString() ?: "",
+    realm = auth.property("realm").getString(),
+  )
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationExtensions.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationExtensions.kt
@@ -1,0 +1,93 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.entrypoint.web.Navigation
+import io.ktor.client.HttpClient
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.AuthenticationConfig
+import io.ktor.server.auth.jwt.jwt
+import io.ktor.server.auth.oauth
+import io.ktor.server.auth.session
+import io.ktor.server.plugins.origin
+import io.ktor.server.request.ApplicationRequest
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.sessions.SessionTransportTransformerMessageAuthentication
+import io.ktor.server.sessions.Sessions
+import io.ktor.server.sessions.cookie
+
+/**
+ * Configures OIDC-related authentication providers for the application.
+ *
+ * This setup includes three distinct providers under a shared naming convention:
+ * 1. **JWT**: For stateless API authentication using bearer tokens.
+ * 2. **OAuth**: For the interactive authorization code flow with the identity provider.
+ * 3. **Session**: For stateful authentication using a [SessionId] cookie.
+ *
+ * @param name The prefix used to register the authentication providers (default is "pillarbox").
+ * @param authConfig The [AuthConfig] containing issuer and realm details.
+ * @param httpClient The [HttpClient] used for back-channel OAuth token exchanges.
+ * @param sessionManager The [SessionManager] responsible for validating existing sessions.
+ * @param policy The [AuthenticationPolicy] used for JWT verification and OAuth settings lookup.
+ */
+fun AuthenticationConfig.configureOidc(
+  name: String = "pillarbox",
+  authConfig: AuthConfig,
+  httpClient: HttpClient,
+  sessionManager: SessionManager,
+  policy: AuthenticationPolicy,
+) {
+  jwt("$name-jwt") {
+    realm = authConfig.realm
+    verifier(policy.jwkProvider, authConfig.issuer)
+    validate { policy.verifyJwt(it) }
+  }
+
+  oauth("$name-oauth") {
+    urlProvider = { request.buildCallbackUrl() }
+    providerLookup = { policy.getOAuthSettings(name) }
+    client = httpClient
+  }
+
+  session<SessionId>("$name-session") {
+    validate { sessionManager.validate(it) }
+    challenge { call.respondRedirect(Navigation.LOGIN) }
+  }
+}
+
+/**
+ * Builds a dynamic callback URL for OAuth redirection based on the incoming request's origin.
+ *
+ * This ensures the redirect URI matches the protocol, host, and port used by the client,
+ * which is critical for environments behind proxies or load balancers.
+ *
+ * @param path The relative path for the OAuth callback (default is "/callback").
+ *
+ * @return A fully qualified URL string.
+ */
+fun ApplicationRequest.buildCallbackUrl(path: String = "/callback"): String {
+  val o = origin
+  return "${o.scheme}://${o.serverHost}:${o.serverPort}$path"
+}
+
+/**
+ * Installs and configures the Ktor [Sessions] plugin with a signed cookie.
+ *
+ * The session cookie is configured with:
+ * - **Security**: Signed using [SessionTransportTransformerMessageAuthentication] to prevent tampering.
+ * - **HttpOnly**: Shielded from client-side JavaScript access to mitigate XSS risks.
+ * - **SameSite**: Set to "Lax" to balance CSRF protection with usability.
+ *
+ * @param sessionConfig The [SessionConfig] defining timeouts, security flags, and the signing secret.
+ */
+fun Application.installSession(sessionConfig: SessionConfig) {
+  install(Sessions) {
+    cookie<SessionId>("PILLARBOX_SESSION_ID") {
+      cookie.path = "/"
+      cookie.maxAgeInSeconds = sessionConfig.timeoutSeconds
+      cookie.secure = sessionConfig.isSecure
+      cookie.httpOnly = true
+      cookie.extensions["SameSite"] = "Lax"
+      transform(SessionTransportTransformerMessageAuthentication(sessionConfig.cookieSecret.toByteArray()))
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationModule.kt
@@ -1,0 +1,53 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.server.config.ApplicationConfig
+import kotlinx.coroutines.runBlocking
+import org.koin.dsl.module
+
+/**
+ * Defines the Koin module for authentication and session management.
+ *
+ * This module provides:
+ * 1. The [AuthConfig] and [SessionConfig] extracted from the application configuration.
+ * 2. The [OpenIDDiscovery] document, fetched synchronously from the identity provider's
+ * discovery URL. Note: This involves a [runBlocking] network call upon first resolution.
+ * 3. A [SessionManager] to handle user session lifecycles and token validation.
+ * 4. An [AuthenticationPolicy] used to configure OAuth2 settings and verify JWT credentials.
+ *
+ * @return A Koin [Module] containing the authentication infrastructure definitions.
+ */
+fun authenticationModule() =
+  module {
+    single { get<ApplicationConfig>().toAuthConfig() }
+    single { get<ApplicationConfig>().toSessionConfig() }
+
+    single {
+      val config = get<AuthConfig>()
+      val client = get<HttpClient>()
+      runBlocking {
+        client.get(config.discoveryUrl).body<OpenIDDiscovery>()
+      }
+    }
+
+    single {
+      SessionManager(
+        repository = get(),
+        httpClient = get(),
+        userInfoUrl = get<AuthConfig>().userInfoUrl,
+        validationIntervalSeconds = get<SessionConfig>().validationIntervalSeconds,
+      )
+    }
+
+    single {
+      val auth = get<AuthConfig>()
+
+      AuthenticationPolicy(
+        clientId = auth.clientId,
+        clientSecret = auth.clientSecret,
+        discovery = get(),
+      )
+    }
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
@@ -1,0 +1,75 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.log.warn
+import com.auth0.jwk.JwkProvider
+import com.auth0.jwk.JwkProviderBuilder
+import io.ktor.http.HttpMethod
+import io.ktor.server.auth.OAuthServerSettings
+import io.ktor.server.auth.jwt.JWTCredential
+import io.ktor.server.auth.jwt.JWTPrincipal
+import java.net.URI
+
+/**
+ * Manages authentication policies, providing configuration for OAuth2 settings
+ * and JWT validation logic based on OpenID Connect discovery.
+ *
+ * @property clientId The unique identifier for the client application.
+ * @property clientSecret The secret key used for authenticating the client with the identity provider.
+ * @property discovery The [OpenIDDiscovery] containing provider-specific endpoints and metadata.
+ */
+class AuthenticationPolicy(
+  val clientId: String,
+  val clientSecret: String,
+  val discovery: OpenIDDiscovery,
+) {
+  companion object {
+    val logger = logger()
+  }
+
+  /**
+   * Provider for JSON Web Keys (JWK) used to verify the signature of incoming JWTs.
+   * Built using the `jwks_uri` obtained from the discovery document.
+   */
+  val jwkProvider: JwkProvider = JwkProviderBuilder(URI(discovery.jwksUri).toURL()).build()
+
+  /**
+   * Constructs the [OAuthServerSettings.OAuth2ServerSettings] required for Ktor's OAuth feature.
+   * * Defaults to using [HttpMethod.Post] for token requests and requests standard OpenID scopes.
+   *
+   * @param name A descriptive name for the OAuth setting.
+   * @return A configured OAuth2 server setting instance.
+   */
+  fun getOAuthSettings(name: String) =
+    OAuthServerSettings.OAuth2ServerSettings(
+      name = name,
+      authorizeUrl = discovery.authorizationEndpoint,
+      accessTokenUrl = discovery.tokenEndpoint,
+      clientId = clientId,
+      clientSecret = clientSecret,
+      accessTokenRequiresBasicAuth = false,
+      requestMethod = HttpMethod.Post,
+      defaultScopes = listOf("openid", "profile", "email"),
+    )
+
+  /**
+   * Verifies the incoming [JWTCredential] by checking the audience claim.
+   *
+   * @param credential The credential extracted from the JWT token.
+   *
+   * @return A [JWTPrincipal] if validation passes; null if the audience is invalid.
+   */
+  fun verifyJwt(credential: JWTCredential): JWTPrincipal? {
+    val audience = credential.payload.audience
+    return if (audience.contains(clientId)) {
+      JWTPrincipal(credential.payload)
+    } else {
+      logger.warn {
+        "JWT verification failed: Audience mismatch. " +
+          "Expected: $clientId, Found: $audience. " +
+          "Subject: ${credential.payload.subject}"
+      }
+      null
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/SessionConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/SessionConfig.kt
@@ -1,0 +1,48 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import io.ktor.server.config.ApplicationConfig
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration parameters for session management and cookie security.
+ *
+ * @property cookieSecret The secret key used to sign the session cookie to prevent tampering.
+ * @property timeoutSeconds The total duration (TTL) a session cookie remains valid.
+ * @property validationIntervalSeconds The interval at which the session must be re-verified
+ * against the OIDC provider.
+ * @property isSecure Whether the session cookie should only be sent over HTTPS.
+ */
+data class SessionConfig(
+  val cookieSecret: String,
+  val timeoutSeconds: Long,
+  val validationIntervalSeconds: Long,
+  val isSecure: Boolean = true,
+)
+
+/**
+ * Extracts [SessionConfig] from the application's configuration file.
+ *
+ * @return A populated [SessionConfig] instance.
+ */
+fun ApplicationConfig.toSessionConfig(): SessionConfig {
+  val session = config("session")
+  return SessionConfig(
+    cookieSecret = session.property("cookieSecret").getString(),
+    timeoutSeconds = session.property("timeoutSeconds").getString().toLong(),
+    validationIntervalSeconds = session.property("validationIntervalSeconds").getString().toLong(),
+    isSecure = session.propertyOrNull("secure")?.getString()?.toBoolean() ?: true,
+  )
+}
+
+/**
+ * Type-safe wrapper for a session identifier used within the session cookie.
+ *
+ * This distinguishes the session ID from other string-based data during
+ * serialization and cookie handling in Ktor.
+ *
+ * @property value The raw session ID string stored in the cookie.
+ */
+@Serializable
+data class SessionId(
+  val value: String,
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManager.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManager.kt
@@ -1,0 +1,116 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.domain.model.Session
+import ch.srgssr.pillarbox.backend.log.debug
+import ch.srgssr.pillarbox.backend.log.error
+import ch.srgssr.pillarbox.backend.log.info
+import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.log.warn
+import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import kotlinx.io.IOException
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Manages the lifecycle of user sessions, providing validation logic optimized for performance with
+ * periodic token verification.
+ *
+ * @property repository The persistent storage for session data.
+ * @property httpClient The client used to perform back-channel validation against the OIDC provider.
+ * @property userInfoUrl The OIDC endpoint used to verify if an access token is still active.
+ * @property validationIntervalSeconds The frequency at which the access token must be re-verified
+ * against the identity provider.
+ */
+class SessionManager(
+  private val repository: SessionRepository,
+  private val httpClient: HttpClient,
+  private val userInfoUrl: String,
+  private val validationIntervalSeconds: Long,
+) {
+  companion object {
+    val logger = logger()
+  }
+
+  /**
+   * Validates a session. If the session exists and has been checked recently (within [validationIntervalSeconds]),
+   * it is returned immediately. Otherwise, the associated access token is verified against the OIDC provider.
+   *
+   * @param sessionId The ID of the session to validate.
+   *
+   * @return The [Session] if valid; null if the session is expired, missing, or the token is revoked.
+   */
+  suspend fun validate(sessionId: SessionId): Session? {
+    val session =
+      repository.find(sessionId.value) ?: run {
+        logger.info { "Session validation failed: Session ${sessionId.value} not found in repository." }
+        return null
+      }
+
+    return verifySession(session)
+  }
+
+  /**
+   * Verifies the integrity of a session by checking its local expiration and
+   * remote OIDC token validity.
+   *
+   * @param session The current session data retrieved from the repository.
+   * @return The valid (and potentially updated) [Session], or `null` if the session is invalid.
+   */
+  private suspend fun verifySession(session: Session): Session? {
+    if (session.valid) return session
+
+    logger.info { "Re-validating OIDC token for session: ${session.sessionId}" }
+
+    return if (session.isTokenValid()) {
+      session.copy(lastChecked = Clock.System.now()).also { updated ->
+        repository.save(session.sessionId, updated)
+        logger.info { "Session ${session.sessionId} successfully re-validated." }
+      }
+    } else {
+      logger.warn { "Session ${session.sessionId} invalidated by OIDC provider." }
+      repository.delete(session.sessionId)
+      null
+    }
+  }
+
+  /**
+   * Whether the session has not yet exceeded the [validationIntervalSeconds] threshold.
+   */
+  private val Session.valid: Boolean
+    get() {
+      val now = Clock.System.now()
+      val elapsed = now - lastChecked
+      val threshold = validationIntervalSeconds.seconds
+
+      return (elapsed < threshold).also { fresh ->
+        if (fresh) {
+          val remaining = threshold - elapsed
+          logger.debug {
+            "Session $sessionId is still valid. " +
+              "Elapsed: ${elapsed.inWholeSeconds}s, " +
+              "Next check in: ${remaining.inWholeSeconds}s"
+          }
+        }
+      }
+    }
+
+  /**
+   * Checks if the provided access token is still valid by calling the OIDC UserInfo endpoint.
+   *
+   * @return True if the provider returns 200 OK; false otherwise.
+   */
+  private suspend fun Session.isTokenValid(): Boolean =
+    try {
+      httpClient.get(userInfoUrl) { bearerAuth(accessToken) }.let {
+        logger.info { "Token validation check returned status: ${it.status}" }
+        it.status == HttpStatusCode.OK
+      }
+    } catch (e: IOException) {
+      logger.error(e) { "Failed to reach OIDC UserInfo endpoint at $userInfoUrl" }
+      false
+    }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
@@ -2,11 +2,11 @@ package ch.srgssr.pillarbox.backend.db
 
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.ktor.server.config.ApplicationConfig
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.koin.core.logger.Level.DEBUG
 import org.koin.dsl.module
 import org.koin.dsl.onClose
 import javax.sql.DataSource
@@ -15,17 +15,20 @@ import javax.sql.DataSource
  * Defines the Koin module for database infrastructure.
  *
  * This module provides:
- *   1. A [DataSource] (HikariCP) configured using the provided [dbConfig].
+ *   1. The [DatabaseConfig] with the configuration parameters for the database.
+ *   1. A [DataSource] (HikariCP) configured using the loaded [DatabaseConfig].
  *   2. An Exposed [Database] instance, which automatically triggers [runMigration] on the
  *      data source before establishing the connection.
  *
- * @param dbConfig The configuration parameters for the database.
- *
  * @return A Koin [Module] containing the database infrastructure definitions.
  */
-fun databaseModule(dbConfig: DatabaseConfig) =
+fun databaseModule() =
   module {
+    single { get<ApplicationConfig>().toDatabaseConfig() }
+
     single<DataSource> {
+      val dbConfig = get<DatabaseConfig>()
+
       HikariDataSource(
         HikariConfig().apply {
           driverClassName = dbConfig.driverClassName
@@ -51,11 +54,12 @@ fun databaseModule(dbConfig: DatabaseConfig) =
     }
 
     single {
+      val dbConfig = get<DatabaseConfig>()
       val dataSource = get<DataSource>()
       val db = Database.connect(dataSource)
 
       if (dbConfig.autoCreate) {
-        val allTables = getAll<Table>().toTypedArray()
+        val allTables = get<List<Table>>().toTypedArray()
 
         transaction(db) {
           SchemaUtils.create(*allTables)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Session.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Session.kt
@@ -1,0 +1,14 @@
+package ch.srgssr.pillarbox.backend.domain.model
+
+import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+@Serializable
+data class Session(
+  val sessionId: String,
+  val accessToken: String,
+  val lastChecked: Instant = Clock.System.now(),
+  val expiresAt: Instant = lastChecked + 24.hours,
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/LoginRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/LoginRoute.kt
@@ -1,0 +1,48 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web
+
+import ch.srgssr.pillarbox.backend.auth.SessionId
+import ch.srgssr.pillarbox.backend.domain.model.Session
+import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
+import io.ktor.server.auth.OAuthAccessTokenResponse
+import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.principal
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.sessions.sessions
+import io.ktor.server.sessions.set
+import java.util.UUID
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Registers the OAuth2 login callback route.
+ * This function handles the "exchange" phase of the OAuth2 flow. It:
+ *
+ * 1. Intercepts the authorization code from the identity provider.
+ * 2. Retrieves the [OAuthAccessTokenResponse.OAuth2] principal.
+ * 3. Maps the OAuth token to a new internal [Session].
+ * 4. Persists the session and issues a [SessionId] cookie to the client.
+ *
+ * @param sessionRepository The persistence layer used to store the newly created user session.
+ */
+fun Route.login(sessionRepository: SessionRepository) {
+  authenticate("pillarbox-oauth") {
+    get(Navigation.LOGIN) { }
+    get(Navigation.CALLBACK) {
+      call.principal<OAuthAccessTokenResponse.OAuth2>()?.let { principal ->
+        val now = Clock.System.now()
+        val session =
+          Session(
+            sessionId = UUID.randomUUID().toString(),
+            accessToken = principal.accessToken,
+            expiresAt = principal.expiresIn.let { now + it.seconds },
+          )
+
+        sessionRepository.save(session.sessionId, session)
+        call.sessions.set(SessionId(session.sessionId))
+        call.respondRedirect(Navigation.CONSOLE)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaHtmxRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaHtmxRoute.kt
@@ -1,0 +1,28 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web
+
+import io.ktor.server.auth.authenticate
+import io.ktor.server.html.respondHtml
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import kotlinx.html.body
+import kotlinx.html.h1
+import kotlinx.html.p
+
+/**
+ * Basic dashboard entry point protected by SSO session.
+ */
+fun Route.dashboard() {
+  authenticate("pillarbox-session") {
+    route(Navigation.CONSOLE) {
+      get {
+        call.respondHtml {
+          body {
+            h1 { +"Pillarbox Console" }
+            p { +"Logged in as an authorized user." }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
@@ -7,6 +7,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toMediaResponseV1
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -16,6 +17,7 @@ import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 
 /**
  * Generic helper to register standard Media CRUD endpoints.
@@ -43,7 +45,7 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
     val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
     val mediaFlow = mediaRepository.getAll(limit, offset)
 
-    call.respond(mediaFlow.map { toResponse(it) })
+    call.respond(mediaFlow.map { toResponse(it) }.toList())
   }
 
   get("/{id}") {
@@ -89,12 +91,14 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
  */
 fun Route.media(mediaRepository: MediaRepository) {
   // Entry point for the V1 media API.
-  route("v1/media") {
-    mediaEndpoints<MediaRequestV1, MediaResponseV1, TagBatchUpdateRequestV1>(
-      mediaRepository = mediaRepository,
-      toDomain = { it.toMedia() },
-      toResponse = { it.toMediaResponseV1() },
-      applyTags = { dto, tags -> dto.apply(tags) },
-    )
+  authenticate("pillarbox-jwt") {
+    route("v1/media") {
+      mediaEndpoints<MediaRequestV1, MediaResponseV1, TagBatchUpdateRequestV1>(
+        mediaRepository = mediaRepository,
+        toDomain = { it.toMedia() },
+        toResponse = { it.toMediaResponseV1() },
+        applyTags = { dto, tags -> dto.apply(tags) },
+      )
+    }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/Navigation.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/Navigation.kt
@@ -1,0 +1,27 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web
+
+/**
+ * Centralized registry for web-based navigation paths.
+ *
+ * This object ensures consistency between route definitions and redirects
+ * across the application, preventing hardcoded string errors in the
+ * authentication and console layers.
+ */
+object Navigation {
+  /**
+   * The entry point for the user interface.
+   */
+  const val CONSOLE = "/console"
+
+  /**
+   * The challenge endpoint for the OAuth2 interactive login flow.
+   * Navigating here triggers the redirect to the OIDC identity provider.
+   */
+  const val LOGIN = "/login"
+
+  /**
+   * The callback endpoint where the OIDC provider returns the authorization code.
+   * This route is responsible for session creation and redirection to the [CONSOLE].
+   */
+  const val CALLBACK = "/callback"
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/io/HttpClientModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/io/HttpClientModule.kt
@@ -1,0 +1,20 @@
+package ch.srgssr.pillarbox.backend.io
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import org.koin.dsl.module
+import org.koin.dsl.onClose
+
+/**
+ * A Koin module that provides a singleton instance of [HttpClient].
+ *
+ * @return A Koin [Module] containing the database infrastructure definitions.
+ */
+fun httpClientModule() =
+  module {
+    single {
+      HttpClient(CIO) { install(ContentNegotiation) { json(get()) } }
+    } onClose { it?.close() } // Always close the client!
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
@@ -2,7 +2,8 @@ package ch.srgssr.pillarbox.backend.persistence
 
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
-import kotlinx.serialization.json.Json
+import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
+import ch.srgssr.pillarbox.backend.persistence.session.SessionTable
 import org.jetbrains.exposed.v1.core.Table
 import org.koin.dsl.module
 
@@ -14,6 +15,9 @@ import org.koin.dsl.module
  */
 fun persistenceModule() =
   module {
-    single<Table> { MediaTable }
+    single<List<Table>> {
+      listOf(MediaTable, SessionTable)
+    }
     single { MediaRepository(get()) }
+    single { SessionRepository(get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionRepository.kt
@@ -1,0 +1,46 @@
+package ch.srgssr.pillarbox.backend.persistence.session
+
+import ch.srgssr.pillarbox.backend.db.ExposedRepository
+import ch.srgssr.pillarbox.backend.domain.model.Session
+import ch.srgssr.pillarbox.backend.time.toKotlinInstant
+import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * Repository responsible for the persistence and retrieval of [Session] entities using Exposed.
+ *
+ * This implementation maps the [Session] domain model to the [SessionTable] schema and
+ * provides specialized methods for media-specific data manipulations.
+ *
+ * @param db The [Database] instance used for all transactions.
+ */
+class SessionRepository(
+  db: Database,
+) : ExposedRepository<Session, String>(db = db, table = SessionTable, idColumn = SessionTable.sessionId) {
+  /**
+   * Decodes a [ResultRow] from the [SessionTable] into a [Session] domain object.
+   */
+  override fun ResultRow.decode() =
+    Session(
+      sessionId = this[SessionTable.sessionId],
+      accessToken = this[SessionTable.accessToken],
+      lastChecked = this[SessionTable.lastChecked].toKotlinInstant(),
+      expiresAt = this[SessionTable.expiresAt].toKotlinInstant(),
+    )
+
+  /**
+   * Encodes a [Session] domain object into an [UpdateBuilder] for inserts or upserts.
+   */
+  override fun Table.encode(
+    builder: UpdateBuilder<*>,
+    item: Session,
+  ) {
+    builder[SessionTable.sessionId] = item.sessionId
+    builder[SessionTable.accessToken] = item.accessToken
+    builder[SessionTable.lastChecked] = item.lastChecked.toUtcOffsetDateTime()
+    builder[SessionTable.expiresAt] = item.expiresAt.toUtcOffsetDateTime()
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionTable.kt
@@ -1,0 +1,18 @@
+package ch.srgssr.pillarbox.backend.persistence.session
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestamp
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+import kotlin.time.Clock
+
+object SessionTable : Table("pb_session") {
+  val sessionId = varchar("session_id", 255)
+
+  val accessToken = text("access_token")
+
+  val lastChecked = timestampWithTimeZone("last_checked")
+
+  val expiresAt = timestampWithTimeZone("expires_at")
+
+  override val primaryKey = PrimaryKey(sessionId)
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/time/OffsetDateTime.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/time/OffsetDateTime.kt
@@ -1,0 +1,21 @@
+package ch.srgssr.pillarbox.backend.time
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import kotlin.time.Instant
+import kotlin.time.toJavaInstant
+import kotlin.time.toKotlinInstant
+
+/**
+ * Converts a Java [OffsetDateTime] to a Kotlin [Instant].
+ *
+ * @return The [Instant] representation of this date-time.
+ */
+fun OffsetDateTime.toKotlinInstant() = this.toInstant().toKotlinInstant()
+
+/**
+ * Converts a Kotlin [Instant] to a Java [OffsetDateTime] at UTC.
+ *
+ * @return An [OffsetDateTime] set to the UTC (+00:00) offset.
+ */
+fun Instant.toUtcOffsetDateTime(): OffsetDateTime = this.toJavaInstant().atOffset(ZoneOffset.UTC)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -25,3 +25,20 @@ database {
     reWriteBatchedInserts = "true"
   }
 }
+
+oidc {
+  issuer = ${?AUTH_ISSUER}
+  client_id = ${?AUTH_CLIENT_ID}
+  secret = ${?AUTH_CLIENT_SECRET}
+  realm = "Pillarbox"
+}
+
+session {
+  cookieSecret = ${?SESSION_COOKIE_SECRET}
+  timeoutSeconds = 28800
+  timeoutSeconds = ${?SESSION_TIMEOUT}
+  validationIntervalSeconds = 600
+  validationIntervalSeconds = ${?SESSION_VALIDATION_INTERVAL}
+  secure = true
+  secure = ${?SESSION_SECURE}
+}

--- a/src/main/resources/db/migration/V1__Initial_Schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_Schema.sql
@@ -5,3 +5,12 @@ CREATE TABLE IF NOT EXISTS pb_media (
   drm_configs JSONB NOT NULL,
   metadata JSONB NOT NULL
   );
+
+CREATE TABLE IF NOT EXISTS pb_session (
+  session_id VARCHAR(255) PRIMARY KEY,
+  access_token TEXT NOT NULL,
+  last_checked TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL
+  );
+
+CREATE INDEX IF NOT EXISTS idx_pb_session_expires ON pb_session (expires_at);

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
@@ -7,6 +7,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagOperationV1
 import ch.srgssr.pillarbox.backend.test.mediaFixture
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
+import ch.srgssr.pillarbox.backend.test.token
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -14,11 +15,14 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
@@ -27,10 +31,14 @@ class MediaRouteTest :
   ShouldSpec({
     should("return an empty list if no media is stored") {
       testApplicationContext {
-        val response = client.get("/v1/media")
+        val response =
+          client.get("/v1/media") {
+            bearerAuth(token)
+          }
 
         response shouldHaveStatus HttpStatusCode.OK
 
+        println("DEBUG: The raw JSON received was: '${response.bodyAsText()}'")
         val mediaList = response.body<List<MediaResponseV1>>()
 
         mediaList.shouldBeEmpty()
@@ -44,6 +52,7 @@ class MediaRouteTest :
 
         // Create the media
         client.post("/v1/media") {
+          bearerAuth(token)
           contentType(ContentType.Application.Json)
           setBody(request)
         } shouldHaveStatus HttpStatusCode.Created
@@ -58,17 +67,25 @@ class MediaRouteTest :
           )
 
         client.patch("/v1/media/${fixture.id}/tags") {
+          bearerAuth(token)
           contentType(ContentType.Application.Json)
           setBody(tagUpdate)
         } shouldHaveStatus HttpStatusCode.OK
 
         // Verify tags
-        val response = client.get("/v1/media/${fixture.id}")
+        val response =
+          client.get("/v1/media/${fixture.id}") {
+            bearerAuth(token)
+          }
         response.body<MediaResponseV1>().tags shouldContain "test-tag"
 
         // Delete the Media
-        client.delete("/v1/media/${fixture.id}") shouldHaveStatus HttpStatusCode.NoContent
-        client.get("/v1/media/${fixture.id}") shouldHaveStatus HttpStatusCode.NotFound
+        client.delete("/v1/media/${fixture.id}") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NoContent
+        client.get("/v1/media/${fixture.id}") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
       }
     }
 
@@ -78,22 +95,32 @@ class MediaRouteTest :
         for (i in 0..totalMedia) {
           val fixture = mediaFixture { id = "media-$i" }
           client.post("/v1/media") {
+            bearerAuth(token)
             contentType(ContentType.Application.Json)
             setBody(fixture.toMediaRequestV1())
           } shouldHaveStatus HttpStatusCode.Created
         }
 
-        client.getMediaPageV1(limit = 5, offset = 0).let { page ->
-          page.size shouldBe 5
-          page.first().id shouldBe "media-0"
-        }
+        client
+          .getMediaPageV1(limit = 5, offset = 0) {
+            bearerAuth(token)
+          }.let { page ->
+            page.size shouldBe 5
+            page.first().id shouldBe "media-0"
+          }
 
-        client.getMediaPageV1(limit = 1, offset = 5).let { page ->
-          page.size shouldBe 1
-          page.first().id shouldBe "media-5"
-        }
+        client
+          .getMediaPageV1(limit = 1, offset = 5) {
+            bearerAuth(token)
+          }.let { page ->
+            page.size shouldBe 1
+            page.first().id shouldBe "media-5"
+          }
 
-        client.getMediaPageV1(limit = 1, offset = 20).size shouldBe 0
+        client
+          .getMediaPageV1(limit = 1, offset = 20) {
+            bearerAuth(token)
+          }.size shouldBe 0
       }
     }
 
@@ -108,6 +135,7 @@ class MediaRouteTest :
           )
 
         client.patch("/v1/media/does-not-exist/tags") {
+          bearerAuth(token)
           contentType(ContentType.Application.Json)
           setBody(tagUpdate)
         } shouldHaveStatus HttpStatusCode.NotFound
@@ -116,7 +144,9 @@ class MediaRouteTest :
 
     should("return NOT_FOUND when deleting a non-existent media") {
       testApplicationContext {
-        client.delete("/v1/media/does-not-exist") shouldHaveStatus HttpStatusCode.NotFound
+        client.delete("/v1/media/does-not-exist") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
       }
     }
   })
@@ -127,10 +157,13 @@ class MediaRouteTest :
 suspend fun HttpClient.getMediaPageV1(
   limit: Int,
   offset: Int,
+  block: HttpRequestBuilder.() -> Unit = {},
 ): List<MediaResponseV1> =
   get("/v1/media") {
     url {
       parameters.append("limit", limit.toString())
       parameters.append("offset", offset.toString())
     }
+
+    block()
   }.body()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
@@ -6,12 +6,14 @@ import ch.srgssr.pillarbox.backend.test.mediaFixture
 import ch.srgssr.pillarbox.backend.test.shouldMatchSchema
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
+import ch.srgssr.pillarbox.backend.test.token
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
@@ -49,6 +51,7 @@ class PlayerMediaRouteTest :
           }
 
         client.post("/v1/media") {
+          bearerAuth(token)
           contentType(ContentType.Application.Json)
           setBody(mediaFixture.toMediaRequestV1())
         } shouldHaveStatus HttpStatusCode.Created
@@ -75,6 +78,7 @@ class PlayerMediaRouteTest :
         for (i in 0..totalMedia) {
           val fixture = mediaFixture { id = "media-$i" }
           client.post("/v1/media") {
+            bearerAuth(token)
             contentType(ContentType.Application.Json)
             setBody(fixture.toMediaRequestV1())
           } shouldHaveStatus HttpStatusCode.Created

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -3,9 +3,13 @@ package ch.srgssr.pillarbox.backend.test
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.config.MapApplicationConfig
+import io.ktor.server.config.mergeWith
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
+import io.ktor.util.AttributeKey
 import kotlinx.serialization.json.Json
+import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -17,16 +21,24 @@ import org.koin.core.context.GlobalContext
  * This utility automates the integration testing by:
  *    1. Loading the standard `application.conf` to configure the server and database.
  *    2. Providing a pre-configured [HttpClient] with JSON support for API calls.
- *    3. Ensuring database isolation between tests by dropping and recreating all
+ *    3. Overriding `oidc.issuer` in the config to point to the mock server.
+ *    4. Ensuring database isolation between tests by dropping and recreating all
  *       registered [Table] schemas after each test execution.
  *
  * @param block The test logic to execute, provides access to the [ApplicationTestBuilder]
  *              and a pre-configured `client` with JSON support.
  */
-fun testApplicationContext(block: suspend ApplicationTestBuilder.() -> Unit) =
+fun testApplicationContext(block: suspend ApplicationTestBuilder.(MockOAuth2Server) -> Unit) {
+  val oAuthServer = MockOAuth2Server()
+  oAuthServer.start()
+
   testApplication {
-    environment {
-      config = ApplicationConfig("application.conf")
+    configure("application.conf") {
+      val issuerUrl = oAuthServer.issuerUrl("pillarbox-realm").toString()
+
+      this["oidc.issuer"] = issuerUrl
+      this["oidc.client_id"] = "pillarbox-test-client"
+      this["oidc.realm"] = "pillarbox-realm"
     }
 
     client =
@@ -41,17 +53,35 @@ fun testApplicationContext(block: suspend ApplicationTestBuilder.() -> Unit) =
       }
 
     try {
-      block()
+      application.attributes.put(MockServerKey, oAuthServer)
+      block(oAuthServer)
     } finally {
       val allTables =
         GlobalContext
           .get()
-          .getAll<Table>()
-          .toList()
+          .get<List<Table>>()
           .toTypedArray()
       transaction {
         SchemaUtils.drop(*allTables)
         SchemaUtils.create(*allTables)
       }
+
+      oAuthServer.shutdown()
     }
   }
+}
+
+private val MockServerKey = AttributeKey<MockOAuth2Server>("MockOAuth2Server")
+
+val ApplicationTestBuilder.mockServer: MockOAuth2Server
+  get() =
+    application.attributes.getOrNull(MockServerKey)
+      ?: error("MockOAuth2Server not found in application attributes.")
+
+val ApplicationTestBuilder.token: String
+  get() =
+    mockServer
+      .issueToken(
+        issuerId = "pillarbox-realm",
+        audience = "pillarbox-test-client",
+      ).serialize()

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -6,3 +6,10 @@ database {
   password = ""
   poolSize = 5
 }
+
+session {
+  cookieSecret = "test-secret-must-be-long-enough-32chars"
+  timeoutSeconds = 28800
+  validationIntervalSeconds = 600
+  secure = false
+}


### PR DESCRIPTION
## Description

Initial implementation of the authentication and authorization infrastructure using OpenID Connect.

## Changes Made

* Implemented dynamic configuration via the `.well-known/openid-configuration` endpoint to
  automatically resolve token, authorization, and JWKS endpoints.
* Configured `jwt` for stateless API validation and `oauth` for standard login flows.
* Added a shared Ktor `HttpClient` to handle discovery requests and authentication handshake.
* Integrated Keycloak into `docker-compose.yml` with a pre-configured `pillarbox` realm, for local
  development.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
