### PR TITLE
feat(auth): enable X-Forwarded-Headers for reverse proxy compatibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@
 # Enables hot-reloading and development-specific networking
 DEVELOPMENT=true
 
+# When true, the app trusts X-Forwarded-* headers (Proto, Host, Port).
+ENABLE_FORWARDED_HEADERS=false
+
 # --- Database Configuration ---
 
 # The full JDBC connection string for the PostgreSQL database.
@@ -19,12 +22,16 @@ DATABASE_USER=dev_user
 # The password for the database user. (Keep this secure in production!)
 DATABASE_PASSWORD=dev_password
 
-
 # --- OIDC / Keycloak Configuration ---
 
 # The Base URL of the Identity Provider. For Keycloak, this MUST include the realm path.
 # This URL is used to fetch the OIDC discovery document at startup.
 AUTH_ISSUER=http://localhost:8081/realms/pillarbox
+
+# The relative path to the OIDC discovery metadata.
+# Default: .well-known/openid-configuration
+# Override this if the provider uses a non-standard discovery path.
+AUTH_DISCOVERY_PATH=.well-known/openid-configuration
 
 # The Client ID registered in the Auth Provider.
 AUTH_CLIENT_ID=pillarbox-api

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,6 +144,7 @@ tasks.named<JavaExec>("run") {
 
   val isDev = getEnv("DEVELOPMENT", "true").toBoolean()
   systemProperty("io.ktor.development", isDev)
+  environment("ENABLE_FORWARDED_HEADERS", getEnv("ENABLE_FORWARDED_HEADERS", "false"))
   environment("DATABASE_URL", getEnv("DATABASE_URL", "jdbc:postgresql://localhost:5432/pillarbox"))
   environment("DATABASE_USER", getEnv("DATABASE_USER", "dev_user"))
   environment("DATABASE_PASSWORD", getEnv("DATABASE_PASSWORD", "dev_password"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ ktor-server-auth = { module = "io.ktor:ktor-server-auth", version.ref = "ktor" }
 ktor-server-auth-jwt = { module = "io.ktor:ktor-server-auth-jwt", version.ref = "ktor" }
 ktor-server-content-negotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-forwarded-header = { module = "io.ktor:ktor-server-forwarded-header", version.ref = "ktor" }
 ktor-server-htmx = { module = "io.ktor:ktor-server-htmx ", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-pebble = { module = "io.ktor:ktor-server-pebble", version.ref = "ktor" }
@@ -105,6 +106,7 @@ ktor-server = [
   "ktor-server-auth-jwt",
   "ktor-server-content-negotiation",
   "ktor-server-core",
+  "ktor-server-forwarded-header",
   "ktor-server-htmx",
   "ktor-server-netty",
   "ktor-server-pebble"

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -17,9 +17,12 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationStopped
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
+import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.netty.EngineMain
 import io.ktor.server.pebble.Pebble
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.forwardedheaders.ForwardedHeaders
+import io.ktor.server.plugins.forwardedheaders.XForwardedHeaders
 import io.ktor.server.routing.routing
 import io.pebbletemplates.pebble.loader.ClasspathLoader
 import org.koin.core.context.stopKoin
@@ -37,6 +40,10 @@ import org.koin.logger.slf4jLogger
 fun main(args: Array<String>): Unit = EngineMain.main(args)
 
 fun Application.module() {
+  if (environment.config.enableProxyHeaders()) {
+    install(ForwardedHeaders)
+  }
+
   install(Pebble) {
     loader(
       ClasspathLoader().apply {
@@ -67,7 +74,6 @@ fun Application.module() {
   }
 
   installSession(get())
-
   install(ContentNegotiation) { json(this@module.get()) }
 
   configureDevelopmentDefaults()
@@ -84,3 +90,16 @@ fun Application.module() {
     stopKoin()
   }
 }
+
+/**
+ * Checks the application configuration to determine if proxy header support is enabled.
+ *
+ * This looks for the `ktor.deployment.enable_forwarded_headers` property.
+ *
+ * @return `true` if the property is explicitly set to "true", `false` otherwise
+ * (including if the property is missing).
+ */
+fun ApplicationConfig.enableProxyHeaders(): Boolean =
+  propertyOrNull("ktor.deployment.enable_forwarded_headers")
+    ?.getString()
+    ?.toBoolean() ?: false

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationExtensions.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationExtensions.kt
@@ -2,6 +2,7 @@ package ch.srgssr.pillarbox.backend.auth
 
 import ch.srgssr.pillarbox.backend.entrypoint.web.Navigation
 import io.ktor.client.HttpClient
+import io.ktor.http.RequestConnectionPoint
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.auth.AuthenticationConfig
@@ -60,14 +61,20 @@ fun AuthenticationConfig.configureOidc(
  * This ensures the redirect URI matches the protocol, host, and port used by the client,
  * which is critical for environments behind proxies or load balancers.
  *
- * @param path The relative path for the OAuth callback (default is "/callback").
+ * @param path The relative path for the OAuth callback (default is [Navigation.CALLBACK]).
  *
  * @return A fully qualified URL string.
  */
-fun ApplicationRequest.buildCallbackUrl(path: String = "/callback"): String {
+fun ApplicationRequest.buildCallbackUrl(path: String = Navigation.CALLBACK): String {
   val o = origin
-  return "${o.scheme}://${o.serverHost}:${o.serverPort}$path"
+  val port = o.serverPort.takeUnless { o.isDefaultPort() }?.let { ":$it" } ?: ""
+
+  return "${o.scheme}://${o.serverHost}$port$path"
 }
+
+fun RequestConnectionPoint.isDefaultPort(): Boolean =
+  (scheme == "http" && serverPort == 80) ||
+    (scheme == "https" && serverPort == 443)
 
 /**
  * Installs and configures the Ktor [Sessions] plugin with a signed cookie.

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -5,6 +5,8 @@ ktor {
     development = ${?DEVELOPMENT}
     watch = [classes, resources]
     watchDelay = 500
+    enable_forwarded_headers = false
+    enable_forwarded_headers = ${?ENABLE_FORWARDED_HEADERS}
   }
 
   application {


### PR DESCRIPTION
## Description

Configure Ktor’s `XForwardedHeaders` plugin (via `ENABLE_FORWARDED_HEADERS`) to fix OIDC redirects using HTTP instead of HTTPS behind a reverse proxy.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
