### PR TITLE
feat: move DRM configurations to MediaSource

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Media.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Media.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.json.JsonObject
  * @property id The unique identifier for the media.
  * @property tags A list of labels or categories associated with the media.
  * @property sources The list of available playback sources (streams).
- * @property drmConfigs The DRM configurations available for this media.
  * @property metadata Descriptive information for display and playback.
  */
 @Serializable
@@ -17,7 +16,6 @@ data class Media(
   val id: String,
   val tags: List<String> = emptyList(),
   val sources: List<MediaSource> = emptyList(),
-  val drmConfigs: List<DrmConfig> = emptyList(),
   val metadata: MediaMetadata,
 )
 
@@ -28,7 +26,8 @@ data class Media(
  * @property type The type of the source (e.g., "ON-DEMAND", "LIVE").
  * @property mimeType The MIME type of the content.
  * @property videoFragmentFormat The format used for video segments.
- * @property audioFragmentsFormat The format used for audio segments.
+ * @property audioFragmentFormat The format used for audio segments.
+ * @property drmConfigs The DRM configurations available for this source.
  */
 @Serializable
 data class MediaSource(
@@ -36,7 +35,8 @@ data class MediaSource(
   val type: String? = null,
   val mimeType: String? = null,
   val videoFragmentFormat: String? = null,
-  val audioFragmentsFormat: String? = null,
+  val audioFragmentFormat: String? = null,
+  val drmConfigs: List<DrmConfig> = emptyList(),
 )
 
 /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaRequestV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaRequestV1.kt
@@ -1,6 +1,5 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.dto
 
-import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
@@ -16,7 +15,6 @@ import kotlinx.serialization.Serializable
  * @property id The unique identifier for the media resource.
  * @property tags A list of keywords or labels used for categorization or filtering.
  * @property sources The collection of streaming endpoints available for this media.
- * @property drmConfigs Digital Rights Management configurations for protected content.
  * @property metadata Contextual information including titles, chapters, and time ranges.
  */
 @Serializable
@@ -24,7 +22,6 @@ data class MediaRequestV1(
   val id: String,
   val tags: List<String> = emptyList(),
   val sources: List<MediaSource> = emptyList(),
-  val drmConfigs: List<DrmConfig> = emptyList(),
   val metadata: MediaMetadata,
 ) {
   /**
@@ -40,7 +37,6 @@ data class MediaRequestV1(
       id = id,
       tags = tags,
       sources = sources,
-      drmConfigs = drmConfigs,
       metadata = metadata,
     )
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaResponseV1.kt
@@ -1,6 +1,5 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.dto
 
-import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
@@ -19,7 +18,6 @@ import kotlinx.serialization.Serializable
  * @property id The unique identifier for the media resource.
  * @property tags A list of keywords or labels used for categorization or filtering.
  * @property sources The complete collection of all available streaming endpoints.
- * @property drmConfigs All Digital Rights Management configurations associated with this media.
  * @property metadata Detailed contextual information including titles, chapters, and markers.
  */
 @Serializable
@@ -27,7 +25,6 @@ data class MediaResponseV1(
   val id: String,
   val tags: List<String> = emptyList(),
   val sources: List<MediaSource> = emptyList(),
-  val drmConfigs: List<DrmConfig> = emptyList(),
   val metadata: MediaMetadata,
 )
 
@@ -43,6 +40,5 @@ fun Media.toMediaResponseV1() =
     id = this.id,
     tags = this.tags,
     sources = this.sources,
-    drmConfigs = this.drmConfigs,
     metadata = this.metadata,
   )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1.kt
@@ -49,7 +49,16 @@ data class PlayerMediaResponseV1(
   val chapters: List<Chapter>?,
   val timeRanges: List<TimeRange>?,
   val customData: JsonObject?,
-)
+) {
+  @Serializable
+  data class MediaSource(
+    val url: String,
+    val type: String? = null,
+    val mimeType: String? = null,
+    val videoFragmentFormat: String? = null,
+    val audioFragmentFormat: String? = null,
+  )
+}
 
 /**
  * Transforms a [Media] domain model into a [PlayerMediaResponseV1].
@@ -72,7 +81,7 @@ fun Media.toPlayerResponse(
     }
 
   val selectedDrm =
-    drmConfigs.firstOrNull {
+    selectedSource?.drmConfigs?.firstOrNull {
       it.keySystem.equals(keySystem, ignoreCase = true)
     }
 
@@ -85,7 +94,7 @@ fun Media.toPlayerResponse(
     seasonNumber = metadata.seasonNumber,
     episodeNumber = metadata.episodeNumber,
     viewport = metadata.viewport,
-    source = selectedSource,
+    source = selectedSource?.toPlayerMediaSourceV1(),
     drm = selectedDrm,
     subtitles = metadata.subtitles,
     chapters = metadata.chapters,
@@ -93,3 +102,19 @@ fun Media.toPlayerResponse(
     customData = metadata.customData,
   )
 }
+
+/**
+ * Maps the internal [Media] domain model to the [MediaResponseV1] DTO.
+ *
+ * Use this extension to prepare domain data for the admin web entry point.
+ *
+ * @return A [MediaResponseV1] containing the domain model's data.
+ */
+fun MediaSource.toPlayerMediaSourceV1() =
+  PlayerMediaResponseV1.MediaSource(
+    url = url,
+    type = type,
+    mimeType = mimeType,
+    videoFragmentFormat = videoFragmentFormat,
+    audioFragmentFormat = audioFragmentFormat,
+  )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
@@ -29,7 +29,6 @@ class MediaRepository(
       id = this[MediaTable.id],
       tags = this[MediaTable.tags],
       sources = this[MediaTable.sources],
-      drmConfigs = this[MediaTable.drmConfigs],
       metadata = this[MediaTable.metadata],
     )
 
@@ -43,7 +42,6 @@ class MediaRepository(
     builder[MediaTable.id] = item.id
     builder[MediaTable.tags] = item.tags
     builder[MediaTable.sources] = item.sources
-    builder[MediaTable.drmConfigs] = item.drmConfigs
     builder[MediaTable.metadata] = item.metadata
   }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaTable.kt
@@ -24,12 +24,6 @@ object MediaTable : Table("pb_media") {
   val tags = array<String>("tags")
 
   /**
-   * Digital Rights Management configurations.
-   * Stored as a JSONB list of [DrmConfig] objects.
-   */
-  val drmConfigs = jsonb<List<DrmConfig>>("drm_configs", Json.Default)
-
-  /**
    * List of available delivery sources.
    * Stored as a JSONB list of [MediaSource] objects.
    */

--- a/src/main/resources/db/migration/V1__Initial_Schema.sql
+++ b/src/main/resources/db/migration/V1__Initial_Schema.sql
@@ -2,7 +2,6 @@ CREATE TABLE IF NOT EXISTS pb_media (
   id VARCHAR(255) PRIMARY KEY,
   tags TEXT[] NOT NULL,
   sources JSONB NOT NULL,
-  drm_configs JSONB NOT NULL,
   metadata JSONB NOT NULL
   );
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
@@ -2,6 +2,7 @@ package ch.srgssr.pillarbox.backend.entrypoint.web
 
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.PlayerMediaResponseV1
+import ch.srgssr.pillarbox.backend.test.MediaLibrary
 import ch.srgssr.pillarbox.backend.test.mediaFixture
 import ch.srgssr.pillarbox.backend.test.shouldMatchSchema
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
@@ -42,9 +43,8 @@ class PlayerMediaRouteTest :
         val mediaFixture =
           mediaFixture {
             id = mediaId
-            withDash()
+            withDash(MediaLibrary.Widevine)
             withHls()
-            withWidevine()
             withSubtitles()
             withIntro()
             withChapters()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1Test.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1Test.kt
@@ -17,7 +17,7 @@ class PlayerMediaResponseV1Test :
 
       val response = media.toPlayerResponse(mimeType = "application/x-mpegURL", keySystem = null)
 
-      response.source shouldBe MediaLibrary.Hls
+      response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
     }
 
     should("not return any source if the requested mimeType is not found") {
@@ -47,11 +47,10 @@ class PlayerMediaResponseV1Test :
     should("select the correct DRM config based on keySystem") {
       val media =
         mediaFixture {
-          withWidevine()
-          withFairPlay()
+          withDash(MediaLibrary.Widevine, MediaLibrary.FairPlay)
         }
 
-      val response = media.toPlayerResponse(mimeType = null, keySystem = "com.apple.fps")
+      val response = media.toPlayerResponse(mimeType = "application/dash+xml", keySystem = "com.apple.fps")
 
       response.drm shouldBe MediaLibrary.FairPlay
     }
@@ -59,10 +58,10 @@ class PlayerMediaResponseV1Test :
     should("return null for DRM if the requested keySystem doesn't exist") {
       val media =
         mediaFixture {
-          withWidevine()
+          withMp4(MediaLibrary.Widevine)
         }
 
-      val response = media.toPlayerResponse(mimeType = null, keySystem = "com.microsoft.playready")
+      val response = media.toPlayerResponse(mimeType = "video/mp4", keySystem = "com.microsoft.playready")
 
       response.drm shouldBe null
     }
@@ -90,7 +89,7 @@ class PlayerMediaResponseV1Test :
     should("handle empty sources or drm lists gracefully") {
       val media = mediaFixture {}
 
-      val emptyMedia = media.copy(sources = emptyList(), drmConfigs = emptyList())
+      val emptyMedia = media.copy(sources = emptyList())
 
       val response = emptyMedia.toPlayerResponse(null, null)
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
@@ -54,19 +54,20 @@ class MediaBuilder {
   private val timeRanges = mutableListOf<TimeRange>()
   var metadata = MediaMetadata(title = "Default Test Title")
 
-  fun withDash() = apply { sources.add(MediaLibrary.Dash) }
+  fun withDash(vararg drm: DrmConfig) =
+    apply {
+      sources.add(MediaLibrary.Dash.copy(drmConfigs = drm.toList()))
+    }
 
-  fun withHls() = apply { sources.add(MediaLibrary.Hls) }
+  fun withHls(vararg drm: DrmConfig) =
+    apply {
+      sources.add(MediaLibrary.Hls.copy(drmConfigs = drm.toList()))
+    }
 
-  fun withMp4() = apply { sources.add(MediaLibrary.Mp4) }
-
-  fun withWidevine() = apply { drmConfigs.add(MediaLibrary.Widevine) }
-
-  fun withPlayReady() = apply { drmConfigs.add(MediaLibrary.PlayReady) }
-
-  fun withFairPlay() = apply { drmConfigs.add(MediaLibrary.FairPlay) }
-
-  fun withClearKey() = apply { drmConfigs.add(MediaLibrary.ClearKey) }
+  fun withMp4(vararg drm: DrmConfig) =
+    apply {
+      sources.add(MediaLibrary.Mp4.copy(drmConfigs = drm.toList()))
+    }
 
   fun withSubtitles() = apply { subtitles.add(MediaLibrary.EnglishSubtitles) }
 
@@ -77,8 +78,7 @@ class MediaBuilder {
   fun build() =
     Media(
       id = id,
-      sources = sources.ifEmpty { listOf(MediaLibrary.Dash) }, // Sane default
-      drmConfigs = drmConfigs,
+      sources = sources.ifEmpty { listOf(MediaLibrary.Dash) },
       metadata =
         metadata.copy(
           subtitles = subtitles.ifEmpty { null },
@@ -95,6 +95,5 @@ fun Media.toMediaRequestV1() =
     id = id,
     tags = tags,
     sources = sources,
-    drmConfigs = drmConfigs,
     metadata = metadata,
   )

--- a/src/test/resources/schemas/pillarbox-standard-metadata-schema.json
+++ b/src/test/resources/schemas/pillarbox-standard-metadata-schema.json
@@ -17,7 +17,7 @@
         "type": { "type": "string" },
         "mimeType": { "type": "string" },
         "videoFragmentFormat": { "type": "string" },
-        "audioFragmentsFormat": { "type": "string" }
+        "audioFragmentFormat": { "type": "string" }
       },
       "required": ["url"]
     },


### PR DESCRIPTION
## Description

Move `drmConfigs` from the root `Media` object directly into the `MediaSource` model to allow source specific protection.

## Changes Made

- Update `MediaSource` to include a list of `DrmConfig`.
- Remove `drmConfigs` from `Media`, `MediaRequestV1` and `MediaResponseV1` root objects.
- Align database entities to store DRM configurations per source.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
