### PR TITLE
feat: handle security level for DRM negotiation

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -92,24 +92,24 @@ If neither is supplied, the API returns a media item without a source.
 
 **Query Parameters**
 
-| Parameter     | Example Value          | Description                                          |
-|---------------|------------------------|------------------------------------------------------|
-| `stream-type` | `application/dash+xml` | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values. |
-| `drm`         | `com.widevine.alpha`   | Preferred DRM key system. Comma-separated for multiple values.              |
+| Parameter        | Example Value                        | Description                                                                                                                         |
+|------------------|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `stream-type`    | `application/dash+xml`               | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
+| `drm`            | `com.widevine.alpha;HW_SECURE_ALL`   | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
 
 Example:
 
 ```bash
 curl --request GET \
-  --url 'http://localhost:8080/v1/player/media/urn:pillarbox:video:12345?stream-type=application/dash+xml&drm=com.widevine.alpha'
+  --url 'http://localhost:8080/v1/player/media/urn:pillarbox:video:12345?stream-type=application/dash+xml&drm=com.widevine.alpha;HW_SECURE_ALL'
 ```
 
 **Headers (fallback)**
 
-| Header                 | Example Value          | Description                                          |
-|------------------------|------------------------|------------------------------------------------------|
-| `X-Accept-Stream-Type` | `application/dash+xml` | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values. |
-| `X-Accept-DRM`         | `com.widevine.alpha`   | Preferred DRM key system. Comma-separated for multiple values.              |
+| Header                 | Example Value                        | Description                                                                                                                         |
+|------------------------|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `X-Accept-Stream-Type` | `application/dash+xml`               | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
+| `X-Accept-DRM`         | `com.widevine.alpha;HW_SECURE_ALL`   | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
 
 Example:
 
@@ -117,8 +117,24 @@ Example:
 curl --request GET \
   --url http://localhost:8080/v1/player/media/urn:pillarbox:video:12345 \
   --header 'X-Accept-Stream-Type: application/dash+xml' \
