### PR TITLE
fix: update default configuration values

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,10 @@ application {
 }
 
 tasks.shadowJar {
+  mergeServiceFiles {
+    include("META-INF/services/**")
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+  }
   archiveFileName = "${archiveBaseName.get()}.${archiveExtension.get()}"
   manifest { attributes["Main-Class"] = application.mainClass.get() }
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,8 @@
 ktor {
   deployment {
     port = 8080
+    development = false
+    development = ${?DEVELOPMENT}
     watch = [classes, resources]
     watchDelay = 500
   }
@@ -28,7 +30,8 @@ database {
 
 oidc {
   issuer = ${?AUTH_ISSUER}
-  discovery_url= ${?AUTH_DISCOVERY_PATH}
+  discovery_url = ".well-known/openid-configuration"
+  discovery_url = ${?AUTH_DISCOVERY_PATH}
   client_id = ${?AUTH_CLIENT_ID}
   secret = ${?AUTH_CLIENT_SECRET}
   realm = "Pillarbox"


### PR DESCRIPTION
## Description

Added missing default values to reduce the number of environment variables needed to run the application where standards apply.

## Changes Made

- Disable `development` mode by default.
- Add default `.wellknown` disovery path for oidc configuration.
- Ensure flyway resource scanners are preserved in the shadow jar. See: https://github.com/flyway/flyway/issues/4170#issuecomment-3569762563

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
