### PR TITLE
feat(auth): introduce User entity with JWT-based profile sync and refresh token support

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -74,6 +74,7 @@ fun Application.module() {
       authConfig = this@module.get(),
       httpClient = this@module.get(),
       sessionManager = this@module.get(),
+      userRepository = this@module.get(),
       policy = this@module.get(),
     )
   }
@@ -85,7 +86,7 @@ fun Application.module() {
 
   // Setup HTTP Routing
   routing {
-    auth(get(), get())
+    auth(get(), get(), get())
     media(get())
     playerMedia(get())
     console(get())

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationExtensions.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationExtensions.kt
@@ -1,6 +1,7 @@
 package ch.srgssr.pillarbox.backend.auth
 
 import ch.srgssr.pillarbox.backend.entrypoint.web.Navigation
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import io.ktor.client.HttpClient
 import io.ktor.http.RequestConnectionPoint
 import io.ktor.server.application.Application
@@ -35,6 +36,7 @@ fun AuthenticationConfig.configureOidc(
   authConfig: AuthConfig,
   httpClient: HttpClient,
   sessionManager: SessionManager,
+  userRepository: UserRepository,
   policy: AuthenticationPolicy,
 ) {
   jwt("$name-jwt") {
@@ -50,7 +52,11 @@ fun AuthenticationConfig.configureOidc(
   }
 
   session<SessionId>("$name-session") {
-    validate { sessionManager.validate(it) }
+    validate {
+      sessionManager.validate(it)?.let { session ->
+        userRepository.find(session.oidcSub)
+      }
+    }
     challenge { call.respondRedirect(Navigation.LOGIN) }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationModule.kt
@@ -14,8 +14,9 @@ import org.koin.dsl.module
  * 1. The [AuthConfig] and [SessionConfig] extracted from the application configuration.
  * 2. The [OpenIDDiscovery] document, fetched synchronously from the identity provider's
  * discovery URL. Note: This involves a [runBlocking] network call upon first resolution.
- * 3. A [SessionManager] to handle user session lifecycles and token validation.
- * 4. An [AuthenticationPolicy] used to configure OAuth2 settings and verify JWT credentials.
+ * 3. A [UserInfoProvider] for fetching and synchronising user profiles from the OIDC provider.
+ * 4. A [SessionManager] to handle user session lifecycles and token validation.
+ * 5. An [AuthenticationPolicy] used to configure OAuth2 settings and verify JWT credentials.
  *
  * @return A Koin [Module] containing the authentication infrastructure definitions.
  */
@@ -33,11 +34,20 @@ fun authenticationModule() =
     }
 
     single {
+      TokenProvider(
+        httpClient = get(),
+        discovery = get(),
+        authConfig = get(),
+      )
+    }
+
+    single { UserManager(repository = get()) }
+
+    single {
       SessionManager(
         repository = get(),
-        httpClient = get(),
-        userInfoUrl = get<OpenIDDiscovery>().userInfoEndpoint,
-        validationIntervalSeconds = get<SessionConfig>().validationIntervalSeconds,
+        userManager = get(),
+        tokenProvider = get(),
       )
     }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManager.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManager.kt
@@ -1,123 +1,89 @@
 package ch.srgssr.pillarbox.backend.auth
 
 import ch.srgssr.pillarbox.backend.domain.model.Session
-import ch.srgssr.pillarbox.backend.log.debug
-import ch.srgssr.pillarbox.backend.log.error
 import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
-import ch.srgssr.pillarbox.backend.log.warn
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
-import io.ktor.client.HttpClient
-import io.ktor.client.request.bearerAuth
-import io.ktor.client.request.get
-import io.ktor.http.HttpStatusCode
-import kotlinx.io.IOException
+import com.auth0.jwt.JWT
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 /**
  * Manages the lifecycle of user sessions, providing validation logic optimized for performance with
  * periodic token verification.
  *
  * @property repository The persistent storage for session data.
- * @property httpClient The client used to perform back-channel validation against the OIDC provider.
- * @property userInfoUrl The OIDC endpoint used to verify if an access token is still active.
- * @property validationIntervalSeconds The frequency at which the access token must be re-verified
+ * @property tokenProvider Used to exchange an expired session's refresh token for new tokens.
  * against the identity provider.
  */
 class SessionManager(
   private val repository: SessionRepository,
-  private val httpClient: HttpClient,
-  private val userInfoUrl: String,
-  private val validationIntervalSeconds: Long,
+  private val userManager: UserManager,
+  private val tokenProvider: TokenProvider,
 ) {
   companion object {
     val logger = logger()
   }
 
-  /**
-   * Validates a session. If the session exists and has been checked recently (within [validationIntervalSeconds]),
-   * it is returned immediately. Otherwise, the associated access token is verified against the OIDC provider.
-   *
-   * @param sessionId The ID of the session to validate.
-   *
-   * @return The [Session] if valid; null if the session is expired, missing, or the token is revoked.
-   */
   suspend fun validate(sessionId: SessionId): Session? {
-    val session =
-      repository.find(sessionId.value) ?: run {
-        logger.info { "Session validation failed: Session ${sessionId.value} not found in repository." }
-        return null
+    val session = repository.find(sessionId.value)
+    return when {
+      session == null -> {
+        null.also { logger.info { "Session validation failed: Session ${sessionId.value} not found in repository." } }
       }
 
-    return if (session.expired) {
-      logger.warn { "Session $sessionId expired at ${session.expiresAt}" }
-      repository.delete(session.sessionId)
-      null
-    } else {
-      verifySession(session)
+      !session.expired -> {
+        session
+      }
+
+      else -> {
+        logger.info { "Session $sessionId expired at ${session.expiresAt}" }
+        refreshOrInvalidate(session)
+      }
     }
   }
 
   /**
-   * Verifies the integrity of a session by checking its local expiration and
-   * remote OIDC token validity.
+   * Attempts to renew an expired session using its stored refresh token.
+   * If no refresh token is present or the token endpoint rejects the request,
+   * the session is deleted and `null` is returned.
    *
-   * @param session The current session data retrieved from the repository.
-   * @return The valid (and potentially updated) [Session], or `null` if the session is invalid.
+   * @param session The expired session to renew.
+   * @return The refreshed [Session] with updated tokens and expiry, or `null` on failure.
    */
-  private suspend fun verifySession(session: Session): Session? {
-    if (session.valid) return session
-
-    logger.info { "Re-validating OIDC token for session: ${session.sessionId}" }
-
-    return if (session.isTokenValid()) {
-      session.copy(lastChecked = Clock.System.now()).also { updated ->
-        repository.save(session.sessionId, updated)
-        logger.info { "Session ${session.sessionId} successfully re-validated." }
+  private suspend fun refreshOrInvalidate(session: Session): Session? {
+    if (session.refreshToken == null) {
+      return null.also {
+        logger.info { "Session ${session.sessionId} has no refresh token. Deleting." }
+        repository.delete(session.sessionId)
       }
-    } else {
-      logger.warn { "Session ${session.sessionId} invalidated by OIDC provider." }
+    }
+
+    return tokenProvider.refresh(session.refreshToken)?.let { tokenResponse ->
+      session.refreshWithToken(tokenResponse).also {
+        userManager.upsert(JWT.decode(it.accessToken))
+        repository.save(it)
+        logger.info { "Session ${it.sessionId} successfully refreshed." }
+      }
+    } ?: run {
       repository.delete(session.sessionId)
       null
     }
   }
 
   /**
-   * Whether the session has not yet exceeded the [validationIntervalSeconds] threshold.
-   */
-  private val Session.valid: Boolean
-    get() {
-      val now = Clock.System.now()
-
-      val elapsed = now - lastChecked
-      val threshold = validationIntervalSeconds.seconds
-
-      return (elapsed < threshold).also { fresh ->
-        if (fresh) {
-          val remaining = threshold - elapsed
-          logger.debug {
-            "Session $sessionId is still valid. " +
-              "Elapsed: ${elapsed.inWholeSeconds}s, " +
-              "Next check in: ${remaining.inWholeSeconds}s"
-          }
-        }
-      }
-    }
-
-  /**
-   * Checks if the provided access token is still valid by calling the OIDC UserInfo endpoint.
-   *
-   * @return True if the provider returns 200 OK; false otherwise.
-   */
-  private suspend fun Session.isTokenValid(): Boolean =
-    try {
-      httpClient.get(userInfoUrl) { bearerAuth(accessToken) }.let {
-        logger.info { "Token validation check returned status: ${it.status}" }
-        it.status == HttpStatusCode.OK
-      }
-    } catch (e: IOException) {
-      logger.error(e) { "Failed to reach OIDC UserInfo endpoint at $userInfoUrl" }
-      false
-    }
+   * Creates an updated copy of the [Session] using the provided [tokenResponse].
+   **/
+  private fun Session.refreshWithToken(
+    tokenResponse: TokenRefreshResponse,
+    now: Instant = Clock.System.now(),
+  ): Session =
+    copy(
+      accessToken = tokenResponse.accessToken,
+      refreshToken = tokenResponse.refreshToken ?: refreshToken,
+      idToken = tokenResponse.idToken ?: idToken,
+      expiresAt = tokenResponse.expiresIn?.let { now + it.seconds } ?: (now + 5.minutes),
+    )
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/TokenProvider.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/TokenProvider.kt
@@ -1,0 +1,76 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.domain.model.User
+import ch.srgssr.pillarbox.backend.log.error
+import ch.srgssr.pillarbox.backend.log.info
+import ch.srgssr.pillarbox.backend.log.logger
+import com.auth0.jwt.interfaces.Payload
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.submitForm
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.parameters
+import kotlinx.io.IOException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Represents the token endpoint response from an OIDC provider.
+ *
+ * @property accessToken The new access token.
+ * @property refreshToken The new refresh token, if the provider rotates them.
+ * @property idToken The new ID token, if included in the response.
+ * @property expiresIn Validity period of [accessToken] in seconds.
+ */
+@Serializable
+data class TokenRefreshResponse(
+  @SerialName("access_token") val accessToken: String,
+  @SerialName("refresh_token") val refreshToken: String? = null,
+  @SerialName("id_token") val idToken: String? = null,
+  @SerialName("expires_in") val expiresIn: Long? = null,
+)
+
+/**
+ * Exchanges a refresh token for a new set of tokens via the OIDC token endpoint.
+ *
+ * @property httpClient The HTTP client used to call the token endpoint.
+ * @property discovery The OIDC discovery document, used to resolve [OpenIDDiscovery.tokenEndpoint].
+ * @property authConfig The application's OIDC credentials, used for client authentication.
+ */
+class TokenProvider(
+  private val httpClient: HttpClient,
+  private val discovery: OpenIDDiscovery,
+  private val authConfig: AuthConfig,
+) {
+  companion object {
+    val logger = logger()
+  }
+
+  /**
+   * Requests new tokens from the OIDC token endpoint using the provided [refreshToken].
+   *
+   * @param refreshToken The refresh token issued during the original authorization.
+   *
+   * @return A [TokenRefreshResponse] on success, or `null` if the provider rejects the token
+   *         or the endpoint is unreachable.
+   */
+  suspend fun refresh(refreshToken: String): TokenRefreshResponse? =
+    try {
+      val response =
+        httpClient.submitForm(
+          url = discovery.tokenEndpoint,
+          formParameters =
+            parameters {
+              append("grant_type", "refresh_token")
+              append("refresh_token", refreshToken)
+              append("client_id", authConfig.clientId)
+              append("client_secret", authConfig.clientSecret)
+            },
+        )
+      logger.info { "Token endpoint returned status: ${response.status}" }
+      if (response.status == HttpStatusCode.OK) response.body() else null
+    } catch (e: IOException) {
+      logger.error(e) { "Failed to reach OIDC token endpoint at ${discovery.tokenEndpoint}" }
+      null
+    }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/UserManager.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/UserManager.kt
@@ -1,0 +1,39 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.domain.model.User
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import com.auth0.jwt.interfaces.Payload
+
+/**
+ * Manages user persistence based on OIDC authentication data.
+ *
+ * @param repository The repository used to store and retrieve [User] entities.
+ */
+class UserManager(
+  private val repository: UserRepository,
+) {
+  /**
+   * Inserts or updates a [User] from the given JWT [payload].
+   *
+   * The user's [OIDC subject][Payload.getSubject] is used as the unique identifier,
+   * and the [display name][Payload.displayName] is stored alongside it.
+   *
+   * @param payload The decoded JWT payload from the authenticated request.
+   */
+  suspend fun upsert(payload: Payload) {
+    repository.save(
+      User(
+        oidcSub = payload.subject,
+        displayName = payload.displayName,
+      ),
+    )
+  }
+
+  /**
+   * Extracts the preferred username from the JWT [Payload].
+   * Usually contains the human-readable login name or display handle.
+   */
+  private val Payload.displayName: String
+    get() =
+      getClaim("name")?.asString() ?: subject
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/ExposedRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/ExposedRepository.kt
@@ -166,14 +166,9 @@ abstract class ExposedRepository<T, ID>(
   /**
    * Persists or overwrites a resource using an upsert operation.
    *
-   * @param idValue The unique identifier to associate with this entity.
-   *
    * @param item The entity to save.
    */
-  open suspend fun save(
-    idValue: ID,
-    item: T,
-  ): Unit =
+  open suspend fun save(item: T): Unit =
     query {
       table.upsert(onUpdate = encodeOnUpdate(item)) {
         encode(it, item)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Session.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Session.kt
@@ -3,6 +3,7 @@ package ch.srgssr.pillarbox.backend.domain.model
 import kotlinx.serialization.Serializable
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -12,10 +13,9 @@ import kotlin.uuid.Uuid
  *
  * @property sessionId A unique identifier for the session. Defaults to a random UUID string.
  * @property accessToken The access token used for bearer authentication against downstream services.
- * @property lastChecked The [Instant] representing the last time this session was successfully
- *                       validated against the identity provider. Defaults to the current system time.
  * @property expiresAt The [Instant] representing the absolute hard expiration of the session.
- *                     Defaults to 24 hours after [lastChecked].
+ * @property oidcSub The OIDC sub that identifies the [ch.srgssr.pillarbox.backend.domain.model.User] associated
+ *                   with this session.
  */
 @Serializable
 @OptIn(ExperimentalUuidApi::class)
@@ -24,8 +24,8 @@ data class Session(
   val accessToken: String,
   val refreshToken: String? = null,
   val idToken: String? = null,
-  val lastChecked: Instant = Clock.System.now(),
-  val expiresAt: Instant = lastChecked + 24.hours,
+  val expiresAt: Instant = Clock.System.now() + 5.minutes,
+  val oidcSub: String,
 ) {
   /**
    * Returns `true` if the current system time has surpassed the [expiresAt] threshold.

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/User.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/User.kt
@@ -1,0 +1,37 @@
+package ch.srgssr.pillarbox.backend.domain.model
+
+import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * Represents an authenticated user of the Pillarbox backend.
+ *
+ * A new instance is typically created at first login and updated on subsequent logins.
+ *
+ * @property oidcSub The `sub` (subject) claim from the OpenID Connect identity provider.
+ * @property displayName Human-readable name shown in the UI (e.g. "Jane Doe").
+ * @property createdAt Timestamp of the initial creation of this user record.
+ * @property updatedAt Timestamp of the last modification to this user record.
+ */
+@Serializable
+@OptIn(ExperimentalUuidApi::class)
+data class User(
+  val oidcSub: String,
+  val displayName: String,
+  val createdAt: Instant = Clock.System.now(),
+  val updatedAt: Instant = Clock.System.now(),
+) {
+  /**
+   * Up to two uppercase initials derived from the words in [displayName].
+   * For example, "Jane Doe" → "JD", "Alice" → "A".
+   */
+  val initials: String
+    get() =
+      displayName
+        .split(" ")
+        .take(2)
+        .mapNotNull { it.firstOrNull()?.uppercaseChar() }
+        .joinToString("")
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/AuthRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/AuthRoute.kt
@@ -2,9 +2,11 @@ package ch.srgssr.pillarbox.backend.entrypoint.web
 
 import ch.srgssr.pillarbox.backend.auth.OpenIDDiscovery
 import ch.srgssr.pillarbox.backend.auth.SessionId
+import ch.srgssr.pillarbox.backend.auth.UserManager
 import ch.srgssr.pillarbox.backend.auth.buildCallbackUrl
 import ch.srgssr.pillarbox.backend.domain.model.Session
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
+import com.auth0.jwt.JWT
 import io.ktor.server.auth.OAuthAccessTokenResponse
 import io.ktor.server.auth.authenticate
 import io.ktor.server.auth.authentication
@@ -25,8 +27,9 @@ import kotlin.time.Duration.Companion.seconds
  *
  * 1. Intercepts the authorization code from the identity provider.
  * 2. Retrieves the [OAuthAccessTokenResponse.OAuth2] principal.
- * 3. Decodes the access token to extract the user identity and roles.
- * 4. Maps the OAuth token to a new internal [Session].
+ * 3. Calls the OIDC UserInfo endpoint via [userInfoProvider] to fetch the user's profile
+ *    and upsert the local user record, marking the login timestamp.
+ * 4. Maps the OAuth token to a new internal [Session] linked to the local user.
  * 5. Persists the session and issues a [SessionId] cookie to the client.
  *
  * **Logout** – Clears the server-side session and cookie, then redirects to
@@ -37,16 +40,21 @@ import kotlin.time.Duration.Companion.seconds
  */
 fun Route.auth(
   sessionRepository: SessionRepository,
+  userManager: UserManager,
   discovery: OpenIDDiscovery,
 ) {
   authenticate("pillarbox-oauth") {
     get(Navigation.LOGIN) { }
     get(Navigation.CALLBACK) {
       val session =
-        call.authentication.principal<OAuthAccessTokenResponse.OAuth2>()?.toSession()
-          ?: return@get call.respondRedirect(Navigation.LOGIN)
+        call.authentication.principal<OAuthAccessTokenResponse.OAuth2>()?.let {
+          val payload = JWT.decode(it.accessToken)
+          userManager.upsert(payload)
+          it.toSession(payload.subject)
+        } ?: return@get call.respondRedirect(Navigation.LOGIN)
 
-      sessionRepository.save(session.sessionId, session)
+      sessionRepository.save(session)
+
       call.sessions.set(SessionId(session.sessionId))
       call.respondRedirect(Navigation.CONSOLE)
     }
@@ -69,10 +77,11 @@ fun Route.auth(
   }
 }
 
-private fun OAuthAccessTokenResponse.OAuth2.toSession() =
+private fun OAuthAccessTokenResponse.OAuth2.toSession(subject: String) =
   Session(
     accessToken = accessToken,
     refreshToken = refreshToken,
     idToken = extraParameters["id_token"],
     expiresAt = expiresIn.let { Clock.System.now() + it.seconds },
+    oidcSub = subject,
   )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
@@ -1,14 +1,19 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web
 
 import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.Session
+import ch.srgssr.pillarbox.backend.domain.model.User
 import ch.srgssr.pillarbox.backend.log.debug
 import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.log.trace
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
+import io.ktor.server.auth.principal
 import io.ktor.server.htmx.hx
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.pebble.PebbleContent
@@ -33,13 +38,19 @@ private val logger = ConsoleRoute.logger()
 @OptIn(ExperimentalKtorApi::class)
 @SuppressWarnings("LongMethod", "CyclomaticComplexMethod")
 fun Route.console(mediaRepository: MediaRepository) {
+  val buildContext: suspend ApplicationCall.() -> Map<String, Any> = {
+    principal<User>()
+      ?.let { mapOf("user" to mapOf("name" to it.displayName, "initials" to it.initials)) }
+      .orEmpty()
+  }
+
   authenticate("pillarbox-session") {
     staticResources("/static", "static")
 
     route(Navigation.CONSOLE) {
       get {
         call.respond(
-          PebbleContent("modules/home/home.page.peb", emptyMap()),
+          PebbleContent("modules/home/home.page.peb", call.buildContext()),
         )
       }
 
@@ -47,9 +58,10 @@ fun Route.console(mediaRepository: MediaRepository) {
         call.respond(
           PebbleContent(
             "modules/home/home.page.peb",
-            mapOf(
-              "deleted" to true,
-            ),
+            buildMap {
+              putAll(call.buildContext())
+              putAll(mapOf("deleted" to true))
+            },
           ),
         )
       }
@@ -84,7 +96,7 @@ fun Route.console(mediaRepository: MediaRepository) {
       hx.post("media") {
         val media = call.receive<Media>()
 
-        mediaRepository.save(media.id, media)
+        mediaRepository.save(media)
 
         call.response.headers.append("HX-Redirect", "/console")
         call.respond(HttpStatusCode.OK)
@@ -95,11 +107,13 @@ fun Route.console(mediaRepository: MediaRepository) {
           call.parameters["id"]
             ?.let { mediaRepository.find(it) }
             ?.also { logger.debug { "Opening editor for media: $it" } }
-
         call.respond(
           PebbleContent(
             "modules/media/editor.page.peb",
-            media?.let { mapOf("item" to media) } ?: emptyMap(),
+            buildMap {
+              putAll(call.buildContext())
+              putAll(media?.let { mapOf("item" to media) }.orEmpty())
+            },
           ),
         )
       }
@@ -116,7 +130,10 @@ fun Route.console(mediaRepository: MediaRepository) {
         call.respond(
           PebbleContent(
             "modules/media/editor.page.peb",
-            mapOf("item" to media.copy(id = "")),
+            buildMap {
+              putAll(call.buildContext())
+              putAll(mapOf("item" to media.copy(id = "")))
+            },
           ),
         )
       }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
@@ -66,7 +66,7 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
     val dto = call.receive<Req>()
     val media = toDomain(dto)
 
-    mediaRepository.save(media.id, media)
+    mediaRepository.save(media)
     call.respond(HttpStatusCode.Created, toResponse(media))
   }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
@@ -4,6 +4,8 @@ import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
 import ch.srgssr.pillarbox.backend.persistence.session.SessionTable
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserTable
 import org.jetbrains.exposed.v1.core.Table
 import org.koin.dsl.module
 
@@ -12,12 +14,15 @@ import org.koin.dsl.module
  * instances of repositories throughout the Pillarbox backend.
  *
  * @see MediaRepository
+ * @see SessionRepository
+ * @see UserRepository
  */
 fun persistenceModule() =
   module {
     single<List<Table>> {
-      listOf(MediaTable, SessionTable)
+      listOf(MediaTable, SessionTable, UserTable)
     }
     single { MediaRepository(get()) }
     single { SessionRepository(get()) }
+    single { UserRepository(get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
@@ -42,7 +42,7 @@ class MediaRepository(
     )
 
   /**
-   * Encodes a [Media] domain object into an [UpdateBuilder] for inserts or upserts.
+   * Encodes a [Media] domain object into an [UpdateBuilder] for inserts.
    */
   override fun Table.encode(
     builder: UpdateBuilder<*>,
@@ -57,7 +57,10 @@ class MediaRepository(
     builder[MediaTable.lastModified] = Clock.System.now().toUtcOffsetDateTime()
   }
 
-  override fun encodeOnUpdate(item: Media): (UpsertBuilder.(UpdateStatement) -> Unit)? =
+  /**
+   * Encodes a [Media] domain object into an [UpdateBuilder] for updates.
+   */
+  override fun encodeOnUpdate(item: Media): (UpsertBuilder.(UpdateStatement) -> Unit) =
     {
       it[MediaTable.tags] = item.tags
       it[MediaTable.sources] = item.sources

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionRepository.kt
@@ -12,8 +12,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 /**
  * Repository responsible for the persistence and retrieval of [Session] entities using Exposed.
  *
- * This implementation maps the [Session] domain model to the [SessionTable] schema and
- * provides specialized methods for media-specific data manipulations.
+ * This implementation maps the [Session] domain model to the [SessionTable] schema.
  *
  * @param db The [Database] instance used for all transactions.
  */
@@ -29,8 +28,8 @@ class SessionRepository(
       accessToken = this[SessionTable.accessToken],
       refreshToken = this[SessionTable.refreshToken],
       idToken = this[SessionTable.idToken],
-      lastChecked = this[SessionTable.lastChecked].toKotlinInstant(),
       expiresAt = this[SessionTable.expiresAt].toKotlinInstant(),
+      oidcSub = this[SessionTable.oidcSub],
     )
 
   /**
@@ -44,7 +43,7 @@ class SessionRepository(
     builder[SessionTable.accessToken] = item.accessToken
     builder[SessionTable.refreshToken] = item.refreshToken
     builder[SessionTable.idToken] = item.idToken
-    builder[SessionTable.lastChecked] = item.lastChecked.toUtcOffsetDateTime()
     builder[SessionTable.expiresAt] = item.expiresAt.toUtcOffsetDateTime()
+    builder[SessionTable.oidcSub] = item.oidcSub
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionTable.kt
@@ -1,20 +1,48 @@
 package ch.srgssr.pillarbox.backend.persistence.session
 
+import ch.srgssr.pillarbox.backend.persistence.session.SessionTable.sessionId
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
 
+/**
+ * Exposed table definition for persisting authenticated user sessions.
+ *
+ * This table stores OAuth2/OIDC session tokens and their associated lifecycle timestamps.
+ */
 object SessionTable : Table("pb_session") {
+  /**
+   * Unique identifier for the session.
+   */
   val sessionId = varchar("session_id", 255)
 
+  /**
+   * The access token used for bearer authentication against downstream services.
+   */
   val accessToken = text("access_token")
 
+  /**
+   * The refresh token used to obtain a new access token, or `null` if not provided.
+   */
   val refreshToken = text("refresh_token").nullable()
 
+  /**
+   * The ID token issued by the identity provider, or `null` if not provided.
+   */
   val idToken = text("id_token").nullable()
 
-  val lastChecked = timestampWithTimeZone("last_checked")
-
+  /**
+   * The time when this session expires absolutely.
+   */
   val expiresAt = timestampWithTimeZone("expires_at")
 
+  /**
+   * The OIDC sub that identifies the [ch.srgssr.pillarbox.backend.domain.model.User] associated
+   * with this session.
+   */
+  val oidcSub = varchar("oidc_sub", 255)
+
+  /**
+   * Primary key definition using the [sessionId] column.
+   */
   override val primaryKey = PrimaryKey(sessionId)
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserRepository.kt
@@ -1,0 +1,57 @@
+package ch.srgssr.pillarbox.backend.persistence.user
+
+import ch.srgssr.pillarbox.backend.db.ExposedRepository
+import ch.srgssr.pillarbox.backend.domain.model.User
+import ch.srgssr.pillarbox.backend.time.toKotlinInstant
+import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.core.statements.UpdateStatement
+import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import kotlin.time.Clock
+
+/**
+ * Repository responsible for the persistence and retrieval of [User] entities using Exposed.
+ *
+ * This implementation maps the [User] domain model to the [UserTable] schema.
+ *
+ * @param db The [Database] instance used for all transactions.
+ */
+class UserRepository(
+  db: Database,
+) : ExposedRepository<User, String>(db = db, table = UserTable, idColumn = UserTable.oidcSub) {
+  /**
+   * Decodes a [ResultRow] from the [UserTable] into a [User] domain object.
+   */
+  override fun ResultRow.decode() =
+    User(
+      oidcSub = this[UserTable.oidcSub],
+      displayName = this[UserTable.displayName],
+      createdAt = this[UserTable.createdAt].toKotlinInstant(),
+      updatedAt = this[UserTable.updatedAt].toKotlinInstant(),
+    )
+
+  /**
+   * Encodes a [User] domain object into an [UpdateBuilder] for inserts.
+   */
+  override fun Table.encode(
+    builder: UpdateBuilder<*>,
+    item: User,
+  ) {
+    builder[UserTable.oidcSub] = item.oidcSub
+    builder[UserTable.displayName] = item.displayName
+    builder[UserTable.createdAt] = Clock.System.now().toUtcOffsetDateTime()
+    builder[UserTable.updatedAt] = Clock.System.now().toUtcOffsetDateTime()
+  }
+
+  /**
+   * Encodes a [User] domain object into an [UpdateBuilder] for updates.
+   */
+  override fun encodeOnUpdate(item: User): (UpsertBuilder.(UpdateStatement) -> Unit) =
+    {
+      it[UserTable.displayName] = item.displayName
+      it[UserTable.updatedAt] = Clock.System.now().toUtcOffsetDateTime()
+    }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserTable.kt
@@ -1,0 +1,36 @@
+package ch.srgssr.pillarbox.backend.persistence.user
+
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+
+/**
+ * Exposed table definition for persisting user accounts.
+ *
+ * This table stores identity information for users authenticated via OIDC.
+ */
+object UserTable : Table("pb_user") {
+  /**
+   * The OIDC subject claim (`sub`) that uniquely identifies the user at the identity provider.
+   */
+  val oidcSub = varchar("oidc_sub", 255)
+
+  /**
+   * Human-readable name for the user, derived from their OIDC profile.
+   */
+  val displayName = varchar("display_name", 255)
+
+  /**
+   * The time when the user record was last updated.
+   */
+  val updatedAt = timestampWithTimeZone("updated_at")
+
+  /**
+   * The time when the user record was created.
+   */
+  val createdAt = timestampWithTimeZone("created_at")
+
+  /**
+   * Primary key definition using the [id] column.
+   */
+  override val primaryKey = PrimaryKey(oidcSub)
+}

--- a/src/main/resources/db/migration/V3__Add_SessionData.sql
+++ b/src/main/resources/db/migration/V3__Add_SessionData.sql
@@ -1,4 +1,13 @@
 DELETE FROM pb_session;
 
+CREATE TABLE IF NOT EXISTS pb_user (
+  oidc_sub     VARCHAR(255) NOT NULL PRIMARY KEY,
+  display_name VARCHAR(255) NOT NULL,
+  updated_at   TIMESTAMPTZ  NOT NULL,
+  created_at   TIMESTAMPTZ  NOT NULL
+  );
+
+ALTER TABLE pb_session DROP COLUMN last_checked;
 ALTER TABLE pb_session ADD COLUMN refresh_token TEXT;
 ALTER TABLE pb_session ADD COLUMN id_token TEXT;
+ALTER TABLE pb_session ADD COLUMN oidc_sub VARCHAR(255) REFERENCES pb_user(oidc_sub);

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManangerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManangerTest.kt
@@ -2,17 +2,14 @@ package ch.srgssr.pillarbox.backend.auth
 
 import ch.srgssr.pillarbox.backend.domain.model.Session
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
+import ch.srgssr.pillarbox.backend.test.buildJwt
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.headersOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -25,20 +22,20 @@ import kotlin.uuid.Uuid
 
 class SessionManagerTest :
   ShouldSpec({
-    should("return session from cache and SKIP network call if fresh") {
+    should("return session directly if not expired") {
       val builder = SessionManagerBuilder()
-      val session = SessionBuilder().lastCheckedInsideInterval(builder.interval).build()
+      val session = SessionBuilder().build()
 
       coEvery { builder.repository.find(session.sessionId) } returns session
 
       val result = builder.build().validate(SessionId(session.sessionId))
 
       result.shouldNotBeNull() shouldBeEqual session
-      builder.engine.requestHistory.size shouldBe 0
-      coVerify(exactly = 0) { builder.repository.save(any(), any()) }
+      coVerify(exactly = 0) { builder.userManager.upsert(any()) }
+      coVerify(exactly = 0) { builder.repository.save(any()) }
     }
 
-    should("return null immediately and skip network if session is not found in repository") {
+    should("return null immediately if session is not found in repository") {
       val builder = SessionManagerBuilder()
       val sessionId = "unknown-id"
 
@@ -47,115 +44,103 @@ class SessionManagerTest :
       val result = builder.build().validate(SessionId(sessionId))
 
       result.shouldBeNull()
-      builder.engine.requestHistory.size shouldBe 0
-      coVerify(exactly = 0) { builder.repository.save(any(), any()) }
+      coVerify(exactly = 0) { builder.userManager.upsert(any()) }
+      coVerify(exactly = 0) { builder.repository.save(any()) }
     }
 
-    should("perform network validation and update cache if session is stale") {
-      val builder = SessionManagerBuilder().withStatus(HttpStatusCode.OK)
-      val session = SessionBuilder().lastCheckedOutsideInterval(builder.interval).build()
+    should("delete session and return null when expired without a refresh token") {
+      val builder = SessionManagerBuilder()
+      val session = SessionBuilder().expired().build()
+
+      coEvery { builder.repository.find(session.sessionId) } returns session
+
+      val result = builder.build().validate(SessionId(session.sessionId))
+
+      result.shouldBeNull()
+      coVerify(exactly = 0) { builder.userManager.upsert(any()) }
+      coVerify { builder.repository.delete(session.sessionId) }
+    }
+
+    should("refresh and return updated session when expired with a valid refresh token") {
+      val refreshResponse =
+        TokenRefreshResponse(
+          accessToken = buildJwt(subject = "test-sub", name = "Test User"),
+          refreshToken = "new-refresh-token",
+          expiresIn = 3600L,
+        )
+      val builder = SessionManagerBuilder().withSuccessfulRefresh(refreshResponse)
+      val session = SessionBuilder().expired().withRefreshToken().build()
 
       coEvery { builder.repository.find(session.sessionId) } returns session
 
       val result = builder.build().validate(SessionId(session.sessionId))
 
       result.shouldNotBeNull()
-      (result.lastChecked > session.lastChecked) shouldBe true
-      builder.engine.requestHistory.size shouldBe 1
-      coVerify { builder.repository.save(session.sessionId, any()) }
+      result.accessToken shouldBe refreshResponse.accessToken
+      result.refreshToken shouldBe refreshResponse.refreshToken
+      (result.expiresAt > session.expiresAt) shouldBe true
+      coVerify { builder.tokenProvider.refresh(session.refreshToken!!) }
+      coVerify { builder.repository.save(match { it.sessionId == session.sessionId }) }
     }
 
-    should("delete session and return null if the OIDC provider revokes the token") {
-      val builder = SessionManagerBuilder().withStatus(HttpStatusCode.Unauthorized)
-      val session = SessionBuilder().lastCheckedOutsideInterval(builder.interval).build()
+    should("delete session and return null when expired and token refresh fails") {
+      val builder = SessionManagerBuilder().withFailedRefresh()
+      val session = SessionBuilder().expired().withRefreshToken().build()
 
       coEvery { builder.repository.find(session.sessionId) } returns session
 
       val result = builder.build().validate(SessionId(session.sessionId))
 
       result.shouldBeNull()
-      builder.engine.requestHistory.size shouldBe 1
-      coVerify { builder.repository.delete(session.sessionId) }
-    }
-
-    should("invalidate when session has expired even if it is inside validation interval") {
-      val builder = SessionManagerBuilder()
-      val session = SessionBuilder().lastCheckedInsideInterval(builder.interval).expired().build()
-
-      coEvery { builder.repository.find(session.sessionId) } returns session
-
-      val result = builder.build().validate(SessionId(session.sessionId))
-
-      result.shouldBeNull()
-      builder.engine.requestHistory.size shouldBe 0
-      coVerify { builder.repository.delete(session.sessionId) }
-    }
-
-    should("invalidate when session has expired and is outside validation interval") {
-      val builder = SessionManagerBuilder()
-      val session = SessionBuilder().lastCheckedOutsideInterval(builder.interval).expired().build()
-
-      coEvery { builder.repository.find(session.sessionId) } returns session
-
-      val result = builder.build().validate(SessionId(session.sessionId))
-
-      result.shouldBeNull()
-      builder.engine.requestHistory.size shouldBe 0
+      coVerify(exactly = 0) { builder.userManager.upsert(any()) }
+      coVerify { builder.tokenProvider.refresh(session.refreshToken!!) }
       coVerify { builder.repository.delete(session.sessionId) }
     }
   })
 
 class SessionManagerBuilder {
   var repository = mockk<SessionRepository>(relaxed = true)
-  var userInfoUrl = "https://auth.example.com/userinfo"
-  var interval = 60L
+  var userManager = mockk<UserManager>(relaxed = true)
+  var tokenProvider = mockk<TokenProvider>(relaxed = true)
 
-  // Captured state to verify external calls
-  private var statusCode = HttpStatusCode.OK
-  val engine =
-    MockEngine {
-      respond("", statusCode, headersOf(HttpHeaders.ContentType, "application/json"))
+  fun withSuccessfulRefresh(response: TokenRefreshResponse) =
+    apply {
+      coEvery { tokenProvider.refresh(any()) } returns response
     }
 
-  fun withStatus(status: HttpStatusCode) = apply { this.statusCode = status }
+  fun withFailedRefresh() =
+    apply {
+      coEvery { tokenProvider.refresh(any()) } returns null
+    }
 
   fun build() =
     SessionManager(
       repository = repository,
-      httpClient = HttpClient(engine),
-      userInfoUrl = userInfoUrl,
-      validationIntervalSeconds = interval,
+      userManager = userManager,
+      tokenProvider = tokenProvider,
     )
 }
 
 @OptIn(ExperimentalUuidApi::class)
 class SessionBuilder {
-  private var lastChecked: Instant = Clock.System.now()
-  private var expiresAt: Instant = lastChecked + 24.hours
-
-  fun lastCheckedOutsideInterval(intervalSeconds: Long) =
-    apply {
-      require(intervalSeconds > 0) { "Interval must be > 0, but was $intervalSeconds" }
-      this.lastChecked = Clock.System.now() - (intervalSeconds + 10).seconds
-    }
-
-  fun lastCheckedInsideInterval(intervalSeconds: Long) =
-    apply {
-      require(intervalSeconds > 5) {
-        "Interval must be > 5 seconds to calculate a 'fresh' timestamp, but was $intervalSeconds"
-      }
-      this.lastChecked = Clock.System.now() - (intervalSeconds - 5).seconds
-    }
+  private var expiresAt: Instant = Clock.System.now() + 24.hours
+  private var refreshToken: String? = null
 
   fun expired() =
     apply {
       this.expiresAt = Clock.System.now() - 1.seconds
     }
 
+  fun withRefreshToken() =
+    apply {
+      this.refreshToken = "stub-refresh-token"
+    }
+
   fun build() =
     Session(
       accessToken = Uuid.random().toString(),
-      lastChecked = lastChecked,
+      refreshToken = refreshToken,
       expiresAt = expiresAt,
+      oidcSub = "test-sub",
     )
 }

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/TokenProviderTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/TokenProviderTest.kt
@@ -1,0 +1,70 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.test.mockOAuth2Server
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldNotBeBlank
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
+
+class TokenProviderTest :
+  ShouldSpec({
+    lateinit var mockServer: MockOAuth2Server
+    lateinit var tokenProvider: TokenProvider
+
+    beforeTest {
+      mockServer = mockOAuth2Server().also { it.start() }
+
+      val httpClient =
+        HttpClient(CIO) {
+          install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+      tokenProvider =
+        TokenProvider(
+          httpClient = httpClient,
+          discovery = httpClient.get(mockServer.wellKnownUrl("pillarbox-realm").toString()).body(),
+          authConfig =
+            AuthConfig(
+              issuer = mockServer.issuerUrl("pillarbox-realm").toString(),
+              clientId = "test-client",
+              clientSecret = "test-secret",
+              realm = "pillarbox-realm",
+            ),
+        )
+    }
+
+    afterTest {
+      mockServer.shutdown()
+    }
+
+    should("return token response on successful refresh") {
+      mockServer.enqueueCallback(DefaultOAuth2TokenCallback(issuerId = "pillarbox-realm", subject = "test-user"))
+
+      val result = tokenProvider.refresh("valid-refresh-token")
+
+      result.shouldNotBeNull()
+      result.accessToken.shouldNotBeBlank()
+    }
+
+    should("return null when the provider rejects the refresh token") {
+      val result = tokenProvider.refresh("expired-refresh-token")
+      result.shouldBeNull()
+    }
+
+    should("return null when the token endpoint is unreachable") {
+      mockServer.shutdown()
+
+      val result = tokenProvider.refresh("valid-refresh-token")
+
+      result.shouldBeNull()
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/UserManagerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/UserManagerTest.kt
@@ -1,0 +1,29 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import ch.srgssr.pillarbox.backend.test.buildJwt
+import com.auth0.jwt.JWT
+import io.kotest.core.spec.style.ShouldSpec
+import io.mockk.coVerify
+import io.mockk.mockk
+
+class UserManagerTest :
+  ShouldSpec({
+    should("save user with name claim as display name") {
+      val repository = mockk<UserRepository>(relaxed = true)
+      val payload = JWT.decode(buildJwt(subject = "test-sub", name = "Test User"))
+
+      UserManager(repository).upsert(payload)
+
+      coVerify { repository.save(match { it.oidcSub == "test-sub" && it.displayName == "Test User" }) }
+    }
+
+    should("fall back to subject as display name when name claim is absent") {
+      val repository = mockk<UserRepository>(relaxed = true)
+      val payload = JWT.decode(buildJwt(subject = "test-sub"))
+
+      UserManager(repository).upsert(payload)
+
+      coVerify { repository.save(match { it.oidcSub == "test-sub" && it.displayName == "test-sub" }) }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MockOAuthUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MockOAuthUtils.kt
@@ -1,0 +1,40 @@
+package ch.srgssr.pillarbox.backend.test
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.nimbusds.oauth2.sdk.TokenRequest
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.mock.oauth2.OAuth2Config
+import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
+
+fun buildJwt(
+  subject: String,
+  name: String? = null,
+): String =
+  JWT
+    .create()
+    .withSubject(subject)
+    .let { if (name != null) it.withClaim("name", name) else it }
+    .sign(Algorithm.none())
+
+fun mockOAuth2Server(issuerId: String = "pillarbox-realm"): MockOAuth2Server =
+  MockOAuth2Server(
+    OAuth2Config(
+      tokenCallbacks =
+        setOf(
+          object : OAuth2TokenCallback {
+            override fun issuerId() = issuerId
+
+            override fun tokenExpiry() = 3600L
+
+            override fun subject(tokenRequest: TokenRequest) = error("No callback enqueued")
+
+            override fun audience(tokenRequest: TokenRequest) = error("No callback enqueued")
+
+            override fun addClaims(tokenRequest: TokenRequest) = error("No callback enqueued")
+
+            override fun typeHeader(tokenRequest: TokenRequest) = error("No callback enqueued")
+          },
+        ),
+    ),
+  )

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -39,28 +39,7 @@ fun testApplicationContext(
   enableProxyHeaders: Boolean = false,
   block: suspend ApplicationTestBuilder.() -> Unit,
 ) {
-  val oAuthServer =
-    MockOAuth2Server(
-      OAuth2Config(
-        tokenCallbacks =
-          setOf(
-            object : OAuth2TokenCallback {
-              override fun issuerId() = "pillarbox-realm"
-
-              override fun tokenExpiry() = 3600L
-
-              override fun subject(tokenRequest: TokenRequest) = error("No callback enqueued")
-
-              override fun audience(tokenRequest: TokenRequest) = error("No callback enqueued")
-
-              override fun addClaims(tokenRequest: TokenRequest) = error("No callback enqueued")
-
-              override fun typeHeader(tokenRequest: TokenRequest) = error("No callback enqueued")
-            },
-          ),
-      ),
-    )
-  oAuthServer.start()
+  val oAuthServer = mockOAuth2Server().also { it.start() }
 
   testApplication {
     configure("application.conf") {


### PR DESCRIPTION
## Description

Establishes User as a domain entity, enabling future role-based access control (#26) and team-based media ownership (#25).

User profiles are synced from the JWT access token claims directly, removing the call to the OIDC userinfo endpoint. This keeps profile data consistent with what is already present in the token.

A token refresh now also triggers a user upsert, so the stored profile stays current over the session lifetime.

On the session side, expired sessions are transparently renewed via the OIDC token endpoint instead of forcing the user back through the login flow.

## Changes Made

- Add `User` domain model, `pb_user` table, `UserRepository`, and `UserTable`.
- Add `UserManager` to upsert a user from a decoded JWT payload.
- Link sessions to their owning user via `oidcSub`; session validation now resolves to a `User` principal.
- Add `TokenProvider` to exchange a refresh token for new tokens at the OIDC token endpoint using client credentials.
- Update `SessionManager` to attempt a token refresh before invalidating an expired session, and to upsert the user on each successful refresh.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
