### PR TITLE
fix: remove double slashes in template paths for classpath loading

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
@@ -37,7 +37,7 @@ fun Route.console(mediaRepository: MediaRepository) {
     route(Navigation.CONSOLE) {
       get {
         call.respond(
-          PebbleContent("modules//home/home.page.peb", emptyMap()),
+          PebbleContent("modules/home/home.page.peb", emptyMap()),
         )
       }
 


### PR DESCRIPTION
## Description

Filesystem loading was lenient with redundant slashes, but the Shadow JAR classpath loader requires strict path resolution.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
