### PR TITLE
ci(release): fix ecs service name in release and deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,6 @@ jobs:
         run: >
           aws ecs update-service \
             --cluster pillarbox-demo-backend-cluster \
-            --service data-transfer-service \
+            --service demo-backend-service \
             --force-new-deployment \
             --region ${{ secrets.AWS_REGION }} >/dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,6 @@ jobs:
         run: >
           aws ecs update-service \
             --cluster pillarbox-demo-backend-cluster \
-            --service data-transfer-service \
+            --service demo-backend-service \
             --force-new-deployment \
             --region ${{ secrets.AWS_REGION }} >/dev/null


### PR DESCRIPTION
## Description

The service name is `demo-backend-service` and not `data-transfer-service`.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
