### PR TITLE
feat(auth): enforce role-based access control on all management endpoints

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,7 +1,6 @@
 # Development & API Usage Guide
 
 This document provides a comprehensive guide on how to interact with the Pillarbox Backend.
-
 Once the application is running, you can interact with it via the web console or the REST API.
 
 ## Web Console
@@ -10,7 +9,6 @@ The Web Console provides a visual interface for managing media assets. It is bui
 and **Pebble templates**, allowing for dynamic updates without full page reloads.
 
 * **URL**: [http://localhost:8080/console](http://localhost:8080/console)
-* **Username / Password**: `dev/password`
 
 ### Console Routes
 
@@ -36,18 +34,31 @@ The REST API is divided into two primary functional areas:
 
 ### Management API (Protected)
 
-To access protected endpoints, you must first authenticate with the Keycloak server
-(running on port `8081` by default).
+Protected endpoints require authentication via the Keycloak server (running on port `8081` by
+default) and are gated by role-based access control. A request without a valid token receives
+`401 Unauthorized`; a valid token that lacks the required role receives `403 Forbidden`.
+
+#### Test Users
+
+The development Keycloak realm is seeded with three users (all passwords are `password`):
+
+| Username   | Roles                        | Access                          |
+|------------|------------------------------|---------------------------------|
+| `reader`   | `Read`                       | Read-only                       |
+| `editor`   | `Read`, `Write`              | Read + create/modify content    |
+| `admin`    | `Read`, `Write`, `Admin`     | Unrestricted                    |
+
+#### Obtaining a Token
 
 ```bash
 TOKEN=$(curl -s -X POST "http://localhost:8081/realms/pillarbox/protocol/openid-connect/token" \
-  -d "username=dev" \
+  -d "username=editor" \
   -d "password=password" \
   -d "grant_type=password" \
   -d "client_id=pillarbox-api" | jq -r '.access_token')
 ```
 
-Use the `$TOKEN` to authorize POST requests to the management API.
+Use the `$TOKEN` to authorize requests to the management API.
 
 ```bash
 curl -v --request POST \
@@ -69,14 +80,11 @@ definitions in [MediaRoute.kt][media-route-kt].
 | **DELETE** | `/v1/media/{id}`         | Remove a media entity from the repository.              |
 | **POST**   | `/v1/media/{id}/restore` | Restores a deleted media entity from the repository.    |
 
-
 ### Player API (Public)
 
 The playback endpoints do not require a token and are open to all clients.
-
 Unlike the management API, these endpoints are **publicly accessible** (no Bearer token required).
 They support content negotiation via query parameters or custom headers.
-
 You can find all the definitions in [PlayerMediaRoute.kt][player-media-route-kt].
 
 | Method  | Endpoint                | Description                                |

--- a/keycloak/pillarbox-realm.json
+++ b/keycloak/pillarbox-realm.json
@@ -1,10 +1,15 @@
 {
   "realm": "pillarbox",
   "enabled": true,
+  "defaultRole": {
+    "name": "PillarboxDemo.Read",
+    "description": "Default role assigned to all new users"
+  },
   "roles": {
     "realm": [
-      { "name": "user" },
-      { "name": "admin" }
+      { "name": "PillarboxDemo.Read", "description": "Read-only access" },
+      { "name": "PillarboxDemo.Write", "description": "Can create and modify content" },
+      { "name": "PillarboxDemo.Admin", "description": "Unrestricted access" }
     ]
   },
   "clients": [
@@ -27,26 +32,59 @@
             "id.token.claim": "false",
             "access.token.claim": "true"
           }
+        },
+        {
+          "name": "realm-roles-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "config": {
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
         }
       ]
     }
   ],
   "users": [
     {
-      "username": "dev",
+      "username": "reader",
       "enabled": true,
-      "email": "dev@example.com",
-      "firstName": "Dev",
+      "email": "reader@example.com",
+      "firstName": "Reader",
       "lastName": "User",
       "emailVerified": true,
       "credentials": [
-        {
-          "type": "password",
-          "value": "password",
-          "temporary": false
-        }
+        { "type": "password", "value": "password", "temporary": false }
       ],
-      "realmRoles": ["user"]
+      "realmRoles": ["PillarboxDemo.Read"]
+    },
+    {
+      "username": "editor",
+      "enabled": true,
+      "email": "editor@example.com",
+      "firstName": "Editor",
+      "lastName": "User",
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "password", "temporary": false }
+      ],
+      "realmRoles": ["PillarboxDemo.Read", "PillarboxDemo.Write"]
+    },
+    {
+      "username": "admin",
+      "enabled": true,
+      "email": "admin@example.com",
+      "firstName": "Admin",
+      "lastName": "User",
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "password", "temporary": false }
+      ],
+      "realmRoles": ["PillarboxDemo.Read", "PillarboxDemo.Write", "PillarboxDemo.Admin"]
     }
   ]
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
@@ -1,5 +1,6 @@
 package ch.srgssr.pillarbox.backend.auth
 
+import ch.srgssr.pillarbox.backend.domain.model.User
 import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.log.warn
 import com.auth0.jwk.JwkProvider
@@ -57,19 +58,22 @@ class AuthenticationPolicy(
    *
    * @param credential The credential extracted from the JWT token.
    *
-   * @return A [JWTPrincipal] if validation passes; null if the audience is invalid.
+   * @return A [User] if validation passes; null if the audience is invalid.
    */
-  fun verifyJwt(credential: JWTCredential): JWTPrincipal? {
-    val audience = credential.payload.audience
-    return if (audience.contains(clientId)) {
-      JWTPrincipal(credential.payload)
-    } else {
+  fun verifyJwt(credential: JWTCredential): User? {
+    if (!credential.payload.audience.contains(clientId)) {
       logger.warn {
         "JWT verification failed: Audience mismatch. " +
-          "Expected: $clientId, Found: $audience. " +
+          "Expected: $clientId, Found: ${credential.payload.audience}. " +
           "Subject: ${credential.payload.subject}"
       }
-      null
+      return null
     }
+
+    return User(
+      oidcSub = credential.payload.subject,
+      displayName = credential.payload.displayName,
+      roles = credential.payload.roles,
+    )
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/Authorization.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/Authorization.kt
@@ -1,0 +1,115 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.domain.model.User
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.auth.AuthenticationChecked
+import io.ktor.server.auth.principal
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.RouteSelector
+import io.ktor.server.routing.RouteSelectorEvaluation
+import io.ktor.server.routing.RoutingResolveContext
+import io.ktor.util.AttributeKey
+
+private val UserKey = AttributeKey<User>("AuthenticatedUser")
+
+/**
+ * Route-scoped plugin that runs after authentication and stores the [User] principal
+ * in the call attributes for convenient access via [ApplicationCall.user].
+ *
+ * If no principal is present, responds with [HttpStatusCode.Unauthorized] and halts the pipeline.
+ *
+ * Must be installed inside an `authenticate` block.
+ */
+val AuthenticatedUserPlugin =
+  createRouteScopedPlugin("AuthenticatedUser") {
+    on(AuthenticationChecked) { call ->
+      val user = call.principal<User>()
+      if (user == null) {
+        call.respond(HttpStatusCode.Unauthorized)
+      } else {
+        call.attributes.put(UserKey, user)
+      }
+    }
+  }
+
+/**
+ * Retrieves the authenticated [User] from the call attributes.
+ *
+ * Requires [AuthenticatedUserPlugin] to be installed on the route.
+ *
+ * @throws IllegalStateException if the attribute has not been set.
+ */
+val ApplicationCall.user: User
+  get() = attributes[UserKey]
+
+/**
+ * Route-scoped plugin that enforces role-based access control.
+ *
+ * Runs after authentication and responds with [HttpStatusCode.Forbidden]
+ * if the principal does not hold any of the roles specified in [RoleAuthConfig].
+ *
+ * Typically installed via the [withRole] DSL helper rather than directly.
+ */
+val RoleAuthorizationPlugin =
+  createRouteScopedPlugin(
+    name = "RoleAuthorization",
+    createConfiguration = { RoleAuthConfig() },
+  ) {
+    on(AuthenticationChecked) { call ->
+      if (call.principal<User>()?.hasAnyRole(pluginConfig.roles) != true) {
+        call.respond(HttpStatusCode.Forbidden)
+      }
+    }
+  }
+
+/**
+ * Configuration for [RoleAuthorizationPlugin].
+ *
+ * @property roles The set of accepted roles. Access is granted if the user holds at least one.
+ */
+class RoleAuthConfig {
+  var roles: Set<Role> = emptySet()
+}
+
+/**
+ * Restricts the enclosed route subtree to users holding at least one of the given [roles].
+ *
+ * Installs [RoleAuthorizationPlugin] on a child route scope, so each call site gets its own
+ * independent role requirement.
+ *
+ * ```kotlin
+ * authenticate("session") {
+ *     install(AuthenticatedUserPlugin)
+ *     withRole(Role.ADMIN, Role.MODERATOR) {
+ *         get("/reports") { /* accessible to either role */ }
+ *     }
+ * }
+ * ```
+ *
+ * @param roles One or more roles, any of which grants access.
+ * @param build The route subtree to protect.
+ */
+fun Route.withRole(
+  vararg roles: Role,
+  build: Route.() -> Unit,
+) {
+  require(roles.isNotEmpty()) { "roles must not be empty" }
+
+  val route =
+    createChild(
+      object : RouteSelector() {
+        override suspend fun evaluate(
+          context: RoutingResolveContext,
+          segmentIndex: Int,
+        ) = RouteSelectorEvaluation.Transparent
+      },
+    )
+  route.install(RoleAuthorizationPlugin) {
+    this.roles = roles.toSet()
+  }
+  route.build()
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensions.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensions.kt
@@ -1,0 +1,28 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.domain.model.Role.Companion.toRole
+import com.auth0.jwt.interfaces.Payload
+
+/**
+ * Extracts the preferred username from the JWT [Payload].
+ * Usually contains the human-readable login name or display handle.
+ */
+val Payload.displayName: String
+  get() =
+    getClaim("name")?.asString() ?: subject
+
+/**
+ * Extracts Pillarbox [Role]s from a JWT [Payload] by reading the `realm_access.roles` claim.
+ *
+ * @return an empty set when the claim is absent or contains no recognisable role names.
+ */
+@Suppress("UNCHECKED_CAST")
+val Payload.roles: Set<Role>
+  get() =
+    (
+      getClaim("realm_access")
+        ?.asMap()
+        ?.get("roles") as? List<String>
+    )?.mapNotNull { it.toRole() }
+      ?.toSet() ?: emptySet()

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/UserManager.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/UserManager.kt
@@ -25,15 +25,8 @@ class UserManager(
       User(
         oidcSub = payload.subject,
         displayName = payload.displayName,
+        roles = payload.roles,
       ),
     )
   }
-
-  /**
-   * Extracts the preferred username from the JWT [Payload].
-   * Usually contains the human-readable login name or display handle.
-   */
-  private val Payload.displayName: String
-    get() =
-      getClaim("name")?.asString() ?: subject
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Session.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Session.kt
@@ -2,7 +2,6 @@ package ch.srgssr.pillarbox.backend.domain.model
 
 import kotlinx.serialization.Serializable
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/User.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/User.kt
@@ -12,6 +12,7 @@ import kotlin.uuid.ExperimentalUuidApi
  *
  * @property oidcSub The `sub` (subject) claim from the OpenID Connect identity provider.
  * @property displayName Human-readable name shown in the UI (e.g. "Jane Doe").
+ * @property roles The list of roles of this user.
  * @property createdAt Timestamp of the initial creation of this user record.
  * @property updatedAt Timestamp of the last modification to this user record.
  */
@@ -20,6 +21,7 @@ import kotlin.uuid.ExperimentalUuidApi
 data class User(
   val oidcSub: String,
   val displayName: String,
+  val roles: Set<Role> = emptySet(),
   val createdAt: Instant = Clock.System.now(),
   val updatedAt: Instant = Clock.System.now(),
 ) {
@@ -34,4 +36,44 @@ data class User(
         .take(2)
         .mapNotNull { it.firstOrNull()?.uppercaseChar() }
         .joinToString("")
+
+  fun hasAnyRole(required: Set<Role>): Boolean = roles.any { it in required }
+}
+
+/**
+ * Defines the access roles for the Pillarbox Demo backend.
+ *
+ * Each entry maps to an app role using the `PillarboxDemo.{Level}` naming convention
+ * (e.g., `PillarboxDemo.Read`).
+ */
+enum class Role {
+  /** Read-only access. */
+  READ,
+
+  /** Read and write access. */
+  WRITE,
+
+  /** Full administrative access. */
+  ADMIN,
+
+  ;
+
+  /** The app role key, following the `PillarboxDemo.{Level}` convention. */
+  val key = "PillarboxDemo.${name.lowercase().replaceFirstChar { it.uppercase() }}"
+
+  companion object {
+    /**
+     * Finds a [Role] entry matching the given app role [key].
+     *
+     * @param key The app role key (e.g., `PillarboxDemo.Read`).
+     *
+     * @return The matching [Role], or `null` if no match is found.
+     */
+    fun find(key: String) = entries.find { it.key == key }
+
+    /**
+     * Parses this string into a [Role], or returns `null` if unrecognised.
+     */
+    fun String.toRole(): Role? = find(this)
+  }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
@@ -1,22 +1,23 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web
 
+import ch.srgssr.pillarbox.backend.auth.AuthenticatedUserPlugin
+import ch.srgssr.pillarbox.backend.auth.user
+import ch.srgssr.pillarbox.backend.auth.withRole
 import ch.srgssr.pillarbox.backend.domain.model.Media
-import ch.srgssr.pillarbox.backend.domain.model.Session
-import ch.srgssr.pillarbox.backend.domain.model.User
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.log.debug
 import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.log.trace
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
-import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.withCharset
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.auth.authenticate
-import io.ktor.server.auth.principal
 import io.ktor.server.htmx.hx
 import io.ktor.server.http.content.staticResources
-import io.ktor.server.pebble.PebbleContent
 import io.ktor.server.pebble.respondTemplate
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -27,6 +28,7 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.utils.io.ExperimentalKtorApi
 import org.jetbrains.exposed.v1.core.eq
+import java.util.Locale
 
 private object ConsoleRoute
 
@@ -38,146 +40,154 @@ private val logger = ConsoleRoute.logger()
 @OptIn(ExperimentalKtorApi::class)
 @SuppressWarnings("LongMethod", "CyclomaticComplexMethod")
 fun Route.console(mediaRepository: MediaRepository) {
-  val buildContext: suspend ApplicationCall.() -> Map<String, Any> = {
-    principal<User>()
-      ?.let { mapOf("user" to mapOf("name" to it.displayName, "initials" to it.initials)) }
-      .orEmpty()
-  }
-
   authenticate("pillarbox-session") {
-    staticResources("/static", "static")
+    install(AuthenticatedUserPlugin)
+
+    withRole(Role.READ) {
+      staticResources("/static", "static")
+    }
 
     route(Navigation.CONSOLE) {
-      get {
-        call.respond(
-          PebbleContent("modules/home/home.page.peb", call.buildContext()),
-        )
-      }
+      withRole(Role.READ) {
+        get {
+          call.respondWithContext("modules/home/home.page.peb")
+        }
 
-      get("bin") {
-        call.respond(
-          PebbleContent(
+        get("bin") {
+          call.respondWithContext(
             "modules/home/home.page.peb",
-            buildMap {
-              putAll(call.buildContext())
-              putAll(mapOf("deleted" to true))
-            },
-          ),
-        )
-      }
-
-      hx.get("media") {
-        val page = call.parameters["page"]?.toIntOrNull() ?: 0
-        val pageSize = call.parameters["pageSize"]?.toIntOrNull() ?: 15
-        val deleted = call.parameters["deleted"] == "true"
-        val offset = (page * pageSize).toLong()
-
-        logger.debug { "Fetching media grid: page=$page, pageSize=$pageSize, offset=$offset" }
-
-        val result =
-          mediaRepository.getAllPaginated(
-            limit = pageSize,
-            offset = offset,
-            filter = { MediaTable.deleted eq deleted },
+            mapOf("deleted" to true),
           )
+        }
 
-        call.respond(
-          PebbleContent(
+        hx.get("media") {
+          val page = call.parameters["page"]?.toIntOrNull() ?: 0
+          val pageSize = call.parameters["pageSize"]?.toIntOrNull() ?: 15
+          val deleted = call.parameters["deleted"] == "true"
+          val offset = (page * pageSize).toLong()
+
+          logger.debug { "Fetching media grid: page=$page, pageSize=$pageSize, offset=$offset" }
+
+          val result =
+            mediaRepository.getAllPaginated(
+              limit = pageSize,
+              offset = offset,
+              filter = { MediaTable.deleted eq deleted },
+            )
+
+          call.respondWithContext(
             "shared/fragments/media-grid.fragment.peb",
             mapOf(
               "result" to result,
               "nextPage" to page + 1,
               "deleted" to deleted,
             ),
-          ),
-        )
-      }
+          )
+        }
 
-      hx.post("media") {
-        val media = call.receive<Media>()
+        get("media/editor/{id?}") {
+          val media =
+            call.parameters["id"]
+              ?.let { mediaRepository.find(it) }
+              ?.also { logger.debug { "Opening editor for media: $it" } }
 
-        mediaRepository.save(media)
-
-        call.response.headers.append("HX-Redirect", "/console")
-        call.respond(HttpStatusCode.OK)
-      }
-
-      get("media/editor/{id?}") {
-        val media =
-          call.parameters["id"]
-            ?.let { mediaRepository.find(it) }
-            ?.also { logger.debug { "Opening editor for media: $it" } }
-        call.respond(
-          PebbleContent(
+          call.respondWithContext(
             "modules/media/editor.page.peb",
-            buildMap {
-              putAll(call.buildContext())
-              putAll(media?.let { mapOf("item" to media) }.orEmpty())
-            },
-          ),
-        )
+            media?.let { mapOf("item" to media) }.orEmpty(),
+          )
+        }
       }
 
-      get("media/editor/{id}/duplicate") {
-        val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.NotFound)
+      withRole(Role.WRITE) {
+        hx.post("media") {
+          val media = call.receive<Media>()
 
-        val media =
+          mediaRepository.save(media)
+
+          call.response.headers.append("HX-Redirect", "/console")
+          call.respond(HttpStatusCode.OK)
+        }
+
+        get("media/editor/{id}/duplicate") {
+          val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.NotFound)
+
+          val media =
+            mediaRepository
+              .find(id)
+              ?.also { logger.debug { "Opening editor with duplicate data from original ID: $id" } }
+              ?: return@get call.respond(HttpStatusCode.NotFound)
+
+          call.respondWithContext(
+            "modules/media/editor.page.peb",
+            mapOf("item" to media.copy(id = "")),
+          )
+        }
+
+        hx.get("/media/editor/fragments/{fragment}") {
+          val fragment =
+            EditorFragment.find(call.parameters["fragment"])
+              ?: return@get call.respond(HttpStatusCode.NotFound)
+          val index = call.request.queryParameters["index"]?.toInt() ?: 0
+
+          logger.trace { "Rendering fragment: ${fragment.name} at index $index" }
+
+          call.respondWithContext(
+            fragment.template,
+            mapOf("index" to index),
+          )
+        }
+
+        hx.delete("media/{id}") {
+          val id = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.NotFound)
+
+          logger.info { "Attempting to delete media with ID: $id" }
+
           mediaRepository
-            .find(id)
-            ?.also { logger.debug { "Opening editor with duplicate data from original ID: $id" } }
-            ?: return@get call.respond(HttpStatusCode.NotFound)
+            .softDelete(id)
+            .takeIf { it }
+            ?.let { call.respond(HttpStatusCode.OK) }
+            ?: call.respond(HttpStatusCode.NotFound)
+        }
 
-        call.respond(
-          PebbleContent(
-            "modules/media/editor.page.peb",
-            buildMap {
-              putAll(call.buildContext())
-              putAll(mapOf("item" to media.copy(id = "")))
-            },
-          ),
-        )
-      }
+        hx.post("media/{id}/restore") {
+          val id = call.parameters["id"] ?: return@post call.respond(HttpStatusCode.NotFound)
 
-      hx.get("/media/editor/fragments/{fragment}") {
-        val fragment =
-          EditorFragment.find(call.parameters["fragment"])
-            ?: return@get call.respond(HttpStatusCode.NotFound)
-        val index = call.request.queryParameters["index"]?.toInt() ?: 0
+          logger.info { "Attempting to restore media with ID: $id" }
 
-        logger.trace { "Rendering fragment: ${fragment.name} at index $index" }
-
-        call.respondTemplate(
-          fragment.template,
-          mapOf("index" to index),
-        )
-      }
-
-      hx.delete("media/{id}") {
-        val id = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.NotFound)
-
-        logger.info { "Attempting to delete media with ID: $id" }
-
-        mediaRepository
-          .softDelete(id)
-          .takeIf { it }
-          ?.let { call.respond(HttpStatusCode.OK) }
-          ?: call.respond(HttpStatusCode.NotFound)
-      }
-
-      hx.post("media/{id}/restore") {
-        val id = call.parameters["id"] ?: return@post call.respond(HttpStatusCode.NotFound)
-
-        logger.info { "Attempting to restore media with ID: $id" }
-
-        mediaRepository
-          .restore(id)
-          .takeIf { it }
-          ?.let { call.respond(HttpStatusCode.OK) }
-          ?: call.respond(HttpStatusCode.NotFound)
+          mediaRepository
+            .restore(id)
+            .takeIf { it }
+            ?.let { call.respond(HttpStatusCode.OK) }
+            ?: call.respond(HttpStatusCode.NotFound)
+        }
       }
     }
   }
 }
+
+data class UserView(
+  val name: String,
+  val initials: String,
+  val roles: List<String>,
+)
+
+fun ApplicationCall.userContext(): Map<String, Any> =
+  mapOf(
+    "user" to
+      UserView(
+        name = user.displayName,
+        initials = user.initials,
+        roles = user.roles.map { it.name },
+      ),
+  )
+
+suspend fun ApplicationCall.respondWithContext(
+  template: String,
+  model: Map<String, Any> = emptyMap(),
+  locale: Locale? = null,
+  etag: String? = null,
+  contentType: ContentType = ContentType.Text.Html.withCharset(Charsets.UTF_8),
+) = respondTemplate(template, userContext() + model, locale, etag, contentType)
 
 /**
  * Represents the various dynamic UI components (fragments) that can be

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
@@ -1,6 +1,8 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web
 
+import ch.srgssr.pillarbox.backend.auth.withRole
 import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
@@ -43,61 +45,64 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
   crossinline toResponse: (Media) -> Res,
   crossinline applyTags: (TagReq, List<String>) -> List<String>,
 ) {
-  get {
-    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 20
-    val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
-    val mediaFlow = mediaRepository.getAll(limit, offset, filter = { MediaTable.deleted eq false })
+  withRole(Role.READ) {
+    get {
+      val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 20
+      val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
+      val mediaFlow = mediaRepository.getAll(limit, offset, filter = { MediaTable.deleted eq false })
 
-    call.respond(mediaFlow.map { toResponse(it) }.toList())
+      call.respond(mediaFlow.map { toResponse(it) }.toList())
+    }
+
+    get("/{id}") {
+      val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+
+      val media =
+        mediaRepository.findOne {
+          (MediaTable.id eq id) and (MediaTable.deleted eq false)
+        } ?: return@get call.respond(HttpStatusCode.NotFound)
+
+      call.respond(toResponse(media))
+    }
   }
+  withRole(Role.WRITE) {
+    post {
+      val dto = call.receive<Req>()
+      val media = toDomain(dto)
 
-  get("/{id}") {
-    val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+      mediaRepository.save(media)
+      call.respond(HttpStatusCode.Created, toResponse(media))
+    }
 
-    val media =
-      mediaRepository.findOne {
-        (MediaTable.id eq id) and (MediaTable.deleted eq false)
-      } ?: return@get call.respond(HttpStatusCode.NotFound)
+    patch("/{id}/tags") {
+      val id = call.parameters["id"] ?: return@patch call.respond(HttpStatusCode.BadRequest)
+      val request = call.receive<TagReq>()
 
-    call.respond(toResponse(media))
-  }
+      mediaRepository
+        .updateTags(id) { applyTags(request, it) }
+        ?.let { call.respond(HttpStatusCode.OK, it) }
+        ?: call.respond(HttpStatusCode.NotFound)
+    }
 
-  post {
-    val dto = call.receive<Req>()
-    val media = toDomain(dto)
+    delete("/{id}") {
+      val id = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
 
-    mediaRepository.save(media)
-    call.respond(HttpStatusCode.Created, toResponse(media))
-  }
+      mediaRepository
+        .softDelete(id)
+        .takeIf { it }
+        ?.let { call.respond(HttpStatusCode.NoContent) }
+        ?: call.respond(HttpStatusCode.NotFound)
+    }
 
-  patch("/{id}/tags") {
-    val id = call.parameters["id"] ?: return@patch call.respond(HttpStatusCode.BadRequest)
-    val request = call.receive<TagReq>()
+    post("/{id}/restore") {
+      val id = call.parameters["id"] ?: return@post call.respond(HttpStatusCode.BadRequest)
 
-    mediaRepository
-      .updateTags(id) { applyTags(request, it) }
-      ?.let { call.respond(HttpStatusCode.OK, it) }
-      ?: call.respond(HttpStatusCode.NotFound)
-  }
-
-  delete("/{id}") {
-    val id = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
-
-    mediaRepository
-      .softDelete(id)
-      .takeIf { it }
-      ?.let { call.respond(HttpStatusCode.NoContent) }
-      ?: call.respond(HttpStatusCode.NotFound)
-  }
-
-  post("/{id}/restore") {
-    val id = call.parameters["id"] ?: return@post call.respond(HttpStatusCode.BadRequest)
-
-    mediaRepository
-      .restore(id)
-      .takeIf { it }
-      ?.let { call.respond(HttpStatusCode.Created) }
-      ?: call.respond(HttpStatusCode.NotFound)
+      mediaRepository
+        .restore(id)
+        .takeIf { it }
+        ?.let { call.respond(HttpStatusCode.Created) }
+        ?: call.respond(HttpStatusCode.NotFound)
+    }
   }
 }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserRepository.kt
@@ -1,6 +1,7 @@
 package ch.srgssr.pillarbox.backend.persistence.user
 
 import ch.srgssr.pillarbox.backend.db.ExposedRepository
+import ch.srgssr.pillarbox.backend.domain.model.Role.Companion.toRole
 import ch.srgssr.pillarbox.backend.domain.model.User
 import ch.srgssr.pillarbox.backend.time.toKotlinInstant
 import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
@@ -29,6 +30,7 @@ class UserRepository(
     User(
       oidcSub = this[UserTable.oidcSub],
       displayName = this[UserTable.displayName],
+      roles = this[UserTable.roles].mapNotNull { it.toRole() }.toSet(),
       createdAt = this[UserTable.createdAt].toKotlinInstant(),
       updatedAt = this[UserTable.updatedAt].toKotlinInstant(),
     )
@@ -42,6 +44,7 @@ class UserRepository(
   ) {
     builder[UserTable.oidcSub] = item.oidcSub
     builder[UserTable.displayName] = item.displayName
+    builder[UserTable.roles] = item.roles.map { it.key }
     builder[UserTable.createdAt] = Clock.System.now().toUtcOffsetDateTime()
     builder[UserTable.updatedAt] = Clock.System.now().toUtcOffsetDateTime()
   }
@@ -52,6 +55,7 @@ class UserRepository(
   override fun encodeOnUpdate(item: User): (UpsertBuilder.(UpdateStatement) -> Unit) =
     {
       it[UserTable.displayName] = item.displayName
+      it[UserTable.roles] = item.roles.map { role -> role.key }
       it[UserTable.updatedAt] = Clock.System.now().toUtcOffsetDateTime()
     }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/user/UserTable.kt
@@ -20,6 +20,11 @@ object UserTable : Table("pb_user") {
   val displayName = varchar("display_name", 255)
 
   /**
+   * A list of roles associated with the user.
+   */
+  val roles = array<String>("roles")
+
+  /**
    * The time when the user record was last updated.
    */
   val updatedAt = timestampWithTimeZone("updated_at")

--- a/src/main/resources/db/migration/V4__Add_Roles.sql
+++ b/src/main/resources/db/migration/V4__Add_Roles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pb_user ADD COLUMN roles TEXT[] NOT NULL DEFAULT '{}';

--- a/src/main/resources/static/css/shared/components/sidebar.component.css
+++ b/src/main/resources/static/css/shared/components/sidebar.component.css
@@ -88,8 +88,12 @@ aside.sidebar footer .user-info {
 }
 
 aside.sidebar footer .user-name {
+  overflow: hidden;
+
   font-size: var(--font-size-1);
   font-weight: var(--font-weight-6);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 body.sidebar-collapsed {

--- a/src/main/resources/templates/shared/components/sidebar.component.peb
+++ b/src/main/resources/templates/shared/components/sidebar.component.peb
@@ -1,3 +1,5 @@
+{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.UserView" #}
+
 <aside class="sidebar" data-purpose="navigation-sidebar" id="sidebar">
   <header>
     <img src="/static/img/srgssr-logo.png" alt="SRG SSR Logo">
@@ -5,9 +7,11 @@
   </header>
 
   <nav>
+    {% if user.roles contains "WRITE" %}
     <a href="/console/media/editor">
       <span class="material-symbols-outlined">add</span> Create Media
     </a>
+    {% endif %}
     <a href="/console">
         <span class="material-symbols-outlined">folder</span> Media Library
     </a>

--- a/src/main/resources/templates/shared/fragments/media-grid.fragment.peb
+++ b/src/main/resources/templates/shared/fragments/media-grid.fragment.peb
@@ -3,8 +3,9 @@
 {# @pebvariable name="deleted" type="java.lang.Boolean" #}
 {# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Media>" #}
 {# @pebvariable name="nextPage" type="java.lang.Integer" #}
+{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.UserView" #}
 
 {% set hasMore = (nextPage * result.limit) < result.totalCount %}
 {% set nextUrl = hasMore ? "/console/media?page=" + nextPage + "&pageSize=" + result.limit + "&deleted=" + deleted : null %}
 
-{{ mediaList(result, nextUrl) }}
+{{ mediaList(result, nextUrl, not (user.roles contains "WRITE")) }}

--- a/src/main/resources/templates/shared/macros/media-card.macros.peb
+++ b/src/main/resources/templates/shared/macros/media-card.macros.peb
@@ -1,6 +1,7 @@
-{% macro mediaCard(media, nextUrl = null) %}
+{% macro mediaCard(media, nextUrl = null, readOnly = false) %}
 {# @pebvariable name="nextUrl" type="java.lang.String" #}
 {# @pebvariable name="media" type="ch.srgssr.pillarbox.backend.domain.model.Media" #}
+{# @pebvariable name="readOnly" type="java.lang.Boolean" #}
 <article class="media-card" id="media-card-{{ media.id }}"
     {% if nextUrl is not empty %}
          hx-get="{{ nextUrl }}"
@@ -33,6 +34,7 @@
   </header>
 
 
+  {% if not readOnly %}
   <footer class="actions">
     <a class="btn btn-icon" href="/console/media/editor/{{ media.id }}" title="Edit {{ media.metadata.title }}">
       <span class="material-symbols-outlined">edit</span>
@@ -62,15 +64,17 @@
       </button>
     {% endif %}
   </footer>
+  {% endif %}
 </article>
 {% endmacro %}
 
-{% macro mediaList(result, nextUrl = null) %}
-{# @pebvariable name="nextUrl" type="java.lang.String" #}
+{% macro mediaList(result, nextUrl = null, readOnly = false) %}
 {# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Media>" #}
+{# @pebvariable name="nextUrl" type="java.lang.String" #}
+{# @pebvariable name="readOnly" type="java.lang.Boolean" #}
 <section class="media-list">
 {%- for item in result.items -%}
-  {{ mediaCard(item, loop.last ? nextUrl : null) }}
+  {{ mediaCard(item, loop.last ? nextUrl : null, readOnly) }}
 {%- endfor -%}
 </section>
 {% endmacro %}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensionsTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensionsTest.kt
@@ -1,0 +1,31 @@
+package ch.srgssr.pillarbox.backend.auth
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.test.buildJwt
+import ch.srgssr.pillarbox.backend.test.buildJwtWithRoleList
+import com.auth0.jwt.JWT
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+class PayloadExtensionsTest :
+  ShouldSpec({
+    should("parse READ and WRITE roles from realm_access claim") {
+      val payload = JWT.decode(buildJwt(subject = "sub", roles = setOf(Role.READ, Role.WRITE)))
+
+      payload.roles shouldBe setOf(Role.READ, Role.WRITE)
+    }
+
+    should("produce empty role set when realm_access claim is absent") {
+      val payload = JWT.decode(buildJwt(subject = "sub"))
+
+      payload.roles.shouldBeEmpty()
+    }
+
+    should("ignore unrecognised role strings") {
+      val payload = JWT.decode(buildJwtWithRoleList(subject = "sub", roles = listOf("root")))
+
+      payload.roles shouldHaveSize 0
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/UserManagerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/UserManagerTest.kt
@@ -1,5 +1,6 @@
 package ch.srgssr.pillarbox.backend.auth
 
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import ch.srgssr.pillarbox.backend.test.buildJwt
 import com.auth0.jwt.JWT
@@ -25,5 +26,23 @@ class UserManagerTest :
       UserManager(repository).upsert(payload)
 
       coVerify { repository.save(match { it.oidcSub == "test-sub" && it.displayName == "test-sub" }) }
+    }
+
+    should("parse roles from realm_access claim") {
+      val repository = mockk<UserRepository>(relaxed = true)
+      val payload = JWT.decode(buildJwt(subject = "test-sub", roles = setOf(Role.READ, Role.WRITE)))
+
+      UserManager(repository).upsert(payload)
+
+      coVerify { repository.save(match { it.roles == setOf(Role.READ, Role.WRITE) }) }
+    }
+
+    should("produce empty role set when realm_access claim is absent") {
+      val repository = mockk<UserRepository>(relaxed = true)
+      val payload = JWT.decode(buildJwt(subject = "test-sub"))
+
+      UserManager(repository).upsert(payload)
+
+      coVerify { repository.save(match { it.roles.isEmpty() }) }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/domain/model/UserTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/domain/model/UserTest.kt
@@ -1,0 +1,30 @@
+package ch.srgssr.pillarbox.backend.domain.model
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+
+class UserTest :
+  ShouldSpec({
+    val readOnlyUser = User(oidcSub = "sub", displayName = "User", roles = setOf(Role.READ))
+
+    should("return true when user holds the required role") {
+      readOnlyUser.hasAnyRole(setOf(Role.READ)).shouldBeTrue()
+    }
+
+    should("return true when user holds one of several required roles") {
+      readOnlyUser.hasAnyRole(setOf(Role.READ, Role.WRITE)).shouldBeTrue()
+    }
+
+    should("return false when user holds none of the required roles") {
+      readOnlyUser.hasAnyRole(setOf(Role.WRITE)).shouldBeFalse()
+    }
+
+    should("return false when required roles set is empty") {
+      readOnlyUser.hasAnyRole(emptySet()).shouldBeFalse()
+    }
+
+    should("return false when user has no roles") {
+      User(oidcSub = "sub", displayName = "User").hasAnyRole(setOf(Role.READ)).shouldBeFalse()
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRouteTest.kt
@@ -1,6 +1,7 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web
 
 import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.test.MediaLibrary
 import ch.srgssr.pillarbox.backend.test.count
 import ch.srgssr.pillarbox.backend.test.get
@@ -9,6 +10,8 @@ import ch.srgssr.pillarbox.backend.test.hxGet
 import ch.srgssr.pillarbox.backend.test.hxPost
 import ch.srgssr.pillarbox.backend.test.login
 import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.noRoles
+import ch.srgssr.pillarbox.backend.test.readOnlyRoles
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
@@ -27,6 +30,69 @@ import org.jsoup.Jsoup
 
 class ConsoleRouteTest :
   ShouldSpec({
+
+    should("redirect unauthenticated requests to login") {
+      testApplicationContext {
+        val response = client.get(Navigation.CONSOLE)
+        response shouldHaveStatus HttpStatusCode.Found
+      }
+    }
+
+    should("allow READ user to access read-only routes") {
+      testApplicationContext {
+        login(roles = readOnlyRoles)
+
+        client.get(Navigation.CONSOLE) shouldHaveStatus HttpStatusCode.OK
+        client.get("${Navigation.CONSOLE}/bin") shouldHaveStatus HttpStatusCode.OK
+        client.hxGet("${Navigation.CONSOLE}/media") shouldHaveStatus HttpStatusCode.OK
+        client.get("${Navigation.CONSOLE}/media/editor/") shouldHaveStatus HttpStatusCode.OK
+      }
+    }
+
+    should("forbid READ user from write routes") {
+      testApplicationContext {
+        login(roles = readOnlyRoles)
+
+        client.hxPost("${Navigation.CONSOLE}/media") {
+          contentType(ContentType.Application.Json)
+          setBody(mediaFixture())
+        } shouldHaveStatus HttpStatusCode.Forbidden
+
+        client.hxDelete("${Navigation.CONSOLE}/media/any-id") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxPost("${Navigation.CONSOLE}/media/any-id/restore") shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("${Navigation.CONSOLE}/media/editor/any-id/duplicate") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxGet("${Navigation.CONSOLE}/media/editor/fragments/chapter") shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("allow READ+WRITE user to access all console routes") {
+      testApplicationContext {
+        login(roles = setOf(Role.READ, Role.WRITE))
+
+        client.get(Navigation.CONSOLE) shouldHaveStatus HttpStatusCode.OK
+        client.hxGet("${Navigation.CONSOLE}/media") shouldHaveStatus HttpStatusCode.OK
+        client.hxGet("${Navigation.CONSOLE}/media/editor/fragments/chapter") shouldHaveStatus HttpStatusCode.OK
+      }
+    }
+
+    should("forbid user with no roles from all console routes") {
+      testApplicationContext {
+        login(roles = noRoles)
+
+        client.get(Navigation.CONSOLE) shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("${Navigation.CONSOLE}/bin") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxGet("${Navigation.CONSOLE}/media") shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("${Navigation.CONSOLE}/media/editor/") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxPost("${Navigation.CONSOLE}/media") {
+          contentType(ContentType.Application.Json)
+          setBody(mediaFixture())
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxDelete("${Navigation.CONSOLE}/media/any-id") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxPost("${Navigation.CONSOLE}/media/any-id/restore") shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("${Navigation.CONSOLE}/media/editor/any-id/duplicate") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxGet("${Navigation.CONSOLE}/media/editor/fragments/chapter") shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
 
     should("render home page when authenticated") {
       testApplicationContext {

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
@@ -5,9 +5,12 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagActionV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagOperationV1
 import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.noRoles
+import ch.srgssr.pillarbox.backend.test.readOnlyRoles
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
 import ch.srgssr.pillarbox.backend.test.token
+import ch.srgssr.pillarbox.backend.test.tokenWithRoles
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -198,6 +201,83 @@ class MediaRouteTest :
         (firstLastModified < updatedMedia.lastModified) shouldBe true
       }
     }
+    should("return 401 on all endpoints when no token is provided") {
+      testApplicationContext {
+        client.get("/v1/media") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.get("/v1/media/any-id") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.post("/v1/media") { contentType(ContentType.Application.Json) } shouldHaveStatus
+          HttpStatusCode.Unauthorized
+        client.patch("/v1/media/any-id/tags") { contentType(ContentType.Application.Json) } shouldHaveStatus
+          HttpStatusCode.Unauthorized
+        client.delete("/v1/media/any-id") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.post("/v1/media/any-id/restore") shouldHaveStatus HttpStatusCode.Unauthorized
+      }
+    }
+
+    should("return 403 on all endpoints when token has no roles") {
+      testApplicationContext {
+        val t = tokenWithRoles(noRoles)
+
+        client.get("/v1/media") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/media") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+          setBody(mediaFixture().toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.patch("/v1/media/any-id/tags") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/media/any-id/restore") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("allow READ role to access GET endpoints") {
+      testApplicationContext {
+        val t = tokenWithRoles(readOnlyRoles)
+
+        client.get("/v1/media") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return 403 on write endpoints when token has READ role only") {
+      testApplicationContext {
+        val t = tokenWithRoles(readOnlyRoles)
+
+        client.post("/v1/media") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+          setBody(mediaFixture().toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.patch("/v1/media/any-id/tags") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/media/any-id/restore") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("allow READ+WRITE token to access all endpoints") {
+      testApplicationContext {
+        val fixture = mediaFixture { id = "auth-test-id" }
+
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(fixture.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.get("/v1/media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/media/${fixture.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.delete("/v1/media/${fixture.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.NoContent
+        client.post("/v1/media/${fixture.id}/restore") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Created
+      }
+    }
+
     should("successfully restore a deleted media item") {
       testApplicationContext {
         val fixture = mediaFixture()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MockOAuthUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MockOAuthUtils.kt
@@ -1,5 +1,6 @@
 package ch.srgssr.pillarbox.backend.test
 
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.nimbusds.oauth2.sdk.TokenRequest
@@ -7,15 +8,28 @@ import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.OAuth2Config
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 
-fun buildJwt(
+fun buildJwtWithRoleList(
   subject: String,
   name: String? = null,
+  roles: List<String> = emptyList(),
 ): String =
   JWT
     .create()
     .withSubject(subject)
     .let { if (name != null) it.withClaim("name", name) else it }
-    .sign(Algorithm.none())
+    .let {
+      if (roles.isNotEmpty()) {
+        it.withClaim("realm_access", mapOf("roles" to roles))
+      } else {
+        it
+      }
+    }.sign(Algorithm.none())
+
+fun buildJwt(
+  subject: String,
+  name: String? = null,
+  roles: Set<Role> = emptySet(),
+): String = buildJwtWithRoleList(subject, name, roles.map { r -> r.key })
 
 fun mockOAuth2Server(issuerId: String = "pillarbox-realm"): MockOAuth2Server =
   MockOAuth2Server(

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -1,5 +1,6 @@
 package ch.srgssr.pillarbox.backend.test
 
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.Navigation
 import com.nimbusds.oauth2.sdk.TokenRequest
 import io.ktor.client.HttpClient
@@ -21,6 +22,10 @@ import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
+
+val readOnlyRoles: Set<Role> = setOf(Role.READ)
+val readWriteRoles: Set<Role> = setOf(Role.READ, Role.WRITE)
+val noRoles: Set<Role> = emptySet()
 
 /**
  * Executes an integration test within a managed Ktor application environment.
@@ -90,18 +95,22 @@ val ApplicationTestBuilder.mockServer: MockOAuth2Server
       ?: error("MockOAuth2Server not found in application attributes.")
 
 val ApplicationTestBuilder.token: String
-  get() =
-    mockServer
-      .issueToken(
-        issuerId = "pillarbox-realm",
-        audience = "pillarbox-test-client",
-      ).serialize()
+  get() = tokenWithRoles(readWriteRoles)
 
-suspend fun ApplicationTestBuilder.login(): HttpResponse {
+fun ApplicationTestBuilder.tokenWithRoles(roles: Set<Role>): String =
+  mockServer
+    .issueToken(
+      issuerId = "pillarbox-realm",
+      audience = "pillarbox-test-client",
+      claims = mapOf("realm_access" to mapOf("roles" to roles.map { it.key })),
+    ).serialize()
+
+suspend fun ApplicationTestBuilder.login(roles: Set<Role> = readWriteRoles): HttpResponse {
   mockServer.enqueueCallback(
     DefaultOAuth2TokenCallback(
       issuerId = "pillarbox-realm",
       subject = "dev-user",
+      claims = mapOf("realm_access" to mapOf("roles" to roles.map { it.key })),
     ),
   )
 


### PR DESCRIPTION
## Description

Resolves #26 by introducing a `withRole` Ktor route-scoped plugin that gates endpoints behind role ownership. Roles are extracted from the Keycloak JWT, mapped to a Role enum, and persisted to the DB on login.

## Changes Made


- Add roles to `User` domain object.
- Add `withRole` DSL.
- Extract roles from JWT payload.
- Update `verifyJwt` to return a `User` principal with roles pre-populated.
- Gate Console and Media API routes.
- Update Keycloak with 3 seeded users.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
