### PR TITLE
feat(console): add folder rename and dropdown actions menu

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
@@ -16,6 +16,7 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.util.getOrFail
 import io.ktor.utils.io.ExperimentalKtorApi
@@ -164,6 +165,21 @@ private fun Route.folderActions(
       mapOf(
         "folder" to folderRepository.save(folder),
         "count" to 0,
+      ),
+    )
+  }
+
+  hx.patch("actions/folder/{id}") {
+    val id = call.parameters.getOrFail("id")
+    val name = call.receiveParameters().getOrFail("name")
+    val folder = folderRepository.find(id) ?: return@patch call.respond(HttpStatusCode.NotFound)
+
+    logger.info { "Renaming folder $id to '$name'" }
+    call.respondWithContext(
+      "modules/home/fragments/folder-card.fragment.peb",
+      mapOf(
+        "folder" to folderRepository.save(folder.copy(name = name)),
+        "count" to folderRepository.countMediaIn(id),
       ),
     )
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
@@ -157,7 +157,7 @@ class FolderRepository(
       if (folderId != null) {
         (MediaTable leftJoin FolderMediaTable)
           .selectAll()
-          .where { (MediaTable.deleted eq false) and (FolderMediaTable.mediaId eq folderId) }
+          .where { (MediaTable.deleted eq false) and (FolderMediaTable.folderId eq folderId) }
           .count()
       } else {
         (MediaTable leftJoin FolderMediaTable)

--- a/src/main/resources/static/css/modules/home/folder-grid.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-grid.fragment.css
@@ -35,7 +35,7 @@
   align-items: center;
   justify-content: space-between;
 
-  padding: var(--size-3);
+  padding: var(--size-2) var(--size-3);
   border: var(--border-size-1) solid var(--surface-3);
   border-radius: var(--radius-2);
 
@@ -68,13 +68,10 @@
   flex-shrink: 0;
   place-items: center;
 
-  inline-size: var(--size-8);
-  block-size: var(--size-8);
-  border-radius: var(--radius-2);
+  inline-size: var(--size-7);
+  block-size: var(--size-7);
 
-  color: var(--red-5);
-
-  background: var(--red-12);
+  color: var(--text-2);
 }
 
 .folder-card-info {
@@ -96,13 +93,18 @@
   color: var(--text-2);
 }
 
-.folder-card-delete {
+.folder-card .dropdown-menu {
   flex-shrink: 0;
+}
+
+.folder-card .dropdown-menu > summary {
   opacity: 0;
   transition: opacity 0.15s var(--ease-out-3);
 }
 
-.folder-card:hover .folder-card-delete {
+.folder-card:hover .dropdown-menu > summary,
+.folder-card .dropdown-menu > summary:focus-visible,
+.folder-card .dropdown-menu[open] > summary {
   opacity: 1;
 }
 

--- a/src/main/resources/static/css/modules/home/home.page.css
+++ b/src/main/resources/static/css/modules/home/home.page.css
@@ -56,16 +56,16 @@
   letter-spacing: 0.05em;
 }
 
-/* ── New-folder dialog ── */
-.new-folder-dialog form {
+/* ── New-folder / rename dialog ── */
+.new-folder-dialog form,
+.rename-folder-dialog form {
   display: flex;
   flex-direction: column;
   gap: var(--size-4);
 }
 
-
-
-.new-folder-dialog footer {
+.new-folder-dialog footer,
+.rename-folder-dialog footer {
   display: flex;
   gap: var(--size-2);
   justify-content: flex-end;

--- a/src/main/resources/static/js/modules/home/fragments/folder-grid.fragment.js
+++ b/src/main/resources/static/js/modules/home/fragments/folder-grid.fragment.js
@@ -1,3 +1,5 @@
+import htmx from "htmx.org";
+
 /**
  * Closes the new-folder dialog and resets its form after a successful submission.
  * @listens document#htmx:afterRequest
@@ -9,4 +11,38 @@ document.addEventListener("htmx:afterRequest", function(e) {
 
   document.getElementById("new-folder-dialog").close();
   form.reset();
+});
+
+/**
+ * Opens the shared rename dialog pre-filled for the selected folder, wiring its
+ * form to the matching hx-patch action target.
+ * @listens document#click
+ */
+document.addEventListener("click", function(e) {
+  const trigger = e.target.closest("[data-rename-folder]");
+
+  if (!trigger) return;
+
+  const { folderId, folderName } = trigger.dataset;
+  const dialog = document.getElementById("rename-folder-dialog");
+  const form = dialog.querySelector("form");
+
+  dialog.querySelector("#rename-folder-name").value = folderName;
+  form.setAttribute("hx-patch", `/console/actions/folder/${folderId}`);
+  form.setAttribute("hx-target", `[id='folder-card-${folderId}']`);
+  htmx.process(form);
+
+  dialog.showModal();
+});
+
+/**
+ * Closes the rename dialog after a successful submission.
+ * @listens document#htmx:afterRequest
+ */
+document.addEventListener("htmx:afterRequest", function(e) {
+  const form = e.target.closest("#rename-folder-dialog form");
+
+  if (!form || !e.detail.successful) return;
+
+  document.getElementById("rename-folder-dialog").close();
 });

--- a/src/main/resources/templates/modules/home/folder-card.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-card.macros.peb
@@ -15,14 +15,29 @@
     </div>
   </a>
     {% if not readOnly %}
-      <button class="btn-icon danger folder-card-delete"
-              hx-delete="/console/actions/folder/{{ folder.id }}"
-              hx-target="[id='folder-card-{{ folder.id }}']"
-              hx-swap="outerHTML"
-              hx-confirm="Delete folder '{{ folder.name }}'? Media inside will remain but be unassigned."
-              title="Delete folder">
-        <span class="material-symbols-outlined">delete</span>
-      </button>
+    <details class="dropdown-menu">
+      <summary class="btn-icon">
+        <span class="material-symbols-outlined">more_vert</span>
+      </summary>
+      <div class="dropdown">
+        <button class="btn dropdown-item" type="button"
+                data-rename-folder
+                data-folder-id="{{ folder.id }}"
+                data-folder-name="{{ folder.name }}"
+                onclick="this.closest('details').removeAttribute('open')">
+          <span class="material-symbols-outlined">edit</span>
+          Rename
+        </button>
+        <button class="btn dropdown-item danger" type="button"
+                hx-delete="/console/actions/folder/{{ folder.id }}"
+                hx-target="[id='folder-card-{{ folder.id }}']"
+                hx-swap="outerHTML"
+                hx-confirm="Delete folder '{{ folder.name }}'? Media inside will remain but be unassigned.">
+          <span class="material-symbols-outlined">delete</span>
+          Delete
+        </button>
+      </div>
+    </details>
     {% endif %}
 </div>
 {% endmacro %}

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -93,4 +93,19 @@
     </footer>
   </form>
 </dialog>
+<dialog id="rename-folder-dialog" class="rename-folder-dialog">
+  <form hx-swap="outerHTML">
+    <h3>Rename Folder</h3>
+    <div class="field">
+      <label for="rename-folder-name">Name</label>
+      <input id="rename-folder-name" name="name" type="text" required autocomplete="off">
+    </div>
+    <footer>
+      <button type="button" onclick="document.getElementById('rename-folder-dialog').close()">
+        Cancel
+      </button>
+      <button type="submit" class="btn btn-primary">Rename</button>
+    </footer>
+  </form>
+</dialog>
 {% endblock %}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRouteTest.kt
@@ -5,6 +5,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
 import ch.srgssr.pillarbox.backend.test.count
 import ch.srgssr.pillarbox.backend.test.hxDelete
 import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.hxPatch
 import ch.srgssr.pillarbox.backend.test.hxPost
 import ch.srgssr.pillarbox.backend.test.login
 import ch.srgssr.pillarbox.backend.test.mediaFixture
@@ -116,6 +117,32 @@ class HomeRouteTest :
       }
     }
 
+    should("rename an existing folder") {
+      testApplicationContext {
+        login()
+        val folderId = client.createFolder("Old Name")
+
+        val response =
+          client.hxPatch("${Navigation.CONSOLE}/actions/folder/$folderId") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("name" to "Renamed").formUrlEncode())
+          }
+        response shouldHaveStatus HttpStatusCode.OK
+
+        Jsoup.parse(response.bodyAsText()).select(".folder-card-name").text() shouldBe "Renamed"
+      }
+    }
+
+    should("return NOT_FOUND when renaming a non-existent folder") {
+      testApplicationContext {
+        login()
+        client.hxPatch("${Navigation.CONSOLE}/actions/folder/not-a-folder") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("name" to "Renamed").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
     should("delete an existing folder") {
       testApplicationContext {
         login()
@@ -134,10 +161,14 @@ class HomeRouteTest :
         }
         val folderId = client.createFolder("Test Folder")
 
-        client.hxPost("${Navigation.CONSOLE}/actions/folder/$folderId/media") {
-          contentType(ContentType.Application.FormUrlEncoded)
-          setBody(listOf("mediaID" to media.id).formUrlEncode())
-        } shouldHaveStatus HttpStatusCode.OK
+        val response =
+          client.hxPost("${Navigation.CONSOLE}/actions/folder/$folderId/media") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("mediaID" to media.id).formUrlEncode())
+          }
+        response shouldHaveStatus HttpStatusCode.OK
+
+        Jsoup.parse(response.bodyAsText()).select(".folder-card-count").text() shouldBe "1 item"
       }
     }
 
@@ -215,6 +246,7 @@ class HomeRouteTest :
         client.hxGet("${Navigation.CONSOLE}/fragments/folder-picker") shouldHaveStatus HttpStatusCode.BadRequest
         client.hxGet("${Navigation.CONSOLE}/fragments/folder-picker-child") shouldHaveStatus HttpStatusCode.OK
         client.hxPost("${Navigation.CONSOLE}/actions/folder") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxPatch("${Navigation.CONSOLE}/actions/folder/any-id") shouldHaveStatus HttpStatusCode.Forbidden
         client.hxDelete("${Navigation.CONSOLE}/actions/folder/any-id") shouldHaveStatus HttpStatusCode.Forbidden
         client.hxPost("${Navigation.CONSOLE}/actions/folder/any-id/media") shouldHaveStatus HttpStatusCode.Forbidden
         client.hxDelete("${Navigation.CONSOLE}/actions/folder/any-id/media/any-id") shouldHaveStatus
@@ -232,6 +264,8 @@ class HomeRouteTest :
         client.hxGet("${Navigation.CONSOLE}/fragments/folder-picker") shouldHaveStatus HttpStatusCode.BadRequest
         client.hxGet("${Navigation.CONSOLE}/fragments/folder-picker-child") shouldHaveStatus HttpStatusCode.OK
         client.hxPost("${Navigation.CONSOLE}/actions/folder") shouldHaveStatus HttpStatusCode.UnsupportedMediaType
+        client.hxPatch("${Navigation.CONSOLE}/actions/folder/any-id") shouldHaveStatus
+          HttpStatusCode.UnsupportedMediaType
         client.hxDelete("${Navigation.CONSOLE}/actions/folder/any-id") shouldHaveStatus HttpStatusCode.NotFound
         client.hxPost("${Navigation.CONSOLE}/actions/folder/any-id/media") shouldHaveStatus
           HttpStatusCode.UnsupportedMediaType

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/HttpClientExtensions.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/HttpClientExtensions.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
 
@@ -22,6 +23,15 @@ suspend fun HttpClient.hxPost(
   block: HttpRequestBuilder.() -> Unit = {},
 ): HttpResponse =
   post(urlString) {
+    header("HX-Request", "true")
+    block()
+  }
+
+suspend fun HttpClient.hxPatch(
+  urlString: String,
+  block: HttpRequestBuilder.() -> Unit = {},
+): HttpResponse =
+  patch(urlString) {
     header("HX-Request", "true")
     block()
   }


### PR DESCRIPTION
## Description

Replace the folder card's standalone delete button with a dropdown menu offering Rename and Delete actions.

## Changes Made

- Add an `hx.patch` console action to rename a folder, re-rendering the card fragment in place.
- Add a shared rename dialog reusing the new-folder dialog styling.
- Slim down the folder card: less padding, plain icon without the red background.
- Fix folder media counts resetting to 0 on HTMX re-render: `countMediaIn(folderId)` was filtering on the media id instead of the folder id, so it never matched

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
