### PR TITLE
fix(auth): make OIDC scopes configurable and fix role display in console

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,9 @@ AUTH_CLIENT_ID=pillarbox-api
 # Mandatory for Confidential Clients. Leave empty for Public Clients.
 AUTH_CLIENT_SECRET=
 
+# Comma-separated OIDC scopes.
+AUTH_SCOPES=openid,profile,email
+
 # --- Session Configuration ---
 
 # The secret key used to sign the session cookie.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -205,6 +205,7 @@ tasks.named<JavaExec>("run") {
   environment("AUTH_DISCOVERY_PATH", getEnv("AUTH_DISCOVERY_PATH", ".well-known/openid-configuration"))
   environment("AUTH_CLIENT_ID", getEnv("AUTH_CLIENT_ID", "pillarbox-api"))
   environment("AUTH_CLIENT_SECRET", getEnv("AUTH_CLIENT_SECRET", ""))
+  environment("AUTH_SCOPES", getEnv("AUTH_SCOPES", "openid,profile,email"))
 
   // --- Session ---
   environment("SESSION_COOKIE_SECRET", getEnv("SESSION_COOKIE_SECRET", "dev-secret-at-least-32-chars-long-!!!"))

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthConfig.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.Transient
  * @property clientId The unique identifier for the application (audience).
  * @property clientSecret The secret key used for server-side token exchange.
  * @property realm The authentication realm used in the challenge header.
+ * @property scopes The OIDC scopes requested during authorization. Defaults to `openid`, `profile`, and `email`
  */
 data class AuthConfig(
   val issuer: String,
@@ -20,6 +21,7 @@ data class AuthConfig(
   val clientId: String,
   val clientSecret: String,
   val realm: String,
+  val scopes: List<String> = listOf("openid", "profile", "email"),
 ) {
   val discoveryUrl: String = "$issuer/$discoveryPath"
 }
@@ -50,5 +52,13 @@ fun ApplicationConfig.toAuthConfig(): AuthConfig {
     clientId = auth.property("client_id").getString(),
     clientSecret = auth.propertyOrNull("secret")?.getString() ?: "",
     realm = auth.property("realm").getString(),
+    scopes =
+      auth
+        .propertyOrNull("scopes")
+        ?.getString()
+        ?.split(",")
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?: listOf("openid", "profile", "email"),
   )
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationModule.kt
@@ -52,12 +52,6 @@ fun authenticationModule() =
     }
 
     single {
-      val auth = get<AuthConfig>()
-
-      AuthenticationPolicy(
-        clientId = auth.clientId,
-        clientSecret = auth.clientSecret,
-        discovery = get(),
-      )
+      AuthenticationPolicy(authConfig = get(), discovery = get())
     }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/auth/AuthenticationPolicy.kt
@@ -15,13 +15,11 @@ import java.net.URI
  * Manages authentication policies, providing configuration for OAuth2 settings
  * and JWT validation logic based on OpenID Connect discovery.
  *
- * @property clientId The unique identifier for the client application.
- * @property clientSecret The secret key used for authenticating the client with the identity provider.
+ * @property authConfig The application's OIDC credentials, used for client authentication.
  * @property discovery The [OpenIDDiscovery] containing provider-specific endpoints and metadata.
  */
 class AuthenticationPolicy(
-  val clientId: String,
-  val clientSecret: String,
+  val authConfig: AuthConfig,
   val discovery: OpenIDDiscovery,
 ) {
   companion object {
@@ -36,7 +34,6 @@ class AuthenticationPolicy(
 
   /**
    * Constructs the [OAuthServerSettings.OAuth2ServerSettings] required for Ktor's OAuth feature.
-   * * Defaults to using [HttpMethod.Post] for token requests and requests standard OpenID scopes.
    *
    * @param name A descriptive name for the OAuth setting.
    * @return A configured OAuth2 server setting instance.
@@ -46,11 +43,11 @@ class AuthenticationPolicy(
       name = name,
       authorizeUrl = discovery.authorizationEndpoint,
       accessTokenUrl = discovery.tokenEndpoint,
-      clientId = clientId,
-      clientSecret = clientSecret,
+      clientId = authConfig.clientId,
+      clientSecret = authConfig.clientSecret,
       accessTokenRequiresBasicAuth = false,
       requestMethod = HttpMethod.Post,
-      defaultScopes = listOf("openid", "profile", "email"),
+      defaultScopes = authConfig.scopes,
     )
 
   /**
@@ -61,10 +58,10 @@ class AuthenticationPolicy(
    * @return A [User] if validation passes; null if the audience is invalid.
    */
   fun verifyJwt(credential: JWTCredential): User? {
-    if (!credential.payload.audience.contains(clientId)) {
+    if (!credential.payload.audience.contains(authConfig.clientId)) {
       logger.warn {
         "JWT verification failed: Audience mismatch. " +
-          "Expected: $clientId, Found: ${credential.payload.audience}. " +
+          "Expected: ${authConfig.clientId}, Found: ${credential.payload.audience}. " +
           "Subject: ${credential.payload.subject}"
       }
       return null

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/ConsoleRoute.kt
@@ -173,7 +173,11 @@ fun ApplicationCall.userContext(): Map<String, Any> =
       UserView(
         name = user.displayName,
         initials = user.initials,
-        roles = user.roles.map { it.name },
+        roles =
+          user.roles
+            .flatMap { it.effectiveRoles }
+            .map { it.name }
+            .distinct(),
       ),
   )
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -32,11 +32,13 @@ database {
 
 oidc {
   issuer = ${?AUTH_ISSUER}
-  discovery_url = ".well-known/openid-configuration"
-  discovery_url = ${?AUTH_DISCOVERY_PATH}
+  discovery_path = ".well-known/openid-configuration"
+  discovery_path = ${?AUTH_DISCOVERY_PATH}
   client_id = ${?AUTH_CLIENT_ID}
   secret = ${?AUTH_CLIENT_SECRET}
   realm = "Pillarbox"
+  scopes = "openid,profile,email"
+  scopes = ${?AUTH_SCOPES}
 }
 
 session {


### PR DESCRIPTION
## Description

Azure requires a dedicated scope to include role claims in the access token, while the local Keycloak setup does not. The scopes were previously hardcoded, so they needed to be made configurable per environment.

## Changes Made

- Add `AUTH_SCOPES` env var wired through `application.conf` and `AuthConfig`.
- Default to `openid,profile,email` so the local environment requires no config change.
- Refactor `AuthenticationPolicy` to accept `AuthConfig` instead of individual fields.
- Fix user context in the console Pebble template by sending the effective roles too.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
