### PR TITLE
fix(console): move dropdown menus to the Popover API to stop clipping

### DIFF
--- a/src/main/resources/static/css/layouts/_dialog.css
+++ b/src/main/resources/static/css/layouts/_dialog.css
@@ -1,14 +1,20 @@
 dialog {
-  transform: scale(1) translateY(0);
+  /* Centering on the base rule keeps the closing dialog in place. */
+  position: fixed;
+  inset: 0;
+  transform: scale(0.97) translateY(calc(-1 * var(--size-2)));
 
+  width: fit-content;
   min-width: var(--size-15);
+  height: fit-content;
+  margin: auto;
   padding: var(--size-5);
   border: var(--border-size-1) solid var(--surface-3);
   border-radius: var(--radius-3);
 
   color: var(--text-1);
 
-  opacity: 1;
+  opacity: 0;
   background: var(--surface-1);
 
   transition:
@@ -16,6 +22,11 @@ dialog {
     transform 0.2s var(--ease-out-3),
     display 0.2s var(--ease-out-3) allow-discrete,
     overlay 0.2s var(--ease-out-3) allow-discrete;
+}
+
+dialog[open] {
+  transform: scale(1) translateY(0);
+  opacity: 1;
 }
 
 @starting-style {

--- a/src/main/resources/static/css/layouts/_dropdown.css
+++ b/src/main/resources/static/css/layouts/_dropdown.css
@@ -1,77 +1,99 @@
-.dropdown-menu {
-  position: relative;
-  padding: 0;
-  background: none;
-}
-
-.dropdown-menu > summary {
-  margin: 0;
-  list-style: none;
-}
-
-.dropdown-menu > summary::-webkit-details-marker {
-  display: none;
-}
-
-.dropdown-menu[open] > summary {
-  margin-bottom: 0;
-}
-
-.dropdown-menu[open] {
-  z-index: var(--layer-4);
-}
-
-.dropdown-chevron {
-  transition: transform 0.15s var(--ease-out-3);
-}
-
-.dropdown-menu[open] .dropdown-chevron {
-  transform: rotate(180deg);
-}
+/* Popover-based dropdown menus. The menu lives in the top layer, so it escapes
+   ancestor overflow and stacking contexts. Where CSS anchor positioning is
+   available the menu is tethered to its invoker and flips to stay on screen;
+   browsers without it fall back to the UA-centred popover. */
 
 .dropdown {
-  position: absolute;
-  z-index: var(--layer-4);
-  top: 100%;
-  right: 0;
-  translate: 0 0;
+  translate: 0 calc(-1 * var(--size-2));
 
-  min-width: var(--size-13);
-  margin-top: var(--size-1);
+  flex-direction: column;
+
+  padding: 0;
   border: var(--border-size-1) solid var(--surface-3);
   border-radius: var(--radius-2);
 
-  opacity: 1;
+  color: var(--text-1);
+
+  opacity: 0;
   background: var(--surface-2);
   box-shadow: var(--shadow-3);
 
   transition:
     opacity 0.15s var(--ease-out-3),
     translate 0.15s var(--ease-out-3),
-    display 0.15s var(--ease-out-3) allow-discrete;
+    display 0.15s allow-discrete,
+    overlay 0.15s allow-discrete;
+}
+
+@supports (inset-block-start: anchor(bottom)) {
+  .dropdown {
+    position: fixed;
+    inset: auto;
+
+    /* Below the invoker, right edges aligned; flips to stay on screen. */
+    inset-block-start: anchor(bottom);
+    inset-inline-end: anchor(right);
+
+    /* The initial value (normal) ignores the implicit invoker anchor. */
+    position-anchor: auto;
+    position-try-fallbacks: flip-block, flip-inline, flip-block flip-inline;
+
+    margin: 0;
+    margin-block-start: var(--size-1);
+  }
+}
+
+/* Safari drops the implicit anchor while the menu fades out; scope an
+   explicit one per invoker/menu pair. */
+@supports (anchor-scope: --dropdown) {
+  :has(> .dropdown) {
+    anchor-scope: --dropdown;
+  }
+
+  :has(> .dropdown) > [popovertarget] {
+    anchor-name: --dropdown;
+  }
+
+  .dropdown {
+    position-anchor: --dropdown;
+  }
+}
+
+/* Set on :popover-open so the UA rule still hides the closed menu; a grid
+   here makes Safari stretch the popover to full height. */
+.dropdown:popover-open {
+  translate: 0 0;
+  display: flex;
+  opacity: 1;
 }
 
 @starting-style {
-  .dropdown-menu[open] .dropdown {
+  .dropdown:popover-open {
     translate: 0 calc(-1 * var(--size-2));
     opacity: 0;
   }
 }
 
-.dropdown-menu:not([open]) .dropdown {
-  display: none;
+.dropdown-chevron {
+  transition: transform 0.15s var(--ease-out-3);
+}
+
+[aria-expanded="true"] .dropdown-chevron {
+  transform: rotate(180deg);
 }
 
 .dropdown-item {
   justify-content: start;
-
-  width: 100%;
   border: none;
   border-radius: var(--radius-1);
-
   text-align: start;
 }
 
 .dropdown-item:hover {
   border: none;
+}
+
+/* Inset the outline so it is not clipped by the popover's edges. */
+.dropdown-item:focus-visible {
+  outline-offset: -2px;
 }

--- a/src/main/resources/static/css/modules/home/folder-grid.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-grid.fragment.css
@@ -93,18 +93,15 @@
   color: var(--text-2);
 }
 
-.folder-card .dropdown-menu {
+.folder-card .btn-icon {
   flex-shrink: 0;
-}
-
-.folder-card .dropdown-menu > summary {
   opacity: 0;
   transition: opacity 0.15s var(--ease-out-3);
 }
 
-.folder-card:hover .dropdown-menu > summary,
-.folder-card .dropdown-menu > summary:focus-visible,
-.folder-card .dropdown-menu[open] > summary {
+.folder-card:hover .btn-icon,
+.folder-card .btn-icon:focus-visible,
+.folder-card .btn-icon[aria-expanded="true"] {
   opacity: 1;
 }
 

--- a/src/main/resources/static/css/modules/home/folder-picker.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-picker.fragment.css
@@ -3,10 +3,13 @@
   height: min(var(--size-15), 70dvh);
 }
 
-dialog[open].move-folder-dialog {
+/* Layout lives on the always-present wrapper, not the [open]-gated dialog, so it
+   survives the close transition (when [open] is removed but the dialog lingers). */
+.folder-picker {
   display: flex;
   flex-direction: column;
   gap: var(--size-4);
+  height: 100%;
 }
 
 .move-folder-dialog footer {

--- a/src/main/resources/static/css/shared/components/breadcrumbs.component.css
+++ b/src/main/resources/static/css/shared/components/breadcrumbs.component.css
@@ -26,6 +26,11 @@
   white-space: nowrap;
 }
 
+/* Inset the outline so it is not clipped by the breadcrumbs' overflow. */
+a.page:focus-visible {
+  outline-offset: -2px;
+}
+
 .breadcrumbs .page.current {
   color: var(--text-1);
 }

--- a/src/main/resources/static/css/shared/components/user-menu.component.css
+++ b/src/main/resources/static/css/shared/components/user-menu.component.css
@@ -6,22 +6,18 @@
 
   inline-size: var(--size-6);
   block-size: var(--size-6);
+  padding: 0;
+  border: none;
   border-radius: var(--radius-round);
 
   font-size: var(--font-size-0);
   font-weight: var(--font-weight-7);
   color: var(--text-1);
-  list-style: none;
 
   background: light-dark(var(--gray-4), var(--gray-7));
 }
 
-.user-avatar::-webkit-details-marker {
-  display: none;
-}
-
 .user-dropdown {
-  right: 0;
   min-width: var(--size-14);
 }
 

--- a/src/main/resources/static/css/shared/fragments/media-grid.fragment.css
+++ b/src/main/resources/static/css/shared/fragments/media-grid.fragment.css
@@ -46,10 +46,6 @@
   box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
 }
 
-.media-card:has(.dropdown-menu[open]) {
-  z-index: var(--layer-1);
-}
-
 .media-card.dragging {
   cursor: grabbing;
   opacity: 0.45;
@@ -106,6 +102,11 @@
   color: var(--text-3);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Inset the outline so it is not clipped by the id row's overflow. */
+.media-card > header p .btn-icon:focus-visible {
+  outline-offset: -2px;
 }
 
 .media-card > header ul.tag-list {

--- a/src/main/resources/templates/layouts/dashboard.layout.peb
+++ b/src/main/resources/templates/layouts/dashboard.layout.peb
@@ -19,11 +19,22 @@
 {% block footer %}{% endblock %}
 
 <script>
-  document.addEventListener("click", (e) => {
-    document.querySelectorAll("details.dropdown-menu[open]").forEach((d) => {
-      if (!d.contains(e.target)) d.removeAttribute("open");
+  // Popover dropdowns light-dismiss themselves; we mirror the open state onto
+  // the invoker's aria-expanded for screen readers and our CSS state hooks.
+  document.addEventListener("toggle", (e) => {
+    const menu = e.target;
+    if (!(menu instanceof HTMLElement) || !menu.matches(".dropdown")) return;
+    const invoker = document.querySelector(`[popovertarget="${CSS.escape(menu.id)}"]`);
+    if (!invoker) return;
+    invoker.setAttribute("aria-expanded", String(e.newState === "open"));
+  }, true);
+
+  // Backdrop clicks close dialogs in browsers without closedby support.
+  if (!("closedBy" in HTMLDialogElement.prototype)) {
+    document.addEventListener("click", (e) => {
+      if (e.target instanceof HTMLDialogElement && e.target.open) e.target.close();
     });
-  });
+  }
 
   function currentTheme() {
     return document.documentElement.dataset.theme ||

--- a/src/main/resources/templates/modules/bin/bin.page.peb
+++ b/src/main/resources/templates/modules/bin/bin.page.peb
@@ -27,7 +27,7 @@
 {% include "../../shared/components/snackbar.component.peb" %}
 
 <template id="confirm-dialog-template">
-  <dialog class="confirm-dialog">
+  <dialog closedby="any" class="confirm-dialog">
     <form method="dialog">
       <p id="confirm-message"></p>
       <footer>

--- a/src/main/resources/templates/modules/home/folder-card.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-card.macros.peb
@@ -15,29 +15,27 @@
     </div>
   </a>
     {% if not readOnly %}
-    <details class="dropdown-menu">
-      <summary class="btn-icon">
-        <span class="material-symbols-outlined">more_vert</span>
-      </summary>
-      <div class="dropdown">
-        <button class="btn dropdown-item" type="button"
-                data-rename-folder
-                data-folder-id="{{ folder.id }}"
-                data-folder-name="{{ folder.name }}"
-                onclick="this.closest('details').removeAttribute('open')">
-          <span class="material-symbols-outlined">edit</span>
-          Rename
-        </button>
-        <button class="btn dropdown-item danger" type="button"
-                hx-delete="/console/actions/folder/{{ folder.id }}"
-                hx-target="[id='folder-card-{{ folder.id }}']"
-                hx-swap="outerHTML"
-                hx-confirm="Delete folder '{{ folder.name }}'? Media inside will remain but be unassigned.">
-          <span class="material-symbols-outlined">delete</span>
-          Delete
-        </button>
-      </div>
-    </details>
+    <button class="btn-icon" type="button" popovertarget="folder-menu-{{ folder.id }}" aria-expanded="false" title="Actions">
+      <span class="material-symbols-outlined">more_vert</span>
+    </button>
+    <div class="dropdown" popover id="folder-menu-{{ folder.id }}">
+      <button class="btn dropdown-item" type="button"
+              data-rename-folder
+              data-folder-id="{{ folder.id }}"
+              data-folder-name="{{ folder.name }}"
+              onclick="this.closest('[popover]').hidePopover()">
+        <span class="material-symbols-outlined">edit</span>
+        Rename
+      </button>
+      <button class="btn dropdown-item danger" type="button"
+              hx-delete="/console/actions/folder/{{ folder.id }}"
+              hx-target="[id='folder-card-{{ folder.id }}']"
+              hx-swap="outerHTML"
+              hx-confirm="Delete folder '{{ folder.name }}'? Media inside will remain but be unassigned.">
+        <span class="material-symbols-outlined">delete</span>
+        Delete
+      </button>
+    </div>
     {% endif %}
 </div>
 {% endmacro %}

--- a/src/main/resources/templates/modules/home/folder-picker.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-picker.macros.peb
@@ -1,34 +1,36 @@
 {% macro folderPicker(folder = null, mediaId) %}
 {# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
 {# @pebvariable name="mediaId" type="java.lang.String" #}
-<h3>Move to Folder</h3>
+<div class="folder-picker">
+  <h3>Move to Folder</h3>
 
-<input type="hidden" id="picker-media-id" name="mediaId" value="{{ mediaId }}">
-{% if folder is not empty %}
-<input type="hidden" id="picker-current-folder-id" value="{{ folder.id }}">
-{% endif %}
+  <input type="hidden" id="picker-media-id" name="mediaId" value="{{ mediaId }}">
+  {% if folder is not empty %}
+  <input type="hidden" id="picker-current-folder-id" value="{{ folder.id }}">
+  {% endif %}
 
-<div class="folder-picker-list"
-     hx-get="/console/fragments/folder-picker-child?mediaId={{ mediaId }}{% if folder is not empty %}&currentFolderId={{ folder.id }}{% endif %}"
-     hx-trigger="load"
-     hx-swap="innerHTML">
-  <p>Loading…</p>
+  <div class="folder-picker-list"
+       hx-get="/console/fragments/folder-picker-child?mediaId={{ mediaId }}{% if folder is not empty %}&currentFolderId={{ folder.id }}{% endif %}"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <p>Loading…</p>
+  </div>
+
+  {% if folder is not empty %}
+  <div class="folder-picker-remove">
+    <button type="button"
+            class="folder-picker-unassign"
+            hx-delete="/console/actions/folder/{{ folder.id }}/media/{{ mediaId }}"
+            hx-swap="none">
+      <span class="material-symbols-outlined" aria-hidden="true">folder_off</span>
+      Remove from "{{ folder.name }}"
+    </button>
+  </div>
+  {% endif %}
+
+  <footer>
+    <button type="button" onclick="document.getElementById('move-folder-dialog').close()">Cancel</button>
+    <button type="button" class="btn-primary" data-move-confirm disabled>Move here</button>
+  </footer>
 </div>
-
-{% if folder is not empty %}
-<div class="folder-picker-remove">
-  <button type="button"
-          class="folder-picker-unassign"
-          hx-delete="/console/actions/folder/{{ folder.id }}/media/{{ mediaId }}"
-          hx-swap="none">
-    <span class="material-symbols-outlined" aria-hidden="true">folder_off</span>
-    Remove from "{{ folder.name }}"
-  </button>
-</div>
-{% endif %}
-
-<footer>
-  <button type="button" onclick="document.getElementById('move-folder-dialog').close()">Cancel</button>
-  <button type="button" class="btn-primary" data-move-confirm disabled>Move here</button>
-</footer>
 {% endmacro %}

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -19,25 +19,23 @@
         Recently Deleted
       </a>
       {% if user.roles contains "WRITE" %}
-      <details class="dropdown-menu">
-        <summary class="btn btn-primary">
-          <span class="material-symbols-outlined">add</span>
-          New
-          <span class="material-symbols-outlined dropdown-chevron">expand_more</span>
-        </summary>
-        <div class="dropdown">
-          <a class="btn dropdown-item"
-             href="/console/editor{% if folder is not empty %}?folderId={{ folder.id }}{% endif %}">
-            <span class="material-symbols-outlined">add_circle</span>
-            Add Media
-          </a>
-          <button class="btn dropdown-item" type="button"
-                  onclick="this.closest('details').removeAttribute('open'); document.getElementById('new-folder-dialog').showModal()">
-            <span class="material-symbols-outlined">create_new_folder</span>
-            New Folder
-          </button>
-        </div>
-      </details>
+      <button class="btn btn-primary" type="button" popovertarget="new-menu" aria-expanded="false">
+        <span class="material-symbols-outlined">add</span>
+        New
+        <span class="material-symbols-outlined dropdown-chevron">expand_more</span>
+      </button>
+      <div class="dropdown" popover id="new-menu">
+        <a class="btn dropdown-item"
+           href="/console/editor{% if folder is not empty %}?folderId={{ folder.id }}{% endif %}">
+          <span class="material-symbols-outlined">add_circle</span>
+          Add Media
+        </a>
+        <button class="btn dropdown-item" type="button"
+                onclick="this.closest('[popover]').hidePopover(); document.getElementById('new-folder-dialog').showModal()">
+          <span class="material-symbols-outlined">create_new_folder</span>
+          New Folder
+        </button>
+      </div>
       {% endif %}
     </div>
   </div>
@@ -63,7 +61,7 @@
 {% include "../../shared/components/snackbar.component.peb" %}
 
 <template id="confirm-dialog-template">
-  <dialog class="confirm-dialog">
+  <dialog closedby="any" class="confirm-dialog">
     <form method="dialog">
       <p id="confirm-message"></p>
       <footer>
@@ -74,8 +72,8 @@
   </dialog>
 </template>
 
-<dialog id="move-folder-dialog" class="move-folder-dialog"></dialog>
-<dialog id="new-folder-dialog" class="new-folder-dialog">
+<dialog closedby="any" id="move-folder-dialog" class="move-folder-dialog"></dialog>
+<dialog closedby="any" id="new-folder-dialog" class="new-folder-dialog">
   <form hx-post="/console/actions/folder"
         hx-target="#folder-grid"
         hx-swap="beforeend">
@@ -93,7 +91,7 @@
     </footer>
   </form>
 </dialog>
-<dialog id="rename-folder-dialog" class="rename-folder-dialog">
+<dialog closedby="any" id="rename-folder-dialog" class="rename-folder-dialog">
   <form hx-swap="outerHTML">
     <h3>Rename Folder</h3>
     <div class="field">

--- a/src/main/resources/templates/shared/components/user-menu.component.peb
+++ b/src/main/resources/templates/shared/components/user-menu.component.peb
@@ -1,10 +1,9 @@
 {# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
-<details class="dropdown-menu" id="user-menu">
-  <summary class="user-avatar" title="{{ user.name | default('User') }}">
-    {{ user.initials | default('?') }}
-  </summary>
-  <div class="dropdown user-dropdown">
-    <div class="user-dropdown-info">
+<button type="button" class="user-avatar" popovertarget="user-menu" aria-expanded="false" title="{{ user.name | default('User') }}">
+  {{ user.initials | default('?') }}
+</button>
+<div class="dropdown user-dropdown" popover id="user-menu">
+  <div class="user-dropdown-info">
       <span class="user-dropdown-name">{{ user.name | default('User') }}</span>
       <span class="user-dropdown-role">
         {%- if user.roles contains "ADMIN" -%}Administrator
@@ -26,4 +25,3 @@
       Sign out
     </a>
   </div>
-</details>

--- a/src/main/resources/templates/shared/macros/media-card.macros.peb
+++ b/src/main/resources/templates/shared/macros/media-card.macros.peb
@@ -39,50 +39,48 @@
 
   {% if not readOnly %}
   <footer class="actions">
-    <details class="dropdown-menu">
-      <summary class="btn-icon">
-        <span class="material-symbols-outlined">more_vert</span>
-      </summary>
-      <div class="dropdown">
-        <a class="btn dropdown-item" href="/console/editor/{{ media.id }}{% if folderId is not empty %}?folderId={{ folderId }}{% endif %}">
-          <span class="material-symbols-outlined">edit</span>
-          Edit
-        </a>
-        <a class="btn dropdown-item" href="/console/editor/{{ media.id }}/duplicate{% if folderId is not empty %}?folderId={{ folderId }}{% endif %}">
-          <span class="material-symbols-outlined">content_copy</span>
-          Duplicate
-        </a>
-        {% if not media.deleted %}
-        <button class="btn dropdown-item" type="button"
-                data-open-move-dialog
-                data-media-id="{{ media.id }}"
-                hx-get="/console/fragments/folder-picker?mediaId={{ media.id }}{% if folderId is not empty %}&folderId={{ folderId }}{% endif %}"
-                hx-target="#move-folder-dialog"
-                hx-swap="innerHTML"
-                onclick="this.closest('details').removeAttribute('open')">
-          <span class="material-symbols-outlined">drive_file_move</span>
-          Move to Folder
-        </button>
-        <button class="btn dropdown-item danger" type="button"
-                hx-delete="/console/actions/media/{{ media.id }}"
-                hx-target="[id='media-card-{{ media.id }}']"
-                hx-swap="outerHTML"
-                hx-confirm="Move '{{ media.metadata.title }}' to the Bin? It can be restored later.">
-          <span class="material-symbols-outlined">delete</span>
-          Delete
-        </button>
-        {% else %}
-        <button class="btn dropdown-item" type="button"
-                hx-post="/console/actions/media/{{ media.id }}/restore"
-                hx-target="[id='media-card-{{ media.id }}']"
-                hx-swap="outerHTML"
-                hx-confirm="Restore '{{ media.metadata.title }}' to the library?">
-          <span class="material-symbols-outlined">restore_from_trash</span>
-          Restore
-        </button>
-        {% endif %}
-      </div>
-    </details>
+    <button class="btn-icon" type="button" popovertarget="media-menu-{{ media.id }}" aria-expanded="false" title="Actions">
+      <span class="material-symbols-outlined">more_vert</span>
+    </button>
+    <div class="dropdown" popover id="media-menu-{{ media.id }}">
+      <a class="btn dropdown-item" href="/console/editor/{{ media.id }}{% if folderId is not empty %}?folderId={{ folderId }}{% endif %}">
+        <span class="material-symbols-outlined">edit</span>
+        Edit
+      </a>
+      <a class="btn dropdown-item" href="/console/editor/{{ media.id }}/duplicate{% if folderId is not empty %}?folderId={{ folderId }}{% endif %}">
+        <span class="material-symbols-outlined">content_copy</span>
+        Duplicate
+      </a>
+      {% if not media.deleted %}
+      <button class="btn dropdown-item" type="button"
+              data-open-move-dialog
+              data-media-id="{{ media.id }}"
+              hx-get="/console/fragments/folder-picker?mediaId={{ media.id }}{% if folderId is not empty %}&folderId={{ folderId }}{% endif %}"
+              hx-target="#move-folder-dialog"
+              hx-swap="innerHTML"
+              onclick="this.closest('[popover]').hidePopover()">
+        <span class="material-symbols-outlined">drive_file_move</span>
+        Move to Folder
+      </button>
+      <button class="btn dropdown-item danger" type="button"
+              hx-delete="/console/actions/media/{{ media.id }}"
+              hx-target="[id='media-card-{{ media.id }}']"
+              hx-swap="outerHTML"
+              hx-confirm="Move '{{ media.metadata.title }}' to the Bin? It can be restored later.">
+        <span class="material-symbols-outlined">delete</span>
+        Delete
+      </button>
+      {% else %}
+      <button class="btn dropdown-item" type="button"
+              hx-post="/console/actions/media/{{ media.id }}/restore"
+              hx-target="[id='media-card-{{ media.id }}']"
+              hx-swap="outerHTML"
+              hx-confirm="Restore '{{ media.metadata.title }}' to the library?">
+        <span class="material-symbols-outlined">restore_from_trash</span>
+        Restore
+      </button>
+      {% endif %}
+    </div>
   </footer>
   {% endif %}
 </article>


### PR DESCRIPTION
## Description

Render the action menus (media card, folder card, user menu and the "New" menu) as popovers in the top layer so they escape the scrollable app container instead of being clipped or pushed off-screen.

## Changes Made

- Tether each menu to its invoker with CSS anchor positioning (flipping to stay on-screen), with a JS fallback for browsers without it-
- Size menus with a single-column grid.
- Inset the focus outline on dropdown items and breadcrumb links so it is no longer clipped by overflow.
- Keep the move-folder dialog's flex layout on an always-present wrapper so it no longer reflows during the close transition.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
