### PR TITLE
fix(auth): map roles as a root claim

### DIFF
--- a/keycloak/pillarbox-realm.json
+++ b/keycloak/pillarbox-realm.json
@@ -1,13 +1,8 @@
 {
   "realm": "pillarbox",
   "enabled": true,
-  "defaultRole": {
-    "name": "PillarboxDemo.Read",
-    "description": "Default role assigned to all new users"
-  },
   "roles": {
     "realm": [
-      { "name": "PillarboxDemo.Read", "description": "Read-only access" },
       { "name": "PillarboxDemo.Write", "description": "Can create and modify content" },
       { "name": "PillarboxDemo.Admin", "description": "Unrestricted access" }
     ]
@@ -38,7 +33,7 @@
           "protocol": "openid-connect",
           "protocolMapper": "oidc-usermodel-realm-role-mapper",
           "config": {
-            "claim.name": "realm_access.roles",
+            "claim.name": "roles",
             "jsonType.label": "String",
             "multivalued": "true",
             "id.token.claim": "false",
@@ -60,7 +55,7 @@
       "credentials": [
         { "type": "password", "value": "password", "temporary": false }
       ],
-      "realmRoles": ["PillarboxDemo.Read"]
+      "realmRoles": []
     },
     {
       "username": "editor",
@@ -72,7 +67,7 @@
       "credentials": [
         { "type": "password", "value": "password", "temporary": false }
       ],
-      "realmRoles": ["PillarboxDemo.Read", "PillarboxDemo.Write"]
+      "realmRoles": ["PillarboxDemo.Write"]
     },
     {
       "username": "admin",
@@ -84,7 +79,7 @@
       "credentials": [
         { "type": "password", "value": "password", "temporary": false }
       ],
-      "realmRoles": ["PillarboxDemo.Read", "PillarboxDemo.Write", "PillarboxDemo.Admin"]
+      "realmRoles": ["PillarboxDemo.Admin"]
     }
   ]
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensions.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensions.kt
@@ -13,16 +13,13 @@ val Payload.displayName: String
     getClaim("name")?.asString() ?: subject
 
 /**
- * Extracts Pillarbox [Role]s from a JWT [Payload] by reading the `realm_access.roles` claim.
+ * Extracts Pillarbox [Role]s from a JWT [Payload] by reading the `roles` claim.
  *
  * @return an empty set when the claim is absent or contains no recognisable role names.
  */
-@Suppress("UNCHECKED_CAST")
 val Payload.roles: Set<Role>
   get() =
-    (
-      getClaim("realm_access")
-        ?.asMap()
-        ?.get("roles") as? List<String>
-    )?.mapNotNull { it.toRole() }
+    getClaim("roles")
+      ?.asList(String::class.java)
+      ?.mapNotNull { it.toRole() }
       ?.toSet() ?: emptySet()

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/User.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/User.kt
@@ -37,26 +37,40 @@ data class User(
         .mapNotNull { it.firstOrNull()?.uppercaseChar() }
         .joinToString("")
 
-  fun hasAnyRole(required: Set<Role>): Boolean = roles.any { it in required }
+  /**
+   * Returns `true` if this user holds, directly or through role
+   * hierarchy, at least one of the [required] roles.
+   *
+   * @param required The set of roles that grant access to a resource.
+   */
+  fun hasAnyRole(required: Set<Role>): Boolean = roles.any { role -> role.effectiveRoles.any { it in required } }
 }
 
 /**
  * Defines the access roles for the Pillarbox Demo backend.
  *
- * Each entry maps to an app role using the `PillarboxDemo.{Level}` naming convention
- * (e.g., `PillarboxDemo.Read`).
+ * Roles form a directed hierarchy: each role may imply one or more
+ * lower-level roles. Use [effectiveRoles] to obtain the full set
+ * of permissions a role grants.
+ *
+ * Each entry maps to an app role using the `PillarboxDemo.{Level}`
+ * naming convention (e.g., `PillarboxDemo.Write`).
  */
-enum class Role {
-  /** Read-only access. */
-  READ,
-
+enum class Role(
+  impliedRoles: Set<Role> = emptySet(),
+) {
   /** Read and write access. */
   WRITE,
 
-  /** Full administrative access. */
-  ADMIN,
-
+  /** Full administrative access; implies [WRITE]. */
+  ADMIN(impliedRoles = setOf(WRITE)),
   ;
+
+  /**
+   * The complete set of roles granted by holding this role,
+   * including this role itself and all implied roles.
+   */
+  val effectiveRoles: Set<Role> = setOf(this) + impliedRoles
 
   /** The app role key, following the `PillarboxDemo.{Level}` convention. */
   val key = "PillarboxDemo.${name.lowercase().replaceFirstChar { it.uppercase() }}"
@@ -65,7 +79,7 @@ enum class Role {
     /**
      * Finds a [Role] entry matching the given app role [key].
      *
-     * @param key The app role key (e.g., `PillarboxDemo.Read`).
+     * @param key The app role key (e.g., `PillarboxDemo.Write`).
      *
      * @return The matching [Role], or `null` if no match is found.
      */

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
@@ -43,59 +43,55 @@ fun Route.console(mediaRepository: MediaRepository) {
   authenticate("pillarbox-session") {
     install(AuthenticatedUserPlugin)
 
-    withRole(Role.READ) {
-      staticResources("/static", "static")
-    }
+    staticResources("/static", "static")
 
     route(Navigation.CONSOLE) {
-      withRole(Role.READ) {
-        get {
-          call.respondWithContext("modules/home/home.page.peb")
-        }
+      get {
+        call.respondWithContext("modules/home/home.page.peb")
+      }
 
-        get("bin") {
-          call.respondWithContext(
-            "modules/home/home.page.peb",
-            mapOf("deleted" to true),
+      get("bin") {
+        call.respondWithContext(
+          "modules/home/home.page.peb",
+          mapOf("deleted" to true),
+        )
+      }
+
+      hx.get("media") {
+        val page = call.parameters["page"]?.toIntOrNull() ?: 0
+        val pageSize = call.parameters["pageSize"]?.toIntOrNull() ?: 15
+        val deleted = call.parameters["deleted"] == "true"
+        val offset = (page * pageSize).toLong()
+
+        logger.debug { "Fetching media grid: page=$page, pageSize=$pageSize, offset=$offset" }
+
+        val result =
+          mediaRepository.getAllPaginated(
+            limit = pageSize,
+            offset = offset,
+            filter = { MediaTable.deleted eq deleted },
           )
-        }
 
-        hx.get("media") {
-          val page = call.parameters["page"]?.toIntOrNull() ?: 0
-          val pageSize = call.parameters["pageSize"]?.toIntOrNull() ?: 15
-          val deleted = call.parameters["deleted"] == "true"
-          val offset = (page * pageSize).toLong()
+        call.respondWithContext(
+          "shared/fragments/media-grid.fragment.peb",
+          mapOf(
+            "result" to result,
+            "nextPage" to page + 1,
+            "deleted" to deleted,
+          ),
+        )
+      }
 
-          logger.debug { "Fetching media grid: page=$page, pageSize=$pageSize, offset=$offset" }
+      get("media/editor/{id?}") {
+        val media =
+          call.parameters["id"]
+            ?.let { mediaRepository.find(it) }
+            ?.also { logger.debug { "Opening editor for media: $it" } }
 
-          val result =
-            mediaRepository.getAllPaginated(
-              limit = pageSize,
-              offset = offset,
-              filter = { MediaTable.deleted eq deleted },
-            )
-
-          call.respondWithContext(
-            "shared/fragments/media-grid.fragment.peb",
-            mapOf(
-              "result" to result,
-              "nextPage" to page + 1,
-              "deleted" to deleted,
-            ),
-          )
-        }
-
-        get("media/editor/{id?}") {
-          val media =
-            call.parameters["id"]
-              ?.let { mediaRepository.find(it) }
-              ?.also { logger.debug { "Opening editor for media: $it" } }
-
-          call.respondWithContext(
-            "modules/media/editor.page.peb",
-            media?.let { mapOf("item" to media) }.orEmpty(),
-          )
-        }
+        call.respondWithContext(
+          "modules/media/editor.page.peb",
+          media?.let { mapOf("item" to media) }.orEmpty(),
+        )
       }
 
       withRole(Role.WRITE) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
@@ -45,26 +45,25 @@ inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.me
   crossinline toResponse: (Media) -> Res,
   crossinline applyTags: (TagReq, List<String>) -> List<String>,
 ) {
-  withRole(Role.READ) {
-    get {
-      val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 20
-      val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
-      val mediaFlow = mediaRepository.getAll(limit, offset, filter = { MediaTable.deleted eq false })
+  get {
+    val limit = call.request.queryParameters["limit"]?.toIntOrNull() ?: 20
+    val offset = call.request.queryParameters["offset"]?.toLongOrNull() ?: 0L
+    val mediaFlow = mediaRepository.getAll(limit, offset, filter = { MediaTable.deleted eq false })
 
-      call.respond(mediaFlow.map { toResponse(it) }.toList())
-    }
-
-    get("/{id}") {
-      val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
-
-      val media =
-        mediaRepository.findOne {
-          (MediaTable.id eq id) and (MediaTable.deleted eq false)
-        } ?: return@get call.respond(HttpStatusCode.NotFound)
-
-      call.respond(toResponse(media))
-    }
+    call.respond(mediaFlow.map { toResponse(it) }.toList())
   }
+
+  get("/{id}") {
+    val id = call.parameters["id"] ?: return@get call.respond(HttpStatusCode.BadRequest)
+
+    val media =
+      mediaRepository.findOne {
+        (MediaTable.id eq id) and (MediaTable.deleted eq false)
+      } ?: return@get call.respond(HttpStatusCode.NotFound)
+
+    call.respond(toResponse(media))
+  }
+
   withRole(Role.WRITE) {
     post {
       val dto = call.receive<Req>()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensionsTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/PayloadExtensionsTest.kt
@@ -11,13 +11,13 @@ import io.kotest.matchers.shouldBe
 
 class PayloadExtensionsTest :
   ShouldSpec({
-    should("parse READ and WRITE roles from realm_access claim") {
-      val payload = JWT.decode(buildJwt(subject = "sub", roles = setOf(Role.READ, Role.WRITE)))
+    should("parse WRITE role from roles claim") {
+      val payload = JWT.decode(buildJwt(subject = "sub", roles = setOf(Role.WRITE)))
 
-      payload.roles shouldBe setOf(Role.READ, Role.WRITE)
+      payload.roles shouldBe setOf(Role.WRITE)
     }
 
-    should("produce empty role set when realm_access claim is absent") {
+    should("produce empty role set when roles claim is absent") {
       val payload = JWT.decode(buildJwt(subject = "sub"))
 
       payload.roles.shouldBeEmpty()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/UserManagerTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/auth/UserManagerTest.kt
@@ -28,16 +28,16 @@ class UserManagerTest :
       coVerify { repository.save(match { it.oidcSub == "test-sub" && it.displayName == "test-sub" }) }
     }
 
-    should("parse roles from realm_access claim") {
+    should("parse roles from roles claim") {
       val repository = mockk<UserRepository>(relaxed = true)
-      val payload = JWT.decode(buildJwt(subject = "test-sub", roles = setOf(Role.READ, Role.WRITE)))
+      val payload = JWT.decode(buildJwt(subject = "test-sub", roles = setOf(Role.ADMIN)))
 
       UserManager(repository).upsert(payload)
 
-      coVerify { repository.save(match { it.roles == setOf(Role.READ, Role.WRITE) }) }
+      coVerify { repository.save(match { it.roles == setOf(Role.ADMIN) }) }
     }
 
-    should("produce empty role set when realm_access claim is absent") {
+    should("produce empty role set when roles claim is absent") {
       val repository = mockk<UserRepository>(relaxed = true)
       val payload = JWT.decode(buildJwt(subject = "test-sub"))
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/domain/model/UserTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/domain/model/UserTest.kt
@@ -6,25 +6,30 @@ import io.kotest.matchers.booleans.shouldBeTrue
 
 class UserTest :
   ShouldSpec({
-    val readOnlyUser = User(oidcSub = "sub", displayName = "User", roles = setOf(Role.READ))
+    val editorUser = User(oidcSub = "sub", displayName = "User", roles = setOf(Role.WRITE))
+    val adminUser = User(oidcSub = "sub", displayName = "User", roles = setOf(Role.ADMIN))
 
     should("return true when user holds the required role") {
-      readOnlyUser.hasAnyRole(setOf(Role.READ)).shouldBeTrue()
+      editorUser.hasAnyRole(setOf(Role.WRITE)).shouldBeTrue()
     }
 
     should("return true when user holds one of several required roles") {
-      readOnlyUser.hasAnyRole(setOf(Role.READ, Role.WRITE)).shouldBeTrue()
+      editorUser.hasAnyRole(setOf(Role.ADMIN, Role.WRITE)).shouldBeTrue()
     }
 
     should("return false when user holds none of the required roles") {
-      readOnlyUser.hasAnyRole(setOf(Role.WRITE)).shouldBeFalse()
+      editorUser.hasAnyRole(setOf(Role.ADMIN)).shouldBeFalse()
     }
 
     should("return false when required roles set is empty") {
-      readOnlyUser.hasAnyRole(emptySet()).shouldBeFalse()
+      editorUser.hasAnyRole(emptySet()).shouldBeFalse()
     }
 
     should("return false when user has no roles") {
-      User(oidcSub = "sub", displayName = "User").hasAnyRole(setOf(Role.READ)).shouldBeFalse()
+      User(oidcSub = "sub", displayName = "User").hasAnyRole(setOf(Role.WRITE)).shouldBeFalse()
+    }
+
+    should("return true when the user holds an implied role") {
+      adminUser.hasAnyRole(setOf(Role.WRITE)).shouldBeTrue()
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRouteTest.kt
@@ -10,8 +10,6 @@ import ch.srgssr.pillarbox.backend.test.hxGet
 import ch.srgssr.pillarbox.backend.test.hxPost
 import ch.srgssr.pillarbox.backend.test.login
 import ch.srgssr.pillarbox.backend.test.mediaFixture
-import ch.srgssr.pillarbox.backend.test.noRoles
-import ch.srgssr.pillarbox.backend.test.readOnlyRoles
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
@@ -38,26 +36,18 @@ class ConsoleRouteTest :
       }
     }
 
-    should("allow READ user to access read-only routes") {
+    should("allow read access but return 403 on write endpoints when authenticated with no roles") {
       testApplicationContext {
-        login(roles = readOnlyRoles)
+        login(roles = emptySet())
+
+        client.hxPost("${Navigation.CONSOLE}/media") {
+          contentType(ContentType.Application.Json)
+          setBody(mediaFixture())
+        } shouldHaveStatus HttpStatusCode.Forbidden
 
         client.get(Navigation.CONSOLE) shouldHaveStatus HttpStatusCode.OK
         client.get("${Navigation.CONSOLE}/bin") shouldHaveStatus HttpStatusCode.OK
         client.hxGet("${Navigation.CONSOLE}/media") shouldHaveStatus HttpStatusCode.OK
-        client.get("${Navigation.CONSOLE}/media/editor/") shouldHaveStatus HttpStatusCode.OK
-      }
-    }
-
-    should("forbid READ user from write routes") {
-      testApplicationContext {
-        login(roles = readOnlyRoles)
-
-        client.hxPost("${Navigation.CONSOLE}/media") {
-          contentType(ContentType.Application.Json)
-          setBody(mediaFixture())
-        } shouldHaveStatus HttpStatusCode.Forbidden
-
         client.hxDelete("${Navigation.CONSOLE}/media/any-id") shouldHaveStatus HttpStatusCode.Forbidden
         client.hxPost("${Navigation.CONSOLE}/media/any-id/restore") shouldHaveStatus HttpStatusCode.Forbidden
         client.get("${Navigation.CONSOLE}/media/editor/any-id/duplicate") shouldHaveStatus HttpStatusCode.Forbidden
@@ -65,32 +55,13 @@ class ConsoleRouteTest :
       }
     }
 
-    should("allow READ+WRITE user to access all console routes") {
+    should("allow WRITE user to access all console routes") {
       testApplicationContext {
-        login(roles = setOf(Role.READ, Role.WRITE))
+        login(roles = setOf(Role.WRITE))
 
         client.get(Navigation.CONSOLE) shouldHaveStatus HttpStatusCode.OK
         client.hxGet("${Navigation.CONSOLE}/media") shouldHaveStatus HttpStatusCode.OK
         client.hxGet("${Navigation.CONSOLE}/media/editor/fragments/chapter") shouldHaveStatus HttpStatusCode.OK
-      }
-    }
-
-    should("forbid user with no roles from all console routes") {
-      testApplicationContext {
-        login(roles = noRoles)
-
-        client.get(Navigation.CONSOLE) shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("${Navigation.CONSOLE}/bin") shouldHaveStatus HttpStatusCode.Forbidden
-        client.hxGet("${Navigation.CONSOLE}/media") shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("${Navigation.CONSOLE}/media/editor/") shouldHaveStatus HttpStatusCode.Forbidden
-        client.hxPost("${Navigation.CONSOLE}/media") {
-          contentType(ContentType.Application.Json)
-          setBody(mediaFixture())
-        } shouldHaveStatus HttpStatusCode.Forbidden
-        client.hxDelete("${Navigation.CONSOLE}/media/any-id") shouldHaveStatus HttpStatusCode.Forbidden
-        client.hxPost("${Navigation.CONSOLE}/media/any-id/restore") shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("${Navigation.CONSOLE}/media/editor/any-id/duplicate") shouldHaveStatus HttpStatusCode.Forbidden
-        client.hxGet("${Navigation.CONSOLE}/media/editor/fragments/chapter") shouldHaveStatus HttpStatusCode.Forbidden
       }
     }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRouteTest.kt
@@ -5,8 +5,6 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagActionV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagOperationV1
 import ch.srgssr.pillarbox.backend.test.mediaFixture
-import ch.srgssr.pillarbox.backend.test.noRoles
-import ch.srgssr.pillarbox.backend.test.readOnlyRoles
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
 import ch.srgssr.pillarbox.backend.test.token
@@ -214,12 +212,12 @@ class MediaRouteTest :
       }
     }
 
-    should("return 403 on all endpoints when token has no roles") {
+    should("allow read access but return 403 on write endpoints when authenticated with no roles") {
       testApplicationContext {
-        val t = tokenWithRoles(noRoles)
+        val t = tokenWithRoles(emptySet())
 
-        client.get("/v1/media") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/media/any-media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.NotFound
         client.post("/v1/media") {
           bearerAuth(t)
           contentType(ContentType.Application.Json)
@@ -234,34 +232,7 @@ class MediaRouteTest :
       }
     }
 
-    should("allow READ role to access GET endpoints") {
-      testApplicationContext {
-        val t = tokenWithRoles(readOnlyRoles)
-
-        client.get("/v1/media") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.OK
-        client.get("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.NotFound
-      }
-    }
-
-    should("return 403 on write endpoints when token has READ role only") {
-      testApplicationContext {
-        val t = tokenWithRoles(readOnlyRoles)
-
-        client.post("/v1/media") {
-          bearerAuth(t)
-          contentType(ContentType.Application.Json)
-          setBody(mediaFixture().toMediaRequestV1())
-        } shouldHaveStatus HttpStatusCode.Forbidden
-        client.patch("/v1/media/any-id/tags") {
-          bearerAuth(t)
-          contentType(ContentType.Application.Json)
-        } shouldHaveStatus HttpStatusCode.Forbidden
-        client.delete("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.post("/v1/media/any-id/restore") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
-      }
-    }
-
-    should("allow READ+WRITE token to access all endpoints") {
+    should("allow WRITE token to access all endpoints") {
       testApplicationContext {
         val fixture = mediaFixture { id = "auth-test-id" }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MockOAuthUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MockOAuthUtils.kt
@@ -19,7 +19,7 @@ fun buildJwtWithRoleList(
     .let { if (name != null) it.withClaim("name", name) else it }
     .let {
       if (roles.isNotEmpty()) {
-        it.withClaim("realm_access", mapOf("roles" to roles))
+        it.withClaim("roles", roles)
       } else {
         it
       }

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -2,7 +2,6 @@ package ch.srgssr.pillarbox.backend.test
 
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.Navigation
-import com.nimbusds.oauth2.sdk.TokenRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.cookies.HttpCookies
@@ -15,17 +14,13 @@ import io.ktor.server.testing.testApplication
 import io.ktor.util.AttributeKey
 import kotlinx.serialization.json.Json
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.security.mock.oauth2.OAuth2Config
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 
-val readOnlyRoles: Set<Role> = setOf(Role.READ)
-val readWriteRoles: Set<Role> = setOf(Role.READ, Role.WRITE)
-val noRoles: Set<Role> = emptySet()
+val writeRoles: Set<Role> = setOf(Role.WRITE)
 
 /**
  * Executes an integration test within a managed Ktor application environment.
@@ -95,22 +90,22 @@ val ApplicationTestBuilder.mockServer: MockOAuth2Server
       ?: error("MockOAuth2Server not found in application attributes.")
 
 val ApplicationTestBuilder.token: String
-  get() = tokenWithRoles(readWriteRoles)
+  get() = tokenWithRoles(writeRoles)
 
 fun ApplicationTestBuilder.tokenWithRoles(roles: Set<Role>): String =
   mockServer
     .issueToken(
       issuerId = "pillarbox-realm",
       audience = "pillarbox-test-client",
-      claims = mapOf("realm_access" to mapOf("roles" to roles.map { it.key })),
+      claims = mapOf("roles" to roles.map { it.key }),
     ).serialize()
 
-suspend fun ApplicationTestBuilder.login(roles: Set<Role> = readWriteRoles): HttpResponse {
+suspend fun ApplicationTestBuilder.login(roles: Set<Role> = writeRoles): HttpResponse {
   mockServer.enqueueCallback(
     DefaultOAuth2TokenCallback(
       issuerId = "pillarbox-realm",
       subject = "dev-user",
-      claims = mapOf("realm_access" to mapOf("roles" to roles.map { it.key })),
+      claims = mapOf("roles" to roles.map { it.key }),
     ),
   )
 


### PR DESCRIPTION
## Description

The keycloak configuration was nesting roles under `realm_access.roles` while in production Azure places them in a flat `roles` array at the JWT root. As part of this cleanup the role model has been simplified: the explicit `PillarboxDemo.Read` role has been removed and read access is now implicit for all authenticated users

## Changes Made

- Changed the Keycloak realm-roles-mapper `claim.name` from `realm_access.roles` to `roles` so both identity providers use the same flat claim.
- Changed the mapping of the payload in the application.
- `withRole(READ)` guards have been dropped from both the Management API and the web console.
- Roles now support a directed hierarchy through an optional impliedRoles parameter. `ADMIN` implicitly grants `WRITE` via this mechanism.
- Keycloak realm updated to reflect both changes: the `PillarboxDemo.Read` defaultRole is removed and users carry only their highest explicit role.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
