### PR TITLE
fix: properly close HikariCP pool on module shutdown

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
@@ -49,8 +49,7 @@ fun databaseModule() =
         },
       )
     } onClose {
-      it?.connection?.close()
-      println("[Pillarbox] HikariPool closed.")
+      (it as? HikariDataSource)?.close()
     }
 
     single {


### PR DESCRIPTION
## Description

Casting to `HikariDataSource` ensures the pool is fully released during auto-reloads, preventing connection exhaustion.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
