### PR TITLE
fix: correct proxy header plugin and add regression tests

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -41,7 +41,7 @@ fun main(args: Array<String>): Unit = EngineMain.main(args)
 
 fun Application.module() {
   if (environment.config.enableProxyHeaders()) {
-    install(ForwardedHeaders)
+    install(XForwardedHeaders)
   }
 
   install(Pebble) {

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/OauthProxyTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/OauthProxyTest.kt
@@ -1,0 +1,76 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.entrypoint.web.Navigation
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import io.ktor.http.Url
+
+class OauthProxyTest :
+  ShouldSpec({
+
+    should("build callback URL using X-Forwarded headers when toggle is ON") {
+      testApplicationContext(enableProxyHeaders = true) {
+        val response =
+          client.get(Navigation.LOGIN) {
+            header(HttpHeaders.XForwardedProto, "https")
+            header(HttpHeaders.XForwardedHost, "pillarbox.ch")
+            header(HttpHeaders.XForwardedPort, "443")
+          }
+
+        val location = response.headers[HttpHeaders.Location]?.let { Url(it) }
+
+        location.shouldNotBeNull()
+        location.parameters["redirect_uri"] shouldBe "https://pillarbox.ch${Navigation.CALLBACK}"
+      }
+    }
+
+    should("should preserve the port if it is non-standard for the scheme") {
+      testApplicationContext(enableProxyHeaders = true) {
+        val response =
+          client.get(Navigation.LOGIN) {
+            header(HttpHeaders.XForwardedProto, "http")
+            header(HttpHeaders.XForwardedHost, "pillarbox.ch")
+            header(HttpHeaders.XForwardedPort, "4001")
+          }
+
+        val location = response.headers[HttpHeaders.Location]?.let { Url(it) }
+
+        location.shouldNotBeNull()
+        location.parameters["redirect_uri"] shouldBe "http://pillarbox.ch:4001${Navigation.CALLBACK}"
+      }
+    }
+
+    should("ignore X-Forwarded headers when toggle is OFF") {
+      testApplicationContext(enableProxyHeaders = false) {
+        val response =
+          client.get(Navigation.LOGIN) {
+            header(HttpHeaders.XForwardedProto, "https")
+            header(HttpHeaders.XForwardedHost, "pillarbox.ch")
+          }
+
+        val location = response.headers[HttpHeaders.Location]?.let { Url(it) }
+
+        location.shouldNotBeNull()
+        location.parameters["redirect_uri"] shouldBe "http://localhost${Navigation.CALLBACK}"
+      }
+    }
+
+    should("ignore Forwarded headers (RFC 7239) even when the toggle is ON") {
+      testApplicationContext(enableProxyHeaders = true) {
+        val response =
+          client.get(Navigation.LOGIN) {
+            header(HttpHeaders.Forwarded, "host=proxy.com;proto=https")
+          }
+
+        val location = response.headers[HttpHeaders.Location]?.let { Url(it) }
+
+        location.shouldNotBeNull()
+        location.parameters["redirect_uri"] shouldBe "http://localhost${Navigation.CALLBACK}"
+      }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -35,7 +35,10 @@ import org.koin.core.context.GlobalContext
  * @param block The test logic to execute, provides access to the [ApplicationTestBuilder]
  *              and a pre-configured `client` with JSON support.
  */
-fun testApplicationContext(block: suspend ApplicationTestBuilder.() -> Unit) {
+fun testApplicationContext(
+  enableProxyHeaders: Boolean = false,
+  block: suspend ApplicationTestBuilder.() -> Unit,
+) {
   val oAuthServer =
     MockOAuth2Server(
       OAuth2Config(
@@ -61,9 +64,8 @@ fun testApplicationContext(block: suspend ApplicationTestBuilder.() -> Unit) {
 
   testApplication {
     configure("application.conf") {
-      val issuerUrl = oAuthServer.issuerUrl("pillarbox-realm").toString()
-
-      this["oidc.issuer"] = issuerUrl
+      this["ktor.deployment.enable_forwarded_headers"] = enableProxyHeaders.toString()
+      this["oidc.issuer"] = oAuthServer.issuerUrl("pillarbox-realm").toString()
       this["oidc.discovery_path"] = ".well-known/openid-configuration"
       this["oidc.client_id"] = "pillarbox-test-client"
       this["oidc.realm"] = "pillarbox-realm"


### PR DESCRIPTION
## Description

Swapped `ForwardedHeaders` for `XForwardedHeaders` to correctly support X-Forwarded-* headers used by ALB. Added integration tests to verify dynamic OAuth callback URL generation under a proxy.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
