### PR TITLE
feat(folders): add hierarchical folder structure with media assignment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,8 @@ indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.kt]
+[*.{kt,kts}]
+ktlint_standard_no-unused-imports = enabled
 max_line_length = 120
 
 [*.md]

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -29,8 +29,10 @@ The console exposes several endpoints that return either full HTML pages or part
 
 The REST API is divided into two primary functional areas:
 
-1. [Management API (Protected)](#management-api-protected): Used for CRUD operations on media metadata, protected by OAuth2.
-2. [Player API (Public)](#player-api-public): Playback requests with support for dynamic stream and DRM negotiation.
+1. [Management API (Protected)](#management-api-protected): Used for CRUD operations on media
+   metadata, protected by OAuth2.
+2. [Player API (Public)](#player-api-public): Playback requests with support for dynamic stream and
+   DRM negotiation.
 
 ### Management API (Protected)
 
@@ -42,11 +44,11 @@ default) and are gated by role-based access control. A request without a valid t
 
 The development Keycloak realm is seeded with three users (all passwords are `password`):
 
-| Username   | Roles                        | Access                          |
-|------------|------------------------------|---------------------------------|
-| `reader`   | `Read`                       | Read-only                       |
-| `editor`   | `Read`, `Write`              | Read + create/modify content    |
-| `admin`    | `Read`, `Write`, `Admin`     | Unrestricted                    |
+| Username | Roles                    | Access                       |
+|----------|--------------------------|------------------------------|
+| `reader` | `Read`                   | Read-only                    |
+| `editor` | `Read`, `Write`          | Read + create/modify content |
+| `admin`  | `Read`, `Write`, `Admin` | Unrestricted                 |
 
 #### Obtaining a Token
 
@@ -80,6 +82,22 @@ definitions in [MediaRoute.kt][media-route-kt].
 | **DELETE** | `/v1/media/{id}`         | Remove a media entity from the repository.              |
 | **POST**   | `/v1/media/{id}/restore` | Restores a deleted media entity from the repository.    |
 
+#### Folder API
+
+Folders provide a hierarchical way to organise media items. They support nesting via a `parentId`
+field. You can find all the definitions in [FolderRoute.kt][folder-route-kt].
+
+| Method     | Endpoint                          | Description                                                                                |
+|------------|-----------------------------------|--------------------------------------------------------------------------------------------|
+| **GET**    | `/v1/folder`                      | List folders. Accepts `limit` and `offset` for pagination; `parentId` to filter by parent. |
+| **GET**    | `/v1/folder/{id}`                 | Retrieve a specific folder by ID.                                                          |
+| **GET**    | `/v1/folder/{id}/media`           | List media items assigned to a folder. Accepts `limit` and `offset`.                       |
+| **POST**   | `/v1/folder`                      | Create a new folder.                                                                       |
+| **PATCH**  | `/v1/folder/{id}`                 | Update an existing folder.                                                                 |
+| **DELETE** | `/v1/folder/{id}`                 | Delete a folder.                                                                           |
+| **POST**   | `/v1/folder/{id}/media`           | Assign a media item to a folder.                                                           |
+| **DELETE** | `/v1/folder/{id}/media/{mediaId}` | Remove a media item's assignment from a folder.                                            |
+
 ### Player API (Public)
 
 The playback endpoints do not require a token and are open to all clients.
@@ -87,10 +105,11 @@ Unlike the management API, these endpoints are **publicly accessible** (no Beare
 They support content negotiation via query parameters or custom headers.
 You can find all the definitions in [PlayerMediaRoute.kt][player-media-route-kt].
 
-| Method  | Endpoint                | Description                                |
-|---------|-------------------------|--------------------------------------------|
-| **GET** | `/v1/player/media`      | List all available playback entities.      |
-| **GET** | `/v1/player/media/{id}` | Retrieve a specific playback entity by ID. |
+| Method  | Endpoint                       | Description                                                          |
+|---------|--------------------------------|----------------------------------------------------------------------|
+| **GET** | `/v1/player/media`             | List all available playback entities. Accepts `limit` and `offset`.  |
+| **GET** | `/v1/player/media/{id}`        | Retrieve a specific playback entity by ID.                           |
+| **GET** | `/v1/player/folder/{id}/media` | List media items assigned to a folder. Accepts `limit` and `offset`. |
 
 #### Content Negotiation
 
@@ -100,10 +119,10 @@ If neither is supplied, the API returns a media item without a source.
 
 **Query Parameters**
 
-| Parameter        | Example Value                        | Description                                                                                                                         |
-|------------------|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `stream-type`    | `application/dash+xml`               | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
-| `drm`            | `com.widevine.alpha;HW_SECURE_ALL`   | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
+| Parameter     | Example Value                      | Description                                                                                                                         |
+|---------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `stream-type` | `application/dash+xml`             | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
+| `drm`         | `com.widevine.alpha;HW_SECURE_ALL` | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
 
 Example:
 
@@ -114,10 +133,10 @@ curl --request GET \
 
 **Headers (fallback)**
 
-| Header                 | Example Value                        | Description                                                                                                                         |
-|------------------------|--------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| `X-Accept-Stream-Type` | `application/dash+xml`               | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
-| `X-Accept-DRM`         | `com.widevine.alpha;HW_SECURE_ALL`   | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
+| Header                 | Example Value                      | Description                                                                                                                         |
+|------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| `X-Accept-Stream-Type` | `application/dash+xml`             | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
+| `X-Accept-DRM`         | `com.widevine.alpha;HW_SECURE_ALL` | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
 
 Example:
 
@@ -142,7 +161,11 @@ level.
 | `HW_SECURE_DECODE`   | L2       | SL2000    |
 | `HW_SECURE_ALL`      | L1       | SL3000    |
 
-Native levels (`L1`, `L2`, `L3`, `SL2000`, `SL3000`) are still accepted and passed through unchanged.
+Native levels (`L1`, `L2`, `L3`, `SL2000`, `SL3000`) are still accepted and passed through
+unchanged.
 
 [media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+
+[folder-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/FolderRoute.kt
+
 [player-media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -6,6 +6,7 @@ import ch.srgssr.pillarbox.backend.auth.installSession
 import ch.srgssr.pillarbox.backend.db.databaseModule
 import ch.srgssr.pillarbox.backend.entrypoint.web.auth
 import ch.srgssr.pillarbox.backend.entrypoint.web.console
+import ch.srgssr.pillarbox.backend.entrypoint.web.folder
 import ch.srgssr.pillarbox.backend.entrypoint.web.media
 import ch.srgssr.pillarbox.backend.entrypoint.web.playerMedia
 import ch.srgssr.pillarbox.backend.io.httpClientModule
@@ -88,7 +89,8 @@ fun Application.module() {
   routing {
     auth(get(), get(), get())
     media(get())
-    playerMedia(get())
+    folder(get(), get())
+    playerMedia(get(), get())
     console(get())
   }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthConfig.kt
@@ -3,7 +3,6 @@ package ch.srgssr.pillarbox.backend.auth
 import io.ktor.server.config.ApplicationConfig
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Transient
 
 /**
  * Configuration parameters for the Authentication provider.

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
@@ -8,7 +8,6 @@ import com.auth0.jwk.JwkProviderBuilder
 import io.ktor.http.HttpMethod
 import io.ktor.server.auth.OAuthServerSettings
 import io.ktor.server.auth.jwt.JWTCredential
-import io.ktor.server.auth.jwt.JWTPrincipal
 import java.net.URI
 
 /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/TokenProvider.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/TokenProvider.kt
@@ -1,10 +1,8 @@
 package ch.srgssr.pillarbox.backend.auth
 
-import ch.srgssr.pillarbox.backend.domain.model.User
 import ch.srgssr.pillarbox.backend.log.error
 import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
-import com.auth0.jwt.interfaces.Payload
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.forms.submitForm

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/ExposedRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/ExposedRepository.kt
@@ -15,6 +15,7 @@ import org.jetbrains.exposed.v1.core.statements.UpdateStatement
 import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.jdbc.upsert
@@ -78,6 +79,21 @@ abstract class ExposedRepository<T, ID>(
         .where { idColumn eq id }
         .map { it.decode() } // Uses the internal hook
         .singleOrNull()
+    }
+
+  /**
+   * Whether a specific resource exists with this unique identifier.
+   *
+   * @param id The unique identifier of the entity.
+   *
+   * @return true if it exists, false otherwise.
+   */
+  open suspend fun exists(id: ID): Boolean =
+    query(readOnly = true) {
+      table
+        .select(idColumn)
+        .where { idColumn eq id }
+        .count() > 0
     }
 
   /**
@@ -168,11 +184,18 @@ abstract class ExposedRepository<T, ID>(
    *
    * @param item The entity to save.
    */
-  open suspend fun save(item: T): Unit =
+  open suspend fun save(item: T): T =
     query {
-      table.upsert(onUpdate = encodeOnUpdate(item)) {
-        encode(it, item)
-      }
+      val stmt =
+        table.upsert(onUpdate = encodeOnUpdate(item)) {
+          encode(it, item)
+        }
+      val id = stmt[idColumn]
+      table
+        .selectAll()
+        .where { idColumn eq id }
+        .single()
+        .decode()
     }
 
   /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Folder.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Folder.kt
@@ -1,0 +1,17 @@
+package ch.srgssr.pillarbox.backend.domain.model
+
+import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+@Serializable
+@OptIn(ExperimentalUuidApi::class)
+data class Folder(
+  val id: String = Uuid.random().toString(),
+  val name: String,
+  val parentId: String? = null,
+  val createdAt: Instant = Clock.System.now(),
+  val updatedAt: Instant = Clock.System.now(),
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
@@ -26,6 +26,7 @@ import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import io.ktor.server.util.getOrFail
 import io.ktor.utils.io.ExperimentalKtorApi
 import org.jetbrains.exposed.v1.core.eq
 import java.util.Locale
@@ -105,7 +106,7 @@ fun Route.console(mediaRepository: MediaRepository) {
         }
 
         get("media/editor/{id}/duplicate") {
-          val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.NotFound)
+          val id = call.parameters.getOrFail("id")
 
           val media =
             mediaRepository
@@ -134,7 +135,7 @@ fun Route.console(mediaRepository: MediaRepository) {
         }
 
         hx.delete("media/{id}") {
-          val id = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.NotFound)
+          val id = call.parameters.getOrFail("id")
 
           logger.info { "Attempting to delete media with ID: $id" }
 
@@ -146,7 +147,7 @@ fun Route.console(mediaRepository: MediaRepository) {
         }
 
         hx.post("media/{id}/restore") {
-          val id = call.parameters["id"] ?: return@post call.respond(HttpStatusCode.NotFound)
+          val id = call.parameters.getOrFail("id")
 
           logger.info { "Attempting to restore media with ID: $id" }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/FolderRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/FolderRoute.kt
@@ -1,0 +1,145 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web
+
+import ch.srgssr.pillarbox.backend.auth.withRole
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toFolderResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toMediaResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
+import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.authenticate
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.util.getOrFail
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.core.eq
+
+/**
+ * Configures the versioned folder-related routes.
+ *
+ * @param folderRepository Repository used to manage folder persistence.
+ * @param mediaRepository Repository used to manage media persistence.
+ */
+@SuppressWarnings("LongMethod", "CyclomaticComplexMethod")
+fun Route.folder(
+  folderRepository: FolderRepository,
+  mediaRepository: MediaRepository,
+) {
+  authenticate("pillarbox-jwt", "pillarbox-session") {
+    route("v1/folder") {
+      get {
+        val filter =
+          call.request.queryParameters["parentId"]?.let {
+            { FolderTable.parentId eq it }
+          }
+
+        with(call.request.queryParameters.toPageRequest()) {
+          call.respond(
+            folderRepository
+              .getAll(
+                limit,
+                offset,
+                filter,
+              ).map { it.toFolderResponseV1() }
+              .toList(),
+          )
+        }
+      }
+
+      get("/{id}") {
+        val id = call.parameters.getOrFail("id")
+
+        when (val folder = folderRepository.find(id)?.toFolderResponseV1()) {
+          null -> call.respond(HttpStatusCode.NotFound)
+          else -> call.respond(folder)
+        }
+      }
+
+      get("/{id}/media") {
+        val id = call.parameters.getOrFail("id")
+        if (!folderRepository.exists(id)) return@get call.respond(HttpStatusCode.NotFound)
+
+        with(call.request.queryParameters.toPageRequest()) {
+          call.respond(
+            mediaRepository
+              .findMediaInFolder(
+                folderId = id,
+                limit,
+                offset,
+                filter = { MediaTable.deleted eq false },
+              ).map { it.toMediaResponseV1() }
+              .toList(),
+          )
+        }
+      }
+
+      withRole(Role.WRITE) {
+        post {
+          val folder = call.receive<FolderRequestV1>().toFolder()
+          call.respond(
+            HttpStatusCode.Created,
+            folderRepository.save(folder).toFolderResponseV1(),
+          )
+        }
+
+        patch("/{id}") {
+          val id = call.parameters.getOrFail("id")
+          if (!folderRepository.exists(id)) return@patch call.respond(HttpStatusCode.NotFound)
+
+          val folder = call.receive<FolderRequestV1>().toFolder().copy(id = id)
+          call.respond(
+            HttpStatusCode.Created,
+            folderRepository.save(folder).toFolderResponseV1(),
+          )
+        }
+
+        delete("/{id}") {
+          val id = call.parameters.getOrFail("id")
+          when (folderRepository.delete(id)) {
+            true -> call.respond(HttpStatusCode.NoContent)
+            false -> call.respond(HttpStatusCode.NotFound)
+          }
+        }
+
+        post("/{id}/media") {
+          val id = call.parameters.getOrFail("id")
+          if (!folderRepository.exists(id)) return@post call.respond(HttpStatusCode.NotFound, "Folder not found")
+
+          with(call.receive<AssignMediaRequestV1>()) {
+            if (!mediaRepository.exists(mediaId)) {
+              return@post call.respond(
+                HttpStatusCode.UnprocessableEntity,
+                "Referenced Media id does not exist",
+              )
+            }
+
+            folderRepository.assignMedia(id, mediaId)
+            call.respond(HttpStatusCode.Created)
+          }
+        }
+
+        delete("/{id}/media/{mediaId}") {
+          val id = call.parameters.getOrFail("id")
+          val mediaId = call.parameters.getOrFail("mediaId")
+
+          when (folderRepository.removeMediaAssignment(id, mediaId)) {
+            true -> call.respond(HttpStatusCode.NoContent)
+            false -> call.respond(HttpStatusCode.NotFound)
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
@@ -7,6 +7,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toMediaResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
 import io.ktor.http.HttpStatusCode
@@ -19,6 +20,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
+import io.ktor.server.util.getOrFail
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.and
@@ -46,15 +48,21 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
   crossinline applyTags: (TagReq, List<String>) -> List<String>,
 ) {
   get {
-    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 20
-    val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
-    val mediaFlow = mediaRepository.getAll(limit, offset, filter = { MediaTable.deleted eq false })
-
-    call.respond(mediaFlow.map { toResponse(it) }.toList())
+    with(call.request.queryParameters.toPageRequest()) {
+      call.respond(
+        mediaRepository
+          .getAll(
+            limit,
+            offset,
+            filter = { MediaTable.deleted eq false },
+          ).map { toResponse(it) }
+          .toList(),
+      )
+    }
   }
 
   get("/{id}") {
-    val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+    val id = call.parameters.getOrFail("id")
 
     val media =
       mediaRepository.findOne {
@@ -74,7 +82,7 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
     }
 
     patch("/{id}/tags") {
-      val id = call.parameters["id"] ?: return@patch call.respond(HttpStatusCode.BadRequest)
+      val id = call.parameters.getOrFail("id")
       val request = call.receive<TagReq>()
 
       mediaRepository
@@ -84,7 +92,7 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
     }
 
     delete("/{id}") {
-      val id = call.parameters["id"] ?: return@delete call.respond(HttpStatusCode.BadRequest)
+      val id = call.parameters.getOrFail("id")
 
       mediaRepository
         .softDelete(id)
@@ -94,7 +102,7 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
     }
 
     post("/{id}/restore") {
-      val id = call.parameters["id"] ?: return@post call.respond(HttpStatusCode.BadRequest)
+      val id = call.parameters.getOrFail("id")
 
       mediaRepository
         .restore(id)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt
@@ -1,86 +1,122 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web
 
-import ch.srgssr.pillarbox.backend.domain.model.Media
-import ch.srgssr.pillarbox.backend.entrypoint.web.dto.PlayerMediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toPlayerResponse
 import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaSourceSelector
 import ch.srgssr.pillarbox.backend.entrypoint.web.service.toDrmPreferences
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
 import ch.srgssr.pillarbox.backend.io.parseHeaderList
 import ch.srgssr.pillarbox.backend.io.parseParamList
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
+import io.ktor.server.util.getOrFail
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 
 /**
- * Generic helper to register player-facing media endpoints.
+ * Configures the versioned public player media routes under `v1/player/`.
  *
- * @param Res The Response DTO type.
- * @param mediaRepository The repository to fetch media from.
- * @param toResponse Mapping function that transforms the domain [Media] into [Res],
+ * These endpoints return player-optimized responses with media sources selected
+ * according to the client's stream-type and DRM preferences.
+ *
+ * @param mediaRepository The repository used to manage media entities.
+ * @param folderRepository The repository used to verify folder existence.
  */
-inline fun <reified Res : Any> Route.playerMediaEndpoints(
+fun Route.playerMedia(
   mediaRepository: MediaRepository,
-  crossinline toResponse: suspend (Media, ApplicationCall) -> Res,
+  folderRepository: FolderRepository,
 ) {
-  get {
-    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 20
-    val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
-    val mediaFlow = mediaRepository.getAll(limit, offset, filter = { MediaTable.deleted eq false })
+  route("v1/player/") {
+    route("media") {
+      get {
+        with(call.request.queryParameters.toPageRequest()) {
+          val mediaSourceSelector = call.request.toMediaSourceSelector()
+          call.respond(
+            mediaRepository
+              .getAll(
+                limit,
+                offset,
+                filter = { MediaTable.deleted eq false },
+              ).map { it.toPlayerResponse(mediaSourceSelector) }
+              .toList(),
+          )
+        }
+      }
 
-    call.respond(mediaFlow.map { toResponse(it, call) })
-  }
+      get("/{id}") {
+        val id = call.parameters.getOrFail("id")
 
-  get("/{id}") {
-    val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+        val media =
+          mediaRepository.findOne {
+            (MediaTable.id eq id) and (MediaTable.deleted eq false)
+          } ?: return@get call.respond(HttpStatusCode.NotFound)
 
-    val media =
-      mediaRepository.findOne {
-        (MediaTable.id eq id) and (MediaTable.deleted eq false)
-      } ?: return@get call.respond(HttpStatusCode.NotFound)
+        call.respond(media.toPlayerResponse(call.request.toMediaSourceSelector()))
+      }
+    }
 
-    call.respond(toResponse(media, call))
+    route("folder") {
+      get("/{id}/media") {
+        val id = call.parameters.getOrFail("id")
+        if (!folderRepository.exists(id)) return@get call.respond(HttpStatusCode.NotFound)
+
+        with(call.request.queryParameters.toPageRequest()) {
+          val mediaSourceSelector = call.request.toMediaSourceSelector()
+          call.respond(
+            mediaRepository
+              .findMediaInFolder(
+                folderId = id,
+                limit,
+                offset,
+                filter = { MediaTable.deleted eq false },
+              ).map { it.toPlayerResponse(mediaSourceSelector) }
+              .toList(),
+          )
+        }
+      }
+    }
   }
 }
 
 /**
- * Configures the versioned player media routes.
+ * Builds a [MediaSourceSelector] from the current request's stream-type and DRM preferences.
  *
- * @param mediaRepository The repository used to manage media entities.
+ * @return A [MediaSourceSelector] configured with the client's preferences.
  */
-fun Route.playerMedia(mediaRepository: MediaRepository) {
-  route("v1/player/media") {
-    playerMediaEndpoints<PlayerMediaResponseV1>(
-      mediaRepository = mediaRepository,
-      // Supported query parameters (take precedence over headers):
-      // - stream-type:     Preferred source MIME type (e.g. "application/dash+xml,application/x-mpegURL")
-      // - drm:             Preferred DRM key system   (e.g. "com.widevine.alpha")
-      //
-      // Supported headers (fallback when query parameters are absent):
-      // - X-Accept-Stream-Type:     Preferred source MIME type
-      // - X-Accept-DRM:             Preferred DRM key system
-      toResponse = { media, call ->
-        val mimeTypes =
-          call.request.queryParameters
-            .parseParamList("stream-type")
-            .ifEmpty { call.request.headers.parseHeaderList("X-Accept-Stream-Type") }
-        val drmPreferences =
-          call.request.queryParameters
-            .parseParamList("drm")
-            .ifEmpty { call.request.headers.parseHeaderList("X-Accept-DRM") }
-            .toDrmPreferences()
+private fun ApplicationRequest.toMediaSourceSelector() =
+  MediaSourceSelector(
+    toMimeTypePreferences(),
+    toDrmPreferences(),
+  )
 
-        media.toPlayerResponse(
-          MediaSourceSelector(mimeTypes, drmPreferences),
-        )
-      },
-    )
-  }
-}
+/**
+ * Extracts the client's preferred MIME types from the `stream-type` query parameter,
+ * falling back to the `X-Accept-Stream-Type` header if the parameter is absent or empty.
+ *
+ * @return An ordered list of preferred stream types.
+ */
+private fun ApplicationRequest.toMimeTypePreferences() =
+  queryParameters
+    .parseParamList("stream-type")
+    .ifEmpty { call.request.headers.parseHeaderList("X-Accept-Stream-Type") }
+
+/**
+ * Extracts the client's DRM preferences from the `drm` query parameter,
+ * falling back to the `X-Accept-DRM` header if the parameter is absent or empty.
+ *
+ * @return list of parsed [DrmPreference][ch.srgssr.pillarbox.backend.entrypoint.web.service.DrmPreference]s,
+ *         preserving priority order.
+ */
+private fun ApplicationRequest.toDrmPreferences() =
+  call.request.queryParameters
+    .parseParamList("drm")
+    .ifEmpty { call.request.headers.parseHeaderList("X-Accept-DRM") }
+    .toDrmPreferences()

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/AssignMediaRequestV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/AssignMediaRequestV1.kt
@@ -1,0 +1,13 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Request body for assigning a media item to a folder.
+ *
+ * @property mediaId Identifier of the media item to assign.
+ */
+@Serializable
+data class AssignMediaRequestV1(
+  val mediaId: String,
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderRequestV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderRequestV1.kt
@@ -1,0 +1,34 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.dto
+
+import ch.srgssr.pillarbox.backend.domain.model.Folder
+import kotlinx.serialization.Serializable
+
+/**
+ * Data Transfer Object (V1) representing a folder request from the admin web entry point.
+ *
+ * This class acts as the external contract for the Pillarbox API. It decouples the
+ * public API schema from the internal domain logic, allowing for versioned
+ * evolution of the folder structure.
+ *
+ * @property name The name of the folder.
+ * @property parentId This folder parent or null if it belongs to the root directory.
+ */
+@Serializable
+data class FolderRequestV1(
+  val name: String,
+  val parentId: String? = null,
+) {
+  /**
+   * Maps the [FolderRequestV1] DTO to the internal [Folder] domain model.
+   *
+   * Use this method to pass the validated request data into the service or
+   * repository layers where domain-specific logic is applied.
+   *
+   * @return A [Folder] instance populated with the request's data.
+   */
+  fun toFolder() =
+    Folder(
+      name = name,
+      parentId = parentId,
+    )
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderResponseV1.kt
@@ -1,0 +1,37 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.dto
+
+import ch.srgssr.pillarbox.backend.domain.model.Folder
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+/**
+ * API response representation of a folder for the V1 endpoint.
+ *
+ * @property id Unique identifier of the folder.
+ * @property name Display name of the folder.
+ * @property parentId Identifier of the parent folder, or `null` for root-level folders.
+ * @property createdAt Timestamp when the folder was created.
+ * @property updatedAt Timestamp of the last folder update.
+ */
+@Serializable
+data class FolderResponseV1(
+  val id: String,
+  val name: String,
+  val parentId: String? = null,
+  val createdAt: Instant,
+  val updatedAt: Instant,
+)
+
+/**
+ * Converts a [Folder] domain model to its V1 API response representation.
+ *
+ * @return A [FolderResponseV1] containing the domain model's data.
+ */
+fun Folder.toFolderResponseV1() =
+  FolderResponseV1(
+    id = this.id,
+    name = this.name,
+    parentId = this.parentId,
+    createdAt = this.createdAt,
+    updatedAt = this.updatedAt,
+  )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/PageRequest.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/PageRequest.kt
@@ -1,0 +1,26 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.utils
+
+import io.ktor.http.Parameters
+import kotlinx.serialization.Serializable
+
+/**
+ * Pagination parameters extracted from query strings.
+ *
+ * @property limit Maximum number of items to return. Defaults to 20.
+ * @property offset Number of items to skip before the first result. Defaults to 0.
+ */
+@Serializable
+data class PageRequest(
+  val limit: Int = 20,
+  val offset: Long = 0L,
+)
+
+/**
+ * Extracts pagination parameters from the query string, falling back to
+ * [PageRequest] defaults for missing or malformed values.
+ */
+fun Parameters.toPageRequest() =
+  PageRequest(
+    limit = get("limit")?.toIntOrNull() ?: 20,
+    offset = get("offset")?.toLongOrNull() ?: 0L,
+  )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
@@ -1,5 +1,8 @@
 package ch.srgssr.pillarbox.backend.persistence
 
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderMediaTable
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
@@ -16,13 +19,15 @@ import org.koin.dsl.module
  * @see MediaRepository
  * @see SessionRepository
  * @see UserRepository
+ * @see FolderRepository
  */
 fun persistenceModule() =
   module {
     single<List<Table>> {
-      listOf(MediaTable, SessionTable, UserTable)
+      listOf(MediaTable, SessionTable, UserTable, FolderTable, FolderMediaTable)
     }
     single { MediaRepository(get()) }
     single { SessionRepository(get()) }
     single { UserRepository(get()) }
+    single { FolderRepository(get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderAncestorView.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderAncestorView.kt
@@ -1,0 +1,33 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderAncestorView.depth
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderAncestorView.descendantId
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+
+/**
+ * Provides the breadcrumb path for any folder: one row per ancestor from
+ * the folder itself ([depth] = 1) up to the root.
+ */
+object FolderAncestorView : Table("v_folder_ancestors") {
+  /** The folder whose ancestry is being traced. */
+  val descendantId = varchar("descendant_id", 255)
+
+  /** Identifier of the ancestor folder at this level. */
+  val id = varchar("id", 255)
+
+  /** Name of the ancestor folder. */
+  val name = varchar("name", 255)
+
+  /** Parent of the ancestor folder, or `null` if it is the root. */
+  val parentId = varchar("parent_id", 255).nullable()
+
+  /** Timestamp when the ancestor folder was created. */
+  val createdAt = timestampWithTimeZone("created_at")
+
+  /** Timestamp when the ancestor folder was last updated. */
+  val updatedAt = timestampWithTimeZone("updated_at")
+
+  /** Distance from [descendantId] to this ancestor. 1 means the folder itself. */
+  val depth = integer("depth")
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderMediaTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderMediaTable.kt
@@ -1,0 +1,25 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+
+/**
+ * Junction table linking media items to folders.
+ *
+ * Each row represents a single media-to-folder assignment. Deleting either the
+ * referenced [MediaTable] or [FolderTable] row cascades to this table.
+ */
+object FolderMediaTable : Table("pb_folder_media") {
+  /** Identifier of the assigned media item. */
+  val mediaId = varchar("media_id", 255).references(MediaTable.id, onDelete = ReferenceOption.CASCADE)
+
+  /** Identifier of the folder the media is assigned to. */
+  val folderId = varchar("folder_id", 255).references(FolderTable.id, onDelete = ReferenceOption.CASCADE)
+
+  /** Timestamp when the media was assigned to the folder. */
+  val addedAt = timestampWithTimeZone("added_at")
+
+  override val primaryKey = PrimaryKey(mediaId)
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
@@ -1,0 +1,175 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.db.ExposedRepository
+import ch.srgssr.pillarbox.backend.domain.model.Folder
+import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.time.toKotlinInstant
+import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.core.statements.UpdateStatement
+import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
+import kotlin.time.Clock
+
+/**
+ * Repository responsible for the persistence and retrieval of [Folder] entities using Exposed.
+ *
+ * This implementation maps the [Folder] domain model to the [FolderTable] schema.
+ *
+ * @param db The [Database] instance used for all transactions.
+ */
+class FolderRepository(
+  db: Database,
+) : ExposedRepository<Folder, String>(db = db, table = FolderTable, idColumn = FolderTable.id) {
+  /**
+   * Decodes a [ResultRow] from the [FolderTable] into a [Folder] domain object.
+   */
+  override fun ResultRow.decode() =
+    Folder(
+      id = this[FolderTable.id],
+      name = this[FolderTable.name],
+      parentId = this[FolderTable.parentId],
+      createdAt = this[FolderTable.createdAt].toKotlinInstant(),
+      updatedAt = this[FolderTable.updatedAt].toKotlinInstant(),
+    )
+
+  /**
+   * Encodes a [Folder] domain object into an [UpdateBuilder] for inserts.
+   */
+  override fun Table.encode(
+    builder: UpdateBuilder<*>,
+    item: Folder,
+  ) {
+    builder[FolderTable.id] = item.id
+    builder[FolderTable.name] = item.name
+    builder[FolderTable.parentId] = item.parentId
+    builder[FolderTable.createdAt] = Clock.System.now().toUtcOffsetDateTime()
+    builder[FolderTable.updatedAt] = Clock.System.now().toUtcOffsetDateTime()
+  }
+
+  /**
+   * Encodes a [Folder] domain object into an [UpdateBuilder] for updates.
+   */
+  override fun encodeOnUpdate(item: Folder): (UpsertBuilder.(UpdateStatement) -> Unit) =
+    {
+      it[FolderTable.name] = item.name
+      it[FolderTable.parentId] = item.parentId
+      it[FolderTable.updatedAt] = Clock.System.now().toUtcOffsetDateTime()
+    }
+
+  /**
+   * Retrieves all ancestor folders of the given folder, ordered from the root down to the
+   * folder in parameter.
+   *
+   * @param folderId The ID of the folder whose ancestors should be retrieved.
+   * @return A list of ancestor [Folder] entities, from the most distant (root) to the closest (parent).
+   */
+  suspend fun findAncestors(folderId: String): List<Folder> =
+    query(readOnly = true) {
+      FolderAncestorView
+        .selectAll()
+        .where { FolderAncestorView.descendantId eq folderId }
+        .orderBy(FolderAncestorView.depth, SortOrder.DESC)
+        .map { row ->
+          Folder(
+            id = row[FolderAncestorView.id],
+            name = row[FolderAncestorView.name],
+            parentId = row[FolderAncestorView.parentId],
+            createdAt = row[FolderAncestorView.createdAt].toKotlinInstant(),
+            updatedAt = row[FolderAncestorView.updatedAt].toKotlinInstant(),
+          )
+        }
+    }
+
+  /**
+   * Assigns a media item to a folder. If the media is already assigned to another folder,
+   * the assignment is moved to the specified folder.
+   *
+   * @param folderId The ID of the target folder.
+   * @param mediaId The ID of the media item to assign.
+   */
+  suspend fun assignMedia(
+    folderId: String,
+    mediaId: String,
+  ): Unit =
+    query {
+      FolderMediaTable.upsert(FolderMediaTable.mediaId) {
+        it[FolderMediaTable.mediaId] = mediaId
+        it[FolderMediaTable.folderId] = folderId
+        it[FolderMediaTable.addedAt] = Clock.System.now().toUtcOffsetDateTime()
+      }
+    }
+
+  /**
+   * Removes the folder assignment for a given media item.
+   *
+   * @param mediaId The ID of the media item to unassign.
+   * @param folderId The folder ID currently assigned to this media.
+   * @return `true` if an assignment was removed, `false` if the media had no folder assignment.
+   */
+  suspend fun removeMediaAssignment(
+    folderId: String,
+    mediaId: String,
+  ): Boolean =
+    query {
+      FolderMediaTable.deleteWhere {
+        (FolderMediaTable.mediaId eq mediaId) and (FolderMediaTable.folderId eq folderId)
+      } > 0
+    }
+
+  /**
+   * Finds the folder that a media item is currently assigned to.
+   *
+   * @param mediaId The ID of the media item.
+   * @return The [Folder] containing the media, or `null` if the media is not assigned to any folder.
+   */
+  suspend fun findFolderOfMedia(mediaId: String): Folder? =
+    query(readOnly = true) {
+      (FolderTable innerJoin FolderMediaTable)
+        .selectAll()
+        .where { FolderMediaTable.mediaId eq mediaId }
+        .singleOrNull()
+        ?.decode()
+    }
+
+  /**
+   * Counts the number of non-deleted media items in a folder, or unassigned media if [folderId] is `null`.
+   *
+   * @param folderId The folder ID to count media for, or `null` to count media not assigned to any folder.
+   * @return The number of matching media items.
+   */
+  suspend fun countMediaIn(folderId: String?): Long =
+    query(readOnly = true) {
+      if (folderId != null) {
+        FolderMediaTable.selectAll().where { FolderMediaTable.folderId eq folderId }.count()
+      } else {
+        (MediaTable leftJoin FolderMediaTable)
+          .selectAll()
+          .where { (MediaTable.deleted eq false) and FolderMediaTable.mediaId.isNull() }
+          .count()
+      }
+    }
+
+  /**
+   * Counts the number of direct subfolders of a folder, or root-level folders if [folderId] is `null`.
+   *
+   * @param folderId The parent folder ID, or `null` to count folders with no parent.
+   * @return The number of matching subfolders.
+   */
+  suspend fun countSubfoldersOf(folderId: String?): Long =
+    query(readOnly = true) {
+      FolderTable
+        .selectAll()
+        .where { if (folderId == null) FolderTable.parentId.isNull() else FolderTable.parentId eq folderId }
+        .count()
+    }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderTable.kt
@@ -1,0 +1,36 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable.parentId
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+
+/**
+ * Exposed table definition for persisting folder metadata.
+ *
+ * Folders form a tree structure via the self-referencing [parentId] column.
+ * Deleting a parent folder cascades to all its children. Media in the folder
+ * are not deleted, see [FolderMediaTable] relation.
+ */
+object FolderTable : Table("pb_folders") {
+  /** Unique identifier for the folder. */
+  val id = varchar("id", 255)
+
+  /** Display name of the folder. */
+  val name = varchar("name", 255)
+
+  /** Parent folder identifier, or `null` for root-level folders. */
+  val parentId = varchar("parent_id", 255).references(id, onDelete = ReferenceOption.CASCADE).nullable()
+
+  /** Timestamp when the folder was created. */
+  val createdAt = timestampWithTimeZone("created_at")
+
+  /** Timestamp when the folder was last updated. */
+  val updatedAt = timestampWithTimeZone("updated_at")
+
+  override val primaryKey = PrimaryKey(id)
+
+  init {
+    uniqueIndex(parentId, name)
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
@@ -2,17 +2,27 @@ package ch.srgssr.pillarbox.backend.persistence.media
 
 import ch.srgssr.pillarbox.backend.db.ExposedRepository
 import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderMediaTable
 import ch.srgssr.pillarbox.backend.time.toKotlinInstant
 import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.core.statements.UpdateStatement
 import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.update
 import kotlin.time.Clock
 
@@ -115,5 +125,46 @@ class MediaRepository(
         it[deleted] = false
         it[lastModified] = Clock.System.now().toUtcOffsetDateTime()
       } > 0
+    }
+
+  fun findMediaInFolder(
+    folderId: String,
+    limit: Int = 100,
+    offset: Long = 0,
+    filter: (() -> Op<Boolean>)? = null,
+    sort: List<Pair<Expression<*>, SortOrder>>? = null,
+  ): Flow<Media> =
+    channelFlow {
+      query(readOnly = true) {
+        MediaTable
+          .join(FolderMediaTable, JoinType.INNER, MediaTable.id, FolderMediaTable.mediaId)
+          .selectAll()
+          .where { (FolderMediaTable.folderId eq folderId) and (MediaTable.deleted eq false) }
+          .apply { filter?.let { andWhere(it) } }
+          .apply { sort?.let { orderBy(*it.toTypedArray()) } }
+          .limit(limit)
+          .offset(offset)
+          .forEach { row -> send(row.decode()) }
+      }
+    }
+
+  private fun findMediaWithoutFolder(
+    limit: Int = 100,
+    offset: Long = 0,
+    filter: (() -> Op<Boolean>)? = null,
+    sort: List<Pair<Expression<*>, SortOrder>>? = null,
+  ): Flow<Media> =
+    channelFlow {
+      query(readOnly = true) {
+        MediaTable
+          .join(FolderMediaTable, JoinType.LEFT, MediaTable.id, FolderMediaTable.mediaId)
+          .selectAll()
+          .where { FolderMediaTable.mediaId.isNull() and (MediaTable.deleted eq false) }
+          .apply { filter?.let { andWhere(it) } }
+          .apply { sort?.let { orderBy(*it.toTypedArray()) } }
+          .limit(limit)
+          .offset(offset)
+          .forEach { row -> send(row.decode()) }
+      }
     }
 }

--- a/src/main/resources/db/migration/V5__Add_Folders.sql
+++ b/src/main/resources/db/migration/V5__Add_Folders.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS pb_folders (
+  id VARCHAR(255) PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  parent_id VARCHAR(255) REFERENCES pb_folders(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE NULLS NOT DISTINCT (parent_id, name)
+  );
+
+CREATE INDEX idx_folder_parent ON pb_folders(parent_id);
+
+CREATE RECURSIVE VIEW v_folder_ancestors (
+    descendant_id, id, name, parent_id, created_at, updated_at, depth
+) AS
+    SELECT id, id, name, parent_id, created_at, updated_at, 1
+    FROM pb_folders
+
+    UNION ALL
+
+    SELECT v.descendant_id, f.id, f.name, f.parent_id, f.created_at, f.updated_at, v.depth + 1
+    FROM pb_folders f
+    JOIN v_folder_ancestors v ON f.id = v.parent_id;
+
+CREATE TABLE IF NOT EXISTS pb_folder_media (
+  folder_id  VARCHAR(255) NOT NULL REFERENCES pb_folders(id) ON DELETE CASCADE,
+  media_id   VARCHAR(255) NOT NULL REFERENCES pb_media(id) ON DELETE CASCADE,
+  added_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+  PRIMARY KEY (media_id)
+);

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManangerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/SessionManangerTest.kt
@@ -3,8 +3,6 @@ package ch.srgssr.pillarbox.backend.auth
 import ch.srgssr.pillarbox.backend.domain.model.Session
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
 import ch.srgssr.pillarbox.backend.test.buildJwt
-import com.auth0.jwt.JWT
-import com.auth0.jwt.algorithms.Algorithm
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.nulls.shouldBeNull

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/FolderRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/FolderRouteTest.kt
@@ -1,0 +1,369 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web
+
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
+import ch.srgssr.pillarbox.backend.test.token
+import ch.srgssr.pillarbox.backend.test.tokenWithRoles
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+
+class FolderRouteTest :
+  ShouldSpec({
+    should("return an empty list if no folders are stored") {
+      testApplicationContext {
+        val response = client.get("/v1/folder") { bearerAuth(token) }
+
+        response shouldHaveStatus HttpStatusCode.OK
+        response.body<List<FolderResponseV1>>().shouldBeEmpty()
+      }
+    }
+
+    should("create, update and delete a folder") {
+      testApplicationContext {
+        val request = FolderRequestV1(name = "Test Folder")
+
+        val created =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(request)
+            }.also { it shouldHaveStatus HttpStatusCode.Created }
+            .body<FolderResponseV1>()
+
+        created.name shouldBe request.name
+
+        client.patch("/v1/folder/${created.id}") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(FolderRequestV1(name = "Renamed Folder"))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client
+          .get("/v1/folder/${created.id}") {
+            bearerAuth(token)
+          }.body<FolderResponseV1>()
+          .name shouldBe "Renamed Folder"
+
+        client.delete("/v1/folder/${created.id}") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NoContent
+
+        client.get("/v1/folder/${created.id}") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return paginated folders correctly") {
+      testApplicationContext {
+        repeat(20) {
+          client.post("/v1/folder") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(FolderRequestV1(name = "Test Folder $it"))
+          } shouldHaveStatus HttpStatusCode.Created
+        }
+
+        client.getFolderPageV1(limit = 5, offset = 0) { bearerAuth(token) }.size shouldBe 5
+        client.getFolderPageV1(limit = 1, offset = 5) { bearerAuth(token) }.size shouldBe 1
+        client.getFolderPageV1(limit = 1, offset = 20) { bearerAuth(token) }.size shouldBe 0
+      }
+    }
+
+    should("filter by parent id child folders") {
+      testApplicationContext {
+        val parent =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Parent Folder"))
+            }.also { it shouldHaveStatus HttpStatusCode.Created }
+            .body<FolderResponseV1>()
+
+        repeat(5) {
+          client.post("/v1/folder") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(FolderRequestV1(name = "Test Folder $it", parentId = parent.id))
+          } shouldHaveStatus HttpStatusCode.Created
+        }
+
+        val folders =
+          client
+            .get("/v1/folder") {
+              bearerAuth(token)
+              url {
+                parameters.append("parentId", parent.id)
+              }
+            }.body<List<FolderResponseV1>>()
+
+        folders.size shouldBe 5
+      }
+    }
+
+    should("return NOT_FOUND when getting a non-existent folder") {
+      testApplicationContext {
+        client.get("/v1/folder/does-not-exist") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return NOT_FOUND when getting media for a non-existent folder") {
+      testApplicationContext {
+        client.get("/v1/folder/does-not-exist/media") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return NOT_FOUND when patching a non-existent folder") {
+      testApplicationContext {
+        client.patch("/v1/folder/does-not-exist") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(FolderRequestV1(name = "Test Folder"))
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return NOT_FOUND when deleting a non-existent folder") {
+      testApplicationContext {
+        client.delete("/v1/folder/does-not-exist") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("assign a media to a folder and list it") {
+      testApplicationContext {
+        val folder =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Test Folder"))
+            }.body<FolderResponseV1>()
+
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.post("/v1/folder/${folder.id}/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = media.id))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val folderMedia =
+          client
+            .get("/v1/folder/${folder.id}/media") { bearerAuth(token) }
+            .body<List<MediaResponseV1>>()
+
+        folderMedia.size shouldBe 1
+        folderMedia.first().id shouldBe media.id
+      }
+    }
+
+    should("remove a media assignment from a folder") {
+      testApplicationContext {
+        val folder =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Test Folder"))
+            }.body<FolderResponseV1>()
+
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.post("/v1/folder/${folder.id}/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = media.id))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.delete("/v1/folder/${folder.id}/media/${media.id}") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NoContent
+
+        client
+          .get("/v1/folder/${folder.id}/media") { bearerAuth(token) }
+          .body<List<MediaResponseV1>>()
+          .shouldBeEmpty()
+      }
+    }
+
+    should("return NOT_FOUND when assigning media to a non-existent folder") {
+      testApplicationContext {
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.post("/v1/folder/does-not-exist/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = media.id))
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return UNPROCESSABLE_ENTITY when assigning a non-existent media to a folder") {
+      testApplicationContext {
+        val folder =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Test Folder"))
+            }.body<FolderResponseV1>()
+
+        client.post("/v1/folder/${folder.id}/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = "non-existent-media"))
+        } shouldHaveStatus HttpStatusCode.UnprocessableEntity
+      }
+    }
+
+    should("return NOT_FOUND when removing media from a non-existent folder") {
+      testApplicationContext {
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.delete("/v1/folder/does-not-exist/media/${media.id}") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return NOT_FOUND when removing a non-existent media from a folder") {
+      testApplicationContext {
+        val folder =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Test Folder"))
+            }.body<FolderResponseV1>()
+
+        client.delete("/v1/folder/${folder.id}/media/does-not-exist") {
+          bearerAuth(token)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return 401 on all endpoints when no token is provided") {
+      testApplicationContext {
+        client.get("/v1/folder") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.get("/v1/folder/any-id") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.get("/v1/folder/any-id/media") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.post("/v1/folder") { contentType(ContentType.Application.Json) } shouldHaveStatus
+          HttpStatusCode.Unauthorized
+        client.patch("/v1/folder/any-id") { contentType(ContentType.Application.Json) } shouldHaveStatus
+          HttpStatusCode.Unauthorized
+        client.delete("/v1/folder/any-id") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.post("/v1/folder/any-id/media") { contentType(ContentType.Application.Json) } shouldHaveStatus
+          HttpStatusCode.Unauthorized
+        client.delete("/v1/folder/any-id/media/any-media-id") shouldHaveStatus HttpStatusCode.Unauthorized
+      }
+    }
+
+    should("allow read access but return 403 on write endpoints when authenticated with no roles") {
+      testApplicationContext {
+        val t = tokenWithRoles(emptySet())
+
+        client.get("/v1/folder") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/folder/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.NotFound
+        client.get("/v1/folder/any-id/media") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.NotFound
+        client.post("/v1/folder") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+          setBody(FolderRequestV1(name = "Test Folder"))
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.patch("/v1/folder/any-id") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+          setBody(FolderRequestV1(name = "Test Folder"))
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/folder/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/folder/any-id/media") {
+          bearerAuth(t)
+          contentType(ContentType.Application.Json)
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/folder/any-id/media/any-media-id") { bearerAuth(t) } shouldHaveStatus
+          HttpStatusCode.Forbidden
+      }
+    }
+
+    should("allow WRITE token to access all endpoints") {
+      testApplicationContext {
+        val folder =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Test Folder"))
+            }.body<FolderResponseV1>()
+
+        client.get("/v1/folder") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/folder/${folder.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/folder/${folder.id}/media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.patch("/v1/folder/${folder.id}") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(FolderRequestV1(name = "Updated"))
+        } shouldHaveStatus HttpStatusCode.Created
+        client.delete("/v1/folder/${folder.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.NoContent
+      }
+    }
+  })
+
+suspend fun HttpClient.getFolderPageV1(
+  limit: Int,
+  offset: Int,
+  block: HttpRequestBuilder.() -> Unit = {},
+): List<FolderResponseV1> =
+  get("/v1/folder") {
+    url {
+      parameters.append("limit", limit.toString())
+      parameters.append("offset", offset.toString())
+    }
+    block()
+  }.body()


### PR DESCRIPTION
## Description

Introduces a folder system for organizing media items into a tree-structured hierarchy. Folders support arbitrary nesting via a self-referencing parent relationship, with a unique constraint on `parent_id`, `name` to prevent duplicate sibling names at the schema level.

Media to folder assignment is modelled as a separate junction table `pb_folder_media` rather than a foreign key on the media row. This keeps media independent of the folder lifecycle (i.e. deleting a folder does not cascade to its media) while the primary key on media_id enforces a single-folder-per-item invariant at the database level.

A recursive SQL view `v_folder_ancestors` resolves the full ancestor chain for any folder in a single query, avoiding iterative application-level traversal when building breadcrumb paths.

The new `/v1/folder` API exposes full CRUD under the existing authentication rules and a new `/v1/player/folder` endpoint allows filtering by folder on the public API.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