-  --header 'X-Accept-DRM: com.widevine.alpha'
+  --header 'X-Accept-DRM: com.widevine.alpha;HW_SECURE_ALL'
 ```
+
+**Security Levels**
+
+The `drm` parameter and `X-Accept-DRM` header accept either DRM-native security levels or EME
+robustness levels. Robustness levels are automatically resolved to the corresponding DRM-native
+level.
+
+| EME Robustness Level | Widevine | PlayReady |
+|----------------------|----------|-----------|
+| `SW_SECURE_CRYPTO`   | L3       | SL2000    |
+| `SW_SECURE_DECODE`   | L3       | SL2000    |
+| `HW_SECURE_CRYPTO`   | L2       | SL2000    |
+| `HW_SECURE_DECODE`   | L2       | SL2000    |
+| `HW_SECURE_ALL`      | L1       | SL3000    |
+
+Native levels (`L1`, `L2`, `L3`, `SL2000`, `SL3000`) are still accepted and passed through unchanged.
 
 [media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
 [player-media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Media.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Media.kt
@@ -87,6 +87,7 @@ data class MediaMetadata(
  * @property licenseUrl The URL to fetch the decryption license.
  * @property certificateUrl The URL to fetch the device certificate, if required.
  * @property multisession Whether to enable DRM session sharing across requests.
+ * @property securityLevel The minimum security level required to use this DRM configuration.
  */
 @Serializable
 data class DrmConfig(
@@ -94,7 +95,7 @@ data class DrmConfig(
   val licenseUrl: String,
   val certificateUrl: String? = null,
   val multisession: Boolean? = null,
-  // TODO Add the security level
+  val securityLevel: String? = null,
 )
 
 /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt
@@ -3,6 +3,8 @@ package ch.srgssr.pillarbox.backend.entrypoint.web
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.PlayerMediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toPlayerResponse
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaSourceSelector
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.toDrmPreferences
 import ch.srgssr.pillarbox.backend.io.parseHeaderList
 import ch.srgssr.pillarbox.backend.io.parseParamList
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
@@ -58,25 +60,25 @@ fun Route.playerMedia(mediaRepository: MediaRepository) {
     playerMediaEndpoints<PlayerMediaResponseV1>(
       mediaRepository = mediaRepository,
       // Supported query parameters (take precedence over headers):
-      // - stream-type: Preferred source MIME type (e.g. "application/dash+xml,application/x-mpegURL")
-      // - drm:         Preferred DRM key system   (e.g. "com.widevine.alpha")
+      // - stream-type:     Preferred source MIME type (e.g. "application/dash+xml,application/x-mpegURL")
+      // - drm:             Preferred DRM key system   (e.g. "com.widevine.alpha")
       //
       // Supported headers (fallback when query parameters are absent):
-      // - X-Accept-Stream-Type: Preferred source MIME type
-      // - X-Accept-DRM:         Preferred DRM key system
+      // - X-Accept-Stream-Type:     Preferred source MIME type
+      // - X-Accept-DRM:             Preferred DRM key system
       toResponse = { media, call ->
-        val preferredStream =
+        val mimeTypes =
           call.request.queryParameters
             .parseParamList("stream-type")
             .ifEmpty { call.request.headers.parseHeaderList("X-Accept-Stream-Type") }
-        val preferredDRM =
+        val drmPreferences =
           call.request.queryParameters
             .parseParamList("drm")
             .ifEmpty { call.request.headers.parseHeaderList("X-Accept-DRM") }
+            .toDrmPreferences()
 
         media.toPlayerResponse(
-          mimeTypes = preferredStream,
-          keySystems = preferredDRM,
+          MediaSourceSelector(mimeTypes, drmPreferences),
         )
       },
     )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1.kt
@@ -6,6 +6,7 @@ import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
 import ch.srgssr.pillarbox.backend.domain.model.SubtitleTrack
 import ch.srgssr.pillarbox.backend.domain.model.TimeRange
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaSourceSelector
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
 
@@ -63,27 +64,15 @@ data class PlayerMediaResponseV1(
 /**
  * Transforms a [Media] domain model into a [PlayerMediaResponseV1].
  *
- * Implements source selection logic: filters by MIME type and DRM compatibility,
- * then picks the best match according to the caller's priority lists.
+ * Source selection is fully delegated to [selector]. This function only
+ * handles the mapping from the selected source to the response shape.
  *
- * @param mimeTypes Prioritized list of accepted MIME types (e.g. "application/dash+xml").
- *                  A source must match at least one entry to be considered.
- * @param keySystems Prioritized list of accepted DRM key systems (e.g. "com.widevine.alpha").
- *                   When empty, both protected and unprotected sources are eligible.
- *
+ * @param selector The [MediaSourceSelector] that encapsulates the client's stream-type and
+ *                 DRM capabilities.
  * @return A player-optimized response containing only the best-matching stream and DRM info.
  */
-fun Media.toPlayerResponse(
-  mimeTypes: List<String> = emptyList(),
-  keySystems: List<String> = emptyList(),
-): PlayerMediaResponseV1 {
-  val selectedSource =
-    sources
-      .filter { it.matchesMimeType(mimeTypes) && it.matchesAnyKeySystem(keySystems) }
-      .map { it.retainingOnlyMatchingDrm(keySystems) }
-      .sortedWith(preferredSourceOrder(mimeTypes, keySystems))
-      .firstOrNull()
-
+fun Media.toPlayerResponse(selector: MediaSourceSelector): PlayerMediaResponseV1 {
+  val selection = selector.select(sources)
   return PlayerMediaResponseV1(
     identifier = id,
     title = metadata.title,
@@ -93,8 +82,8 @@ fun Media.toPlayerResponse(
     seasonNumber = metadata.seasonNumber,
     episodeNumber = metadata.episodeNumber,
     viewport = metadata.viewport,
-    source = selectedSource?.toPlayerMediaSourceV1(),
-    drm = selectedSource?.preferredDrm(keySystems),
+    source = selection?.source?.toPlayerMediaSourceV1(),
+    drm = selection?.drm,
     subtitles = metadata.subtitles,
     chapters = metadata.chapters,
     timeRanges = metadata.timeRanges,
@@ -102,58 +91,8 @@ fun Media.toPlayerResponse(
   )
 }
 
-private fun MediaSource.matchesMimeType(mimeTypes: List<String>): Boolean =
-  mimeTypes.any { mimeType?.equals(it, ignoreCase = true) == true }
-
-private fun DrmConfig.matchesKeySystem(keySystems: List<String>): Boolean =
-  keySystems.any { this.keySystem.equals(it, ignoreCase = true) }
-
 /**
- * A source is DRM-compatible when:
- * - the source is unprotected, OR
- * - at least one of its DRM configs matches a requested key system.
- */
-private fun MediaSource.matchesAnyKeySystem(keySystems: List<String>): Boolean =
-  drmConfigs.isEmpty() || drmConfigs.any { it.matchesKeySystem(keySystems) }
-
-/** Returns a copy of this source keeping only DRM configs that match a requested key system. */
-private fun MediaSource.retainingOnlyMatchingDrm(keySystems: List<String>): MediaSource =
-  copy(drmConfigs = drmConfigs.filter { it.matchesKeySystem(keySystems) })
-
-/**
- * Ordering rules (ascending = more preferred):
- * 1. Protected sources before unprotected ones (when a key system was requested).
- * 2. Lower MIME type index = higher priority in [mimeTypes].
- * 3. Lower key system index = higher priority in [keySystems].
- */
-private fun preferredSourceOrder(
-  mimeTypes: List<String>,
-  keySystems: List<String>,
-): Comparator<MediaSource> =
-  compareBy(
-    { if (it.drmConfigs.isEmpty()) 1 else 0 },
-    { mimeTypes.indexOfFirst { mt -> it.mimeType?.equals(mt, ignoreCase = true) == true } },
-    { it.bestDrmPriority(keySystems) },
-  )
-
-/** Returns the best (lowest) key-system priority index across all DRM configs, or MAX if none. */
-private fun MediaSource.bestDrmPriority(keySystems: List<String>): Int =
-  drmConfigs.minOfOrNull { drm ->
-    keySystems.indexOfFirst { ks -> drm.keySystem.equals(ks, ignoreCase = true) }
-  } ?: Int.MAX_VALUE
-
-/** Returns the first DRM config whose key system appears in [keySystems], respecting their order. */
-private fun MediaSource.preferredDrm(keySystems: List<String>): DrmConfig? =
-  keySystems.firstNotNullOfOrNull { ks ->
-    drmConfigs.find { drm -> drm.keySystem.equals(ks, ignoreCase = true) }
-  }
-
-/**
- * Maps the internal [Media] domain model to the [MediaResponseV1] DTO.
- *
- * Use this extension to prepare domain data for the admin web entry point.
- *
- * @return A [MediaResponseV1] containing the domain model's data.
+ * Maps the domain [MediaSource] to the player-specific [PlayerMediaResponseV1.MediaSource] DTO.
  */
 fun MediaSource.toPlayerMediaSourceV1() =
   PlayerMediaResponseV1.MediaSource(

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/DrmPreference.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/DrmPreference.kt
@@ -1,0 +1,56 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.service
+
+/**
+ * A client's preference for a specific DRM key system, optionally
+ * constrained to a maximum security level.
+ *
+ * @property keySystem The  key system for this preference.
+ * @property maxSecurityLevel The highest acceptable security level for this key system,
+ *                            or `null` if unconstrained.
+ */
+data class DrmPreference(
+  val keySystem: String,
+  val maxSecurityLevel: String? = null,
+)
+
+/**
+ * Maps EME robustness levels to DRM-specific security levels per key system.
+ */
+private val robustnessToLevel: Map<Pair<String, String>, String> =
+  mapOf(
+    ("com.widevine.alpha" to "SW_SECURE_CRYPTO") to "L3",
+    ("com.widevine.alpha" to "SW_SECURE_DECODE") to "L3",
+    ("com.widevine.alpha" to "HW_SECURE_CRYPTO") to "L2",
+    ("com.widevine.alpha" to "HW_SECURE_DECODE") to "L2",
+    ("com.widevine.alpha" to "HW_SECURE_ALL") to "L1",
+    ("com.microsoft.playready" to "SW_SECURE_CRYPTO") to "SL2000",
+    ("com.microsoft.playready" to "SW_SECURE_DECODE") to "SL2000",
+    ("com.microsoft.playready" to "HW_SECURE_CRYPTO") to "SL2000",
+    ("com.microsoft.playready" to "HW_SECURE_DECODE") to "SL2000",
+    ("com.microsoft.playready" to "HW_SECURE_ALL") to "SL3000",
+  )
+
+/**
+ * Parses a DRM preference string of the form `"keySystem"` or `"keySystem;securityLevel"`.
+ *
+ * @receiver the raw preference string.
+ * @return the parsed [DrmPreference].
+ */
+fun String.toDrmPreference(): DrmPreference {
+  if (";" !in this) return DrmPreference(keySystem = this)
+
+  val (keySystem, level) = split(";", limit = 2).map { it.trim() }
+
+  return DrmPreference(
+    keySystem,
+    level.takeIf { isNotEmpty() }?.let { robustnessToLevel[keySystem to level] ?: level },
+  )
+}
+
+/**
+ * Parses a list of raw DRM preference strings.
+ *
+ * @receiver list of raw strings.
+ * @return list of parsed [DrmPreference]s, preserving priority order.
+ */
+fun List<String>.toDrmPreferences(): List<DrmPreference> = mapNotNull { it.toDrmPreference() }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/MediaSourceSelector.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/MediaSourceSelector.kt
@@ -1,0 +1,187 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.service
+
+import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
+import ch.srgssr.pillarbox.backend.domain.model.MediaSource
+
+/**
+ * Selects the best [MediaSource] from a list given a client's stream and DRM capabilities.
+ *
+ * The selector is built once per request and encapsulates all matching and ordering logic.
+ * Invoke [select] with the available sources to obtain the chosen [Selection].
+ *
+ * **Selection rules (in priority order):**
+ * 1. The source's MIME type must appear in [mimeTypes].
+ * 2. The source must be unprotected, or have at least one DRM config compatible with [drmPreferences].
+ * 3. DRM-protected sources rank above unprotected ones (when DRM preferences are expressed).
+ * 4. Lower index in [mimeTypes] = higher MIME-type priority.
+ * 5. Lower index in [drmPreferences] = higher DRM priority.
+ *
+ * @property mimeTypes Prioritised list of accepted MIME types (e.g. "application/dash+xml").
+ * @property drmPreferences Prioritised list of accepted DRM preferences.
+ */
+class MediaSourceSelector(
+  private val mimeTypes: List<String>,
+  private val drmPreferences: List<DrmPreference>,
+) {
+  /**
+   * The outcome of a successful source selection.
+   *
+   * @property source The winning [MediaSource].
+   * @property drm The single [DrmConfig] chosen from [source], or `null` for unprotected sources.
+   */
+  data class Selection(
+    val source: MediaSource,
+    val drm: DrmConfig?,
+  )
+
+  /**
+   * Selects the best source from [sources].
+   *
+   * Filters out ineligible sources, strips incompatible DRM configs from the remaining ones,
+   * sorts by the [selection rules][MediaSourceSelector], and returns the top candidate.
+   *
+   * @param sources The available media sources to choose from.
+   * @return The [Selection] for the highest-priority eligible source, or `null` if none qualify.
+   */
+  fun select(sources: List<MediaSource>): Selection? =
+    sources
+      .filter { it.isEligible() }
+      .map { it.retainCompatibleDrm() }
+      .sortedWith(selectionOrder())
+      .firstOrNull()
+      ?.let { source -> Selection(source, source.preferredDrm()) }
+
+  /**
+   * Checks whether this source passes all eligibility criteria:
+   * its MIME type must be accepted and its DRM protection must be compatible (or absent).
+   */
+  private fun MediaSource.isEligible(): Boolean = matchesMimeType() && isDrmCompatible()
+
+  /**
+   * Returns `true` if this source's [mimeType][MediaSource.mimeType] matches
+   * any entry in the accepted [mimeTypes] list (case-insensitive).
+   */
+  private fun MediaSource.matchesMimeType(): Boolean = mimeTypes.any { mimeType?.equals(it, ignoreCase = true) == true }
+
+  /**
+   * Returns `true` if this source is either unprotected (no DRM configs)
+   * or has at least one [DrmConfig] compatible with the client's [drmPreferences].
+   */
+  private fun MediaSource.isDrmCompatible(): Boolean =
+    drmConfigs.isEmpty() || drmConfigs.any { config -> drmPreferences.any { it.isCompatibleWith(config) } }
+
+  /**
+   * Checks whether this [DrmPreference] is compatible with the given [config].
+   *
+   * Compatibility requires matching key systems. When both the preference's [DrmPreference.maxSecurityLevel]
+   * and the config's [DrmConfig.securityLevel] are present, the client's level must be at least as strong
+   * as the level required by the config (verified via [SecurityLevels.isCompatible]).
+   *
+   * @param config The DRM configuration to test against.
+   * @return `true` if this preference can satisfy [config].
+   */
+  private fun DrmPreference.isCompatibleWith(config: DrmConfig): Boolean =
+    when {
+      config.keySystem != keySystem -> false
+      (maxSecurityLevel == null || config.securityLevel == null) -> true
+      else -> SecurityLevels.isCompatible(config.keySystem, maxSecurityLevel, config.securityLevel)
+    }
+
+  /**
+   * Returns a copy of this source containing only the [DrmConfig] entries
+   * that are compatible with the client's [drmPreferences].
+   */
+  private fun MediaSource.retainCompatibleDrm(): MediaSource =
+    copy(drmConfigs = drmConfigs.filter { config -> drmPreferences.any { it.isCompatibleWith(config) } })
+
+  /**
+   * Builds the [Comparator] used to rank eligible sources.
+   *
+   * Sources are compared by:
+   * 1. **DRM presence** – protected sources rank first over unprotected ones.
+   * 2. **MIME-type priority** – lower index in [mimeTypes] is better.
+   * 3. **DRM priority** – lowest compatible index in [drmPreferences] wins.
+   */
+  private fun selectionOrder(): Comparator<MediaSource> =
+    compareBy(
+      { if (it.drmConfigs.isEmpty()) 1 else 0 },
+      { mimeTypes.indexOfFirst { mt -> it.mimeType?.equals(mt, ignoreCase = true) == true } },
+      { it.bestDrmPriority() },
+    )
+
+  /**
+   * Returns the best (lowest) DRM preference index across all compatible [DrmConfig] entries
+   * of this source, or [Int.MAX_VALUE] if none match.
+   */
+  private fun MediaSource.bestDrmPriority(): Int =
+    drmConfigs.minOfOrNull { config ->
+      drmPreferences.indexOfFirst { it.isCompatibleWith(config) }
+    } ?: Int.MAX_VALUE
+
+  /**
+   * Returns the first [DrmConfig] from this source that matches the client's [drmPreferences],
+   * respecting preference order, or `null` if the source is unprotected.
+   */
+  private fun MediaSource.preferredDrm(): DrmConfig? =
+    drmPreferences.firstNotNullOfOrNull { pref ->
+      drmConfigs.find { pref.isCompatibleWith(it) }
+    }
+}
+
+/**
+ * Maps well-known DRM key-system / security-level pairs to a numeric rank
+ * so that levels can be compared across different DRM schemes.
+ *
+ * A **lower rank** means a **stronger** security level (e.g. Widevine L1 = 1, L3 = 3).
+ *
+ * Currently supported key systems:
+ * - `com.widevine.alpha`: L1, L2, L3
+ * - `com.microsoft.playready`: SL3000, SL2000, SL150
+ */
+private object SecurityLevels {
+  /** Maps `(keySystem, level)` pairs to their numeric rank. */
+  private val rankings: Map<Pair<String, String>, Int> =
+    mapOf(
+      ("com.widevine.alpha" to "L1") to 1,
+      ("com.widevine.alpha" to "L2") to 2,
+      ("com.widevine.alpha" to "L3") to 3,
+      ("com.microsoft.playready" to "SL3000") to 1,
+      ("com.microsoft.playready" to "SL2000") to 2,
+      ("com.microsoft.playready" to "SL150") to 3,
+    )
+
+  /**
+   * Returns the numeric rank for the given [keySystem] and [level],
+   * or `null` if the combination is unknown.
+   *
+   * @param keySystem The DRM key system identifier (e.g. `"com.widevine.alpha"`).
+   * @param level The security level string (e.g. `"L1"`, `"SL3000"`).
+   */
+  fun rankOf(
+    keySystem: String,
+    level: String,
+  ): Int? = rankings[keySystem to level]
+
+  /**
+   * Checks whether the [actual] security level of the client is strong enough
+   * to satisfy the [required] level demanded by a DRM config.
+   *
+   * Comparison is rank-based: a lower-or-equal rank means the client meets or exceeds
+   * the requirement. Returns `false` if either level is unknown for the given [keySystem].
+   *
+   * @param keySystem The DRM key system identifier.
+   * @param actual The client's reported security level.
+   * @param required The security level required by the DRM config.
+   * @return `true` if the client's level is at least as strong as [required].
+   */
+  @SuppressWarnings("ReturnCount")
+  fun isCompatible(
+    keySystem: String,
+    actual: String,
+    required: String,
+  ): Boolean {
+    val actualRank = rankOf(keySystem, actual) ?: return false
+    val requiredRank = rankOf(keySystem, required) ?: return false
+    return actualRank <= requiredRank
+  }
+}

--- a/src/main/resources/templates/modules/media/media-form.macros.peb
+++ b/src/main/resources/templates/modules/media/media-form.macros.peb
@@ -87,8 +87,9 @@
 
     <div class="form-row">
       {{ inputText("sources[" + sourceIndex + "].drmConfigs[" + drmIndex + "].keySystem", "Key System", item.keySystem) }}
-      {{ inputUrl("sources[" + sourceIndex + "].drmConfigs[" + drmIndex + "].licenseUrl", "License URL", item.licenseUrl) }}
+      {{ inputText("sources[" + sourceIndex + "].drmConfigs[" + drmIndex + "].securityLevel", "Security Level", item.securityLevel, placeholder = "e.g. L1") }}
     </div>
+    {{ inputUrl("sources[" + sourceIndex + "].drmConfigs[" + drmIndex + "].licenseUrl", "License URL", item.licenseUrl) }}
     {{ inputUrl("sources[" + sourceIndex + "].drmConfigs[" + drmIndex + "].certificateUrl", "Certificate URL", item.certificateUrl) }}
   </div>
 </details>

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRouteTest.kt
@@ -102,7 +102,7 @@ class PlayerMediaRouteTest :
         val media =
           mediaFixture {
             withMp4()
-            withDash(MediaLibrary.Widevine)
+            withDash(MediaLibrary.WidevineL3)
             withHls()
           }
         client.post("/v1/media") {
@@ -115,11 +115,9 @@ class PlayerMediaRouteTest :
           client
             .get("/v1/player/media/${media.id}") {
               url {
-                parameters.append(
-                  "stream-type",
-                  "application/x-mpegURL,video/mp4",
-                )
+                parameters.append("stream-type", "application/x-mpegURL,video/mp4")
                 parameters.append("drm", "com.widevine.alpha,com.apple.fps")
+                parameters.append("security-level", "L3")
               }
             }.body<PlayerMediaResponseV1>()
 
@@ -134,10 +132,11 @@ class PlayerMediaRouteTest :
                 parameters.append("stream-type", "application/x-mpegURL")
                 parameters.append("drm", "com.widevine.alpha")
                 parameters.append("drm", "com.apple.fps")
+                parameters.append("security-level", "L3")
               }
             }.body<PlayerMediaResponseV1>()
         multiResponse.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
-        multiResponse.drm shouldBe MediaLibrary.Widevine
+        multiResponse.drm shouldBe MediaLibrary.WidevineL3
       }
     }
 
@@ -145,7 +144,7 @@ class PlayerMediaRouteTest :
       testApplicationContext {
         val media =
           mediaFixture {
-            withDash(MediaLibrary.Widevine)
+            withDash(MediaLibrary.WidevineL3)
             withHls(MediaLibrary.FairPlay)
           }
         client.post("/v1/media") {
@@ -159,10 +158,10 @@ class PlayerMediaRouteTest :
           client
             .get("/v1/player/media/${media.id}") {
               header("X-Accept-Stream-Type", "application/dash+xml,application/x-mpegURL")
-              header("X-Accept-DRM", "com.widevine.alpha,com.apple.fps")
+              header("X-Accept-DRM", "com.widevine.alpha;L3,com.apple.fps")
             }.body<PlayerMediaResponseV1>()
         csvResponse.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
-        csvResponse.drm shouldBe MediaLibrary.Widevine
+        csvResponse.drm shouldBe MediaLibrary.WidevineL3
 
         // Repeated headers
         val multiResponse =
@@ -177,30 +176,33 @@ class PlayerMediaRouteTest :
       }
     }
 
-    should("prefer query parameters over headers for both stream-type and drm") {
+    should("prefer query parameters over headers for stream-type, drm, and security-level") {
       testApplicationContext {
         val media =
           mediaFixture {
-            withDash(MediaLibrary.Widevine)
-            withHls(MediaLibrary.FairPlay)
+            withDash(MediaLibrary.WidevineL1)
+            withHls(MediaLibrary.WidevineL3)
           }
         client.post("/v1/media") {
           bearerAuth(token)
           contentType(ContentType.Application.Json)
           setBody(media.toMediaRequestV1())
         } shouldHaveStatus HttpStatusCode.Created
+
         val response =
           client
             .get("/v1/player/media/${media.id}") {
               url {
                 parameters.append("stream-type", "application/dash+xml")
                 parameters.append("drm", "com.widevine.alpha")
+                parameters.append("security-level", "L1")
               }
               header("X-Accept-Stream-Type", "application/x-mpegURL")
-              header("X-Accept-DRM", "com.apple.fps")
+              header("X-Accept-DRM", "com.widevine.alpha;L3")
             }.body<PlayerMediaResponseV1>()
+
         response.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
-        response.drm shouldBe MediaLibrary.Widevine
+        response.drm shouldBe MediaLibrary.WidevineL1
       }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1Test.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1Test.kt
@@ -1,195 +1,306 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.dto
 
+import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
+import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaSourceSelector
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.toDrmPreferences
 import ch.srgssr.pillarbox.backend.test.MediaLibrary
 import ch.srgssr.pillarbox.backend.test.mediaFixture
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
+
+private data class SourceSelectionCase(
+  val name: String,
+  val media: Media,
+  val mimeTypes: List<String>,
+  val drm: List<String>,
+  val expectedSource: PlayerMediaResponseV1.MediaSource?,
+  val expectedDrm: DrmConfig?,
+)
 
 class PlayerMediaResponseV1Test :
   ShouldSpec({
 
-    should("select the specific source when a valid mimeType is provided") {
-      val media =
-        mediaFixture {
-          withDash()
-          withHls()
-        }
-
-      val response = media.toPlayerResponse(mimeTypes = listOf("application/x-mpegURL"))
-
-      response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
-    }
-
-    should("not return any source if the requested mimeType is not found") {
-      val media =
-        mediaFixture {
-          withDash()
-          withHls()
-        }
-
-      val response = media.toPlayerResponse(mimeTypes = listOf("video/mp4"))
-
-      response.source shouldBe null
-    }
-
-    should("not return any source if the requested mimeType is null") {
-      val media =
-        mediaFixture {
-          withDash()
-          withHls()
-        }
-
-      val response = media.toPlayerResponse(mimeTypes = emptyList())
-
-      response.source shouldBe null
-    }
-
-    should("prefer the mimeType that appears earlier in the priority list") {
-      val media =
-        mediaFixture {
-          withMp4()
-          withHls()
-          withDash()
-        }
-      val response =
-        media.toPlayerResponse(
-          mimeTypes = listOf("application/x-mpegURL", "application/dash+xml"),
-        )
-      response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
-    }
-
-    should("select the correct DRM config based on keySystem") {
-      val media =
-        mediaFixture {
-          withDash(MediaLibrary.Widevine, MediaLibrary.FairPlay)
-        }
-
-      val response =
-        media.toPlayerResponse(
-          mimeTypes = listOf("application/dash+xml"),
-          keySystems = listOf("com.apple.fps"),
-        )
-
-      response.drm shouldBe MediaLibrary.FairPlay
-    }
-
-    should("return null for DRM if the requested keySystem doesn't exist") {
-      val media =
-        mediaFixture {
-          withMp4(MediaLibrary.Widevine)
-        }
-
-      val response =
-        media.toPlayerResponse(
+    context("source and DRM selection") {
+      withData(
+        nameFn = { "should ${it.name}" },
+        // MIME type selection
+        SourceSelectionCase(
+          name = "select the specific source when a valid mimeType is provided",
+          media =
+            mediaFixture {
+              withDash()
+              withHls()
+            },
+          mimeTypes = listOf("application/x-mpegURL"),
+          drm = emptyList(),
+          expectedSource = MediaLibrary.Hls.toPlayerMediaSourceV1(),
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "not return any source if the requested mimeType is not found",
+          media =
+            mediaFixture {
+              withDash()
+              withHls()
+            },
           mimeTypes = listOf("video/mp4"),
-          keySystems = listOf("com.microsoft.playready"),
-        )
-
-      response.drm shouldBe null
-    }
-
-    should("prefer the keySystem that appears earlier in the priority list") {
-      val media =
-        mediaFixture {
-          withDash(MediaLibrary.FairPlay, MediaLibrary.Widevine)
-        }
-      val response =
-        media.toPlayerResponse(
-          mimeTypes = listOf("application/dash+xml"),
-          keySystems = listOf("com.widevine.alpha", "com.apple.fps"),
-        )
-      response.drm shouldBe MediaLibrary.Widevine
-    }
-
-    should("strip non-matching DRM configs from the selected source's drm field") {
-      val media =
-        mediaFixture {
-          withDash(MediaLibrary.Widevine, MediaLibrary.FairPlay)
-        }
-      val response =
-        media.toPlayerResponse(
-          mimeTypes = listOf("application/dash+xml"),
-          keySystems = listOf("com.widevine.alpha"),
-        )
-      response.drm shouldBe MediaLibrary.Widevine
-    }
-
-    should("prefer a protected source over an unprotected one when a compatible keySystem is requested") {
-      val media =
-        mediaFixture {
-          withDash()
-          withHls(MediaLibrary.Widevine)
-        }
-
-      val response =
-        media.toPlayerResponse(
-          mimeTypes = listOf("application/dash+xml", "application/x-mpegURL"),
-          keySystems = listOf("com.widevine.alpha"),
-        )
-
-      response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
-      response.drm shouldBe MediaLibrary.Widevine
-    }
-
-    should("return an unprotected source when an incompatible keySystem is requested") {
-      val media =
-        mediaFixture {
-          withDash()
-          withHls(MediaLibrary.Widevine)
-        }
-
-      val response =
-        media.toPlayerResponse(
+          drm = emptyList(),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "not return any source if the requested mimeType is null",
+          media =
+            mediaFixture {
+              withDash()
+              withHls()
+            },
+          mimeTypes = emptyList(),
+          drm = emptyList(),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "prefer the mimeType that appears earlier in the priority list",
+          media =
+            mediaFixture {
+              withMp4()
+              withHls()
+              withDash()
+            },
           mimeTypes = listOf("application/x-mpegURL", "application/dash+xml"),
-          keySystems = listOf("com.microsoft.playready"),
-        )
-
-      response.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
-    }
-
-    should("exclude a protected source and fall back to unprotected when keySystems is empty") {
-      val media =
-        mediaFixture {
-          withDash(MediaLibrary.Widevine)
-          withHls()
-        }
-      val response =
-        media.toPlayerResponse(
-          mimeTypes = listOf("application/dash+xml", "application/x-mpegURL"),
-          keySystems = emptyList(),
-        )
-      response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
-      response.drm shouldBe null
-    }
-
-    should("prefer the source whose DRM key system appears earlier in the priority list when mimeTypes are equal") {
-      val media =
-        mediaFixture {
-          withDash(MediaLibrary.FairPlay)
-          withDash(MediaLibrary.Widevine)
-        }
-      val response =
-        media.toPlayerResponse(
+          drm = emptyList(),
+          expectedSource = MediaLibrary.Hls.toPlayerMediaSourceV1(),
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "match mimeType case-insensitively",
+          media = mediaFixture { withHls() },
+          mimeTypes = listOf("APPLICATION/X-MPEGURL"),
+          drm = emptyList(),
+          expectedSource = MediaLibrary.Hls.toPlayerMediaSourceV1(),
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "never select a source whose mimeType is null",
+          media = mediaFixture { withSource(MediaLibrary.Dash.copy(mimeType = null)) },
           mimeTypes = listOf("application/dash+xml"),
-          keySystems = listOf("com.widevine.alpha", "com.apple.fps"),
-        )
-      response.drm shouldBe MediaLibrary.Widevine
-    }
-
-    should("return null source when all sources are protected and keySystems is empty") {
-      val media =
-        mediaFixture {
-          withDash(MediaLibrary.Widevine)
-          withHls(MediaLibrary.FairPlay)
-        }
-      val response =
-        media.toPlayerResponse(
+          drm = emptyList(),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "handle empty sources gracefully",
+          media = mediaFixture {}.copy(sources = emptyList()),
+          mimeTypes = listOf("application/dash+xml"),
+          drm = emptyList(),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        // DRM key system selection
+        SourceSelectionCase(
+          name = "select the correct DRM config based on keySystem",
+          media = mediaFixture { withDash(MediaLibrary.Widevine, MediaLibrary.FairPlay) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.apple.fps"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.FairPlay,
+        ),
+        SourceSelectionCase(
+          name = "return null for DRM if the requested keySystem doesn't exist",
+          media = mediaFixture { withMp4(MediaLibrary.Widevine) },
+          mimeTypes = listOf("video/mp4"),
+          drm = listOf("com.microsoft.playready"),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "prefer the keySystem that appears earlier in the priority list",
+          media = mediaFixture { withDash(MediaLibrary.FairPlay, MediaLibrary.Widevine) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha", "com.apple.fps"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.Widevine,
+        ),
+        SourceSelectionCase(
+          name = "strip non-matching DRM configs from the selected source",
+          media = mediaFixture { withDash(MediaLibrary.Widevine, MediaLibrary.FairPlay) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.Widevine,
+        ),
+        SourceSelectionCase(
+          name = "prefer a protected source over an unprotected one when a compatible keySystem is requested",
+          media =
+            mediaFixture {
+              withDash()
+              withHls(MediaLibrary.Widevine)
+            },
           mimeTypes = listOf("application/dash+xml", "application/x-mpegURL"),
-          keySystems = emptyList(),
-        )
-      response.source shouldBe null
-      response.drm shouldBe null
+          drm = listOf("com.widevine.alpha"),
+          expectedSource = MediaLibrary.Hls.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.Widevine,
+        ),
+        SourceSelectionCase(
+          name = "return an unprotected source when an incompatible keySystem is requested",
+          media =
+            mediaFixture {
+              withDash()
+              withHls(MediaLibrary.Widevine)
+            },
+          mimeTypes = listOf("application/x-mpegURL", "application/dash+xml"),
+          drm = listOf("com.microsoft.playready"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "exclude a protected source and fall back to unprotected when keySystems is empty",
+          media =
+            mediaFixture {
+              withDash(MediaLibrary.Widevine)
+              withHls()
+            },
+          mimeTypes = listOf("application/dash+xml", "application/x-mpegURL"),
+          drm = emptyList(),
+          expectedSource = MediaLibrary.Hls.toPlayerMediaSourceV1(),
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "prefer the source whose DRM key system appears earlier in the priority list when mimeTypes are equal",
+          media =
+            mediaFixture {
+              withDash(MediaLibrary.FairPlay)
+              withDash(MediaLibrary.Widevine)
+            },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha", "com.apple.fps"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.Widevine,
+        ),
+        SourceSelectionCase(
+          name = "return null source when all sources are protected and keySystems is empty",
+          media =
+            mediaFixture {
+              withDash(MediaLibrary.Widevine)
+              withHls(MediaLibrary.FairPlay)
+            },
+          mimeTypes = listOf("application/dash+xml", "application/x-mpegURL"),
+          drm = emptyList(),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        // Security level filtering (native levels)
+        SourceSelectionCase(
+          name = "include a DRM config with no security level regardless of the client security level",
+          media = mediaFixture { withDash(MediaLibrary.Widevine) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;L3"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.Widevine,
+        ),
+        SourceSelectionCase(
+          name = "include a DRM config whose security level matches the client exactly",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL3) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;L3"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL3,
+        ),
+        SourceSelectionCase(
+          name = "include a DRM config with a less restrictive security level than the client",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL3) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;L1"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL3,
+        ),
+        SourceSelectionCase(
+          name = "exclude a DRM config whose security level is more restrictive than the client supports",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL1) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;L3"),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "prefer a DRM config compatible with the client security level over an incompatible one",
+          media =
+            mediaFixture {
+              withDash(MediaLibrary.WidevineL1)
+              withHls(MediaLibrary.WidevineL3)
+            },
+          mimeTypes = listOf("application/dash+xml", "application/x-mpegURL"),
+          drm = listOf("com.widevine.alpha;L3"),
+          expectedSource = MediaLibrary.Hls.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL3,
+        ),
+        SourceSelectionCase(
+          name = "apply no security level constraint when security level parameter is null",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL1) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL1,
+        ),
+        SourceSelectionCase(
+          name = "exclude DRM config whose security level constraint is unknown for the key system",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL1) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;SL3000"),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        // Security level filtering (EME robustness levels)
+        SourceSelectionCase(
+          name = "resolve HW_SECURE_ALL to L1 for Widevine and match an L1-required source",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL1) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;HW_SECURE_ALL"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL1,
+        ),
+        SourceSelectionCase(
+          name = "resolve HW_SECURE_CRYPTO to L2 for Widevine and exclude an L1-required source",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL1) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;HW_SECURE_CRYPTO"),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "resolve SW_SECURE_CRYPTO to L3 for Widevine and match an L3-required source",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL3) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;SW_SECURE_CRYPTO"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL3,
+        ),
+        SourceSelectionCase(
+          name = "resolve SW_SECURE_DECODE to L3 for Widevine and exclude an L1-required source",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL1) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;SW_SECURE_DECODE"),
+          expectedSource = null,
+          expectedDrm = null,
+        ),
+        SourceSelectionCase(
+          name = "resolve HW_SECURE_DECODE to L2 for Widevine and match an L3-required source",
+          media = mediaFixture { withDash(MediaLibrary.WidevineL3) },
+          mimeTypes = listOf("application/dash+xml"),
+          drm = listOf("com.widevine.alpha;HW_SECURE_DECODE"),
+          expectedSource = MediaLibrary.Dash.toPlayerMediaSourceV1(),
+          expectedDrm = MediaLibrary.WidevineL3,
+        ),
+      ) { case ->
+        val selector = MediaSourceSelector(case.mimeTypes, case.drm.toDrmPreferences())
+        val response = case.media.toPlayerResponse(selector)
+
+        response.source shouldBe case.expectedSource
+        response.drm shouldBe case.expectedDrm
+      }
     }
 
     should("correctly map all metadata fields from domain to DTO") {
@@ -204,44 +315,11 @@ class PlayerMediaResponseV1Test :
             )
         }
 
-      val response = media.toPlayerResponse()
+      val response = media.toPlayerResponse(MediaSourceSelector(emptyList(), emptyList()))
 
       response.identifier shouldBe "media-id"
       response.title shouldBe "Title"
       response.description shouldBe "Description"
       response.episodeNumber shouldBe 1
-    }
-
-    should("handle empty sources or drm lists gracefully") {
-      val media = mediaFixture {}
-
-      val emptyMedia = media.copy(sources = emptyList())
-
-      val response = emptyMedia.toPlayerResponse(mimeTypes = listOf("application/dash+xml"))
-
-      response.source shouldBe null
-      response.drm shouldBe null
-    }
-
-    should("match mimeType case-insensitively") {
-      val media =
-        mediaFixture {
-          withHls()
-        }
-      val response =
-        media.toPlayerResponse(mimeTypes = listOf("APPLICATION/X-MPEGURL"))
-      response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
-    }
-
-    should("never select a source whose mimeType is null") {
-      val nullMimeTypeSource = MediaLibrary.Dash.copy(mimeType = null)
-      val media =
-        mediaFixture {
-          withSource(nullMimeTypeSource)
-        }
-
-      val response =
-        media.toPlayerResponse(mimeTypes = listOf("application/dash+xml"))
-      response.source shouldBe null
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
@@ -19,7 +19,13 @@ object MediaLibrary {
 
   // DRM Configs
   val Widevine = DrmConfig(keySystem = "com.widevine.alpha", licenseUrl = "https://wv.license.com")
+  val WidevineL1 =
+    DrmConfig(keySystem = "com.widevine.alpha", licenseUrl = "https://wv.license.com", securityLevel = "L1")
+  val WidevineL3 =
+    DrmConfig(keySystem = "com.widevine.alpha", licenseUrl = "https://wv.license.com", securityLevel = "L3")
   val PlayReady = DrmConfig(keySystem = "com.microsoft.playready", licenseUrl = "https://pr.license.com")
+  val PlayReadySL3000 =
+    DrmConfig(keySystem = "com.microsoft.playready", licenseUrl = "https://pr.license.com", securityLevel = "SL3000")
   val FairPlay = DrmConfig(keySystem = "com.apple.fps", licenseUrl = "https://fp.license.com")
   val ClearKey = DrmConfig(keySystem = "org.w3.clearkey", licenseUrl = "https://ck.license.com")
 


### PR DESCRIPTION
## Description

Resolves #22 by handling security level from drm configurations.

## Changes Made

- Add a `securityLevel` field to `DrmConfig`.
- Filter out DRM configs whose security level exceeds what the client supports.
- `X-Accept-DRM` header and query parameter can now optionally define a maximum security level as a suffix, with the format `<key_system>;<security_level>`.
- Expose the field in the DRM configuration form of the admin console.
- Security levels can be passed as EME robustness level, and the server will automatically map them to the corresponding security level for the key system.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
