### PR TITLE
feat: add copy action to media cards

### DIFF
--- a/src/main/resources/static/css/modules/home/home.page.css
+++ b/src/main/resources/static/css/modules/home/home.page.css
@@ -1,5 +1,6 @@
 @import url("../../layouts/dashboard.layout.css");
 @import url("../../shared/fragments/media-grid.fragment.css");
+@import url("../../shared/components/snackbar.component.css");
 
 form[method="dialog"] {
   display: grid;

--- a/src/main/resources/static/css/shared/components/snackbar.component.css
+++ b/src/main/resources/static/css/shared/components/snackbar.component.css
@@ -1,0 +1,10 @@
+#snackbar {
+  margin: 0;
+  padding: var(--size-2) var(--size-4);
+  background: var(--surface-2);
+  border: var(--border-size-1) solid var(--surface-3);
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-2);
+  inset: auto;
+  translate: -50% calc(-100% - var(--size-2));
+}

--- a/src/main/resources/static/js/components/snackbar.component.js
+++ b/src/main/resources/static/js/components/snackbar.component.js
@@ -1,0 +1,26 @@
+const snackbarComponent = document.getElementById("snackbar");
+let snackbarTimeout = null;
+
+/**
+ * Displays a transient snackbar message anchored above a given element.
+ *
+ * The snackbar is shown immediately and hidden automatically after 2 seconds.
+ * Calling this function while the snackbar is already visible resets the timer
+ * and repositions it above the new anchor.
+ *
+ * @param {string} message - The text to display in the snackbar.
+ * @param {Element} anchor - The element above which the snackbar is positioned.
+ */
+export function showSnackbar(message, anchor) {
+  const rect = anchor.getBoundingClientRect();
+
+  snackbarComponent.textContent = message;
+  snackbarComponent.style.left = `${rect.left + rect.width / 2}px`;
+  snackbarComponent.style.top = `${rect.top}px`;
+
+  clearTimeout(snackbarTimeout);
+  if (!snackbarComponent.matches(":popover-open")) {
+    snackbarComponent.showPopover();
+  }
+  snackbarTimeout = setTimeout(() => snackbarComponent.hidePopover(), 2000);
+}

--- a/src/main/resources/static/js/home.page.js
+++ b/src/main/resources/static/js/home.page.js
@@ -1,4 +1,23 @@
 import "htmx.org";
+import { showSnackbar } from "./components/snackbar.component.js";
+
+/**
+ * Copies the Player API URL of a media card to the clipboard when the copy
+ * button is clicked.
+ *
+ * @listens document#click
+ * @param {MouseEvent} e - The click event.
+ */
+document.addEventListener("click", function(e) {
+  const button = e.target.closest("[data-copy-url]");
+
+  if (!button) return;
+
+  navigator.clipboard.writeText(
+    window.location.origin + button.dataset.copyUrl
+  );
+  showSnackbar("Link Copied!", button);
+});
 
 /**
  * Listens for htmx confirm events and displays a native modal dialog

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -17,6 +17,7 @@
 {% endblock %}
 {% block footer %}
 {{ parent() }}
+{% include "../../shared/components/snackbar.component.peb" %}
 <template id="confirm-dialog-template">
   <dialog class="confirm-dialog">
     <form method="dialog">

--- a/src/main/resources/templates/shared/components/snackbar.component.peb
+++ b/src/main/resources/templates/shared/components/snackbar.component.peb
@@ -1,0 +1,1 @@
+<div id="snackbar" popover></div>

--- a/src/main/resources/templates/shared/macros/media-card.macros.peb
+++ b/src/main/resources/templates/shared/macros/media-card.macros.peb
@@ -15,7 +15,16 @@
 
   <header>
     <h3>{{ media.metadata.title | default('Untitled Asset') }}</h3>
-    <p>{{ media.id }}</p>
+    <p>
+      {% if not media.deleted %}
+      <button class="btn-icon"
+              data-copy-url="/v1/player/media/{{ media.id }}"
+              title="Copy Player API URL">
+        <span class="material-symbols-outlined">link</span>
+      </button>
+      {% endif %}
+      {{ media.id }}
+    </p>
     <ul class="tag-list">
             {% for tag in media.tags %}
         <li>{{ tag }}</li>


### PR DESCRIPTION
## Description

Resolves #13 by adding a copy button before the media id to copy the absolute  Player API URL to the clipboard on click. 

## Changes Made

- Added a new snackbar component to provide visual feedback.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
