### PR TITLE
feat(permissions): gate folder and media changes by user, team and role

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Use these commands for standard development lifecycle tasks.
 | **Linting**     | `./gradlew ktlintCheck detekt` |
 | **Format Code** | `./gradlew ktlintFormat`       |
 
+> [!NOTE]
+> Tests spin up a throwaway PostgreSQL container via [Testcontainers][testcontainers] and run the
+> real Flyway migrations against it, so a running Docker daemon is required.
+
 ### Usage
 
 To get started with the console and API, please refer to
@@ -145,42 +149,6 @@ This project automates its own development workflow using GitHub Actions:
 
 ## Contributing
 
-Contributions are welcome! If you'd like to contribute, please follow the project's code style and
-linting rules. Here are some commands to help you get started:
-
-Check your code style:
-
-```shell
-./gradlew ktlintCheck
-```
-
-You can try an automatically apply the style by running:
-
-```shell
-./gradlew ktlintFormat
-```
-
-Detect potential issues:
-
-```shell
-./gradlew detekt
-```
-
-All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-format to ensure compatibility with our automated release system. A pre-commit hook is available to
-validate commit messages.
-
-You can set up hook to automate these checks before commiting and pushing your changes, to do so
-update the Git hooks path:
-
-```bash
-git config core.hooksPath .githooks/
-```
-
-Refer to our [Contribution Guide](docs/CONTRIBUTING.md) for more detailed information.
-
-## Contributing
-
 Contributions are welcome! Please follow the project's code style and linting rules before
 submitting.
 
@@ -213,3 +181,4 @@ This project is licensed under the [MIT License](LICENSE).
 [ktor]: https://ktor.io/
 [nvmrc-doc]: https://github.com/nvm-sh/nvm?tab=readme-ov-file#nvmrc
 [pillarbox-schema]: src/test/resources/schemas/pillarbox-standard-metadata-schema.json
+[testcontainers]: https://testcontainers.com/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,12 +56,12 @@ dependencies {
   // --- Test ---
   testImplementation(libs.bundles.kotest)
   testImplementation(libs.bundles.ktor.test)
-  testImplementation(libs.h2)
   testImplementation(libs.json.schema.validator)
   testImplementation(libs.jsoup)
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.mock.oauth2.server)
   testImplementation(libs.mockk)
+  testImplementation(libs.testcontainers.postgresql)
 }
 
 // ==============================================================================

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,17 +13,29 @@ and **Pebble templates**, allowing for dynamic updates without full page reloads
 ### Console Routes
 
 The console exposes several endpoints that return either full HTML pages or partial HTML fragments.
+Fragment and action endpoints are driven by HTMX. Mutating actions require the `Write` role, and
+restoring from the bin requires the `Admin` role; folder and media mutations are additionally gated
+by folder write access (see [Folder permissions](#folder-permissions)).
 
-| Method     | Endpoint                                 | Type | Description                                                                                                             |
-|------------|------------------------------------------|------|-------------------------------------------------------------------------------------------------------------------------|
-| **GET**    | `/console`                               | Page | Renders the main dashboard/home page.                                                                                   |
-| **GET**    | `/console/media`                         | HTMX | Returns a paginated grid fragment of media items, accepts `page` and `pageSize` query parameters to handle navigation.. |
-| **POST**   | `/console/media`                         | HTMX | Saves a media entity and triggers a client-side redirect.                                                               |
-| **DELETE** | `/console/media/{id}`                    | HTMX | Deletes a specific media entity from the repository.                                                                    |
-| **GET**    | `/console/media/editor/{id?}`            | Page | Opens the media editor (empty for new, populated for existing).                                                         |
-| **GET**    | `/console/media/editor/{id}/duplicate`   | Page | Opens the editor with data from an existing ID (ID cleared) for duplication.                                            |
-| **GET**    | `/console/media/editor/fragments/{name}` | HTMX | Returns a set of input fields for a specific object type.                                                               |
-| **POST**   | `/console/media/{id}/restore`            | HTMX | Restores a deleted media entity from the repository.                                                                    |
+| Method     | Endpoint                                       | Type     | Description                                                                               |
+|------------|------------------------------------------------|----------|-------------------------------------------------------------------------------------------|
+| **GET**    | `/console`                                     | Page     | Renders the main dashboard/home page. Accepts `folderId` to open a folder.                |
+| **GET**    | `/console/bin`                                 | Page     | Renders the bin (recently deleted media).                                                 |
+| **GET**    | `/console/editor/{id?}`                        | Page     | Opens the media editor (empty for new, populated for an existing id). Accepts `folderId`. |
+| **GET**    | `/console/editor/{id}/duplicate`               | Page     | Opens the editor pre-filled from an existing id (id cleared) for duplication.             |
+| **GET**    | `/console/fragments/media-grid`                | Fragment | Paginated media grid. Accepts `page`, `pageSize`, `folderId`, and `deleted`.              |
+| **GET**    | `/console/fragments/folder-grid`               | Fragment | Grid of subfolders. Accepts `id` (parent folder, omitted for root).                       |
+| **GET**    | `/console/fragments/folder-picker`             | Fragment | Folder picker dialog for moving a media item. Accepts `mediaId` and `folderId`.           |
+| **GET**    | `/console/fragments/folder-picker-child`       | Fragment | Lazily loads child folders in the picker. Accepts `id` and `currentFolderId`.             |
+| **GET**    | `/console/fragments/editor/{fragment}`         | Fragment | Returns a set of input fields for a specific editor row type.                             |
+| **POST**   | `/console/actions/folder`                      | Action   | Creates a folder.                                                                         |
+| **PATCH**  | `/console/actions/folder/{id}`                 | Action   | Renames a folder.                                                                         |
+| **DELETE** | `/console/actions/folder/{id}`                 | Action   | Deletes a folder.                                                                         |
+| **POST**   | `/console/actions/folder/{id}/media`           | Action   | Assigns a media item to a folder.                                                         |
+| **DELETE** | `/console/actions/folder/{id}/media/{mediaId}` | Action   | Removes a media item's assignment from a folder.                                          |
+| **POST**   | `/console/actions/media`                       | Action   | Saves a media entity (create/update) and triggers a client-side redirect.                 |
+| **DELETE** | `/console/actions/media/{id}`                  | Action   | Soft-deletes a media entity (moves it to the bin).                                        |
+| **POST**   | `/console/actions/media/{id}/restore`          | Action   | Restores a deleted media entity from the bin. Requires the `Admin` role.                  |
 
 ## REST API
 
@@ -73,36 +85,98 @@ curl -v --request POST \
 All endpoints below require the `Authorization: Bearer $TOKEN` header. You can find all the
 definitions in [MediaRoute.kt][media-route-kt].
 
-| Method     | Endpoint                 | Description                                             |
-|------------|--------------------------|---------------------------------------------------------|
-| **GET**    | `/v1/media`              | List all media (supports `limit` and `offset` queries). |
-| **GET**    | `/v1/media/{id}`         | Retrieve a specific media entity by ID.                 |
-| **POST**   | `/v1/media`              | Create or fully update a media entity.                  |
-| **PATCH**  | `/v1/media/{id}/tags`    | Batch update tags for a specific media entity.          |
-| **DELETE** | `/v1/media/{id}`         | Remove a media entity from the repository.              |
-| **POST**   | `/v1/media/{id}/restore` | Restores a deleted media entity from the repository.    |
+| Method     | Endpoint                 | Description                                                |
+|------------|--------------------------|------------------------------------------------------------|
+| **GET**    | `/v1/media`              | List all media (supports `limit` and `offset` queries).    |
+| **GET**    | `/v1/media/{id}`         | Retrieve a specific media entity by ID.                    |
+| **POST**   | `/v1/media`              | Create or fully update a media entity.                     |
+| **PATCH**  | `/v1/media/{id}/tags`    | Batch update tags for a specific media entity.             |
+| **DELETE** | `/v1/media/{id}`         | Soft-delete a media entity (moves it to the bin).          |
+| **POST**   | `/v1/media/{id}/restore` | Restore a deleted media entity. Requires the `Admin` role. |
+
+Mutations (`POST`, `PATCH`, `DELETE`) require the `Write` role and are additionally gated by the
+write access of the media's folder (see [Folder permissions](#folder-permissions)). Restoring from
+the bin is reserved for the `Admin` role.
 
 #### Folder API
 
 Folders provide a hierarchical way to organise media items. They support nesting via a `parentId`
 field. You can find all the definitions in [FolderRoute.kt][folder-route-kt].
 
-| Method     | Endpoint                          | Description                                                                                |
-|------------|-----------------------------------|--------------------------------------------------------------------------------------------|
-| **GET**    | `/v1/folder`                      | List folders. Accepts `limit` and `offset` for pagination; `parentId` to filter by parent. |
-| **GET**    | `/v1/folder/{id}`                 | Retrieve a specific folder by ID.                                                          |
-| **GET**    | `/v1/folder/{id}/media`           | List media items assigned to a folder. Accepts `limit` and `offset`.                       |
-| **POST**   | `/v1/folder`                      | Create a new folder.                                                                       |
-| **PATCH**  | `/v1/folder/{id}`                 | Update an existing folder.                                                                 |
-| **DELETE** | `/v1/folder/{id}`                 | Delete a folder.                                                                           |
-| **POST**   | `/v1/folder/{id}/media`           | Assign a media item to a folder.                                                           |
-| **DELETE** | `/v1/folder/{id}/media/{mediaId}` | Remove a media item's assignment from a folder.                                            |
+| Method     | Endpoint                                    | Description                                                                                |
+|------------|---------------------------------------------|--------------------------------------------------------------------------------------------|
+| **GET**    | `/v1/folder`                                | List folders. Accepts `limit` and `offset` for pagination; `parentId` to filter by parent. |
+| **GET**    | `/v1/folder/{id}`                           | Retrieve a specific folder by ID.                                                          |
+| **GET**    | `/v1/folder/{id}/media`                     | List media items assigned to a folder. Accepts `limit` and `offset`.                       |
+| **POST**   | `/v1/folder`                                | Create a new folder.                                                                       |
+| **PATCH**  | `/v1/folder/{id}`                           | Update an existing folder.                                                                 |
+| **DELETE** | `/v1/folder/{id}`                           | Delete a folder.                                                                           |
+| **POST**   | `/v1/folder/{id}/media`                     | Assign a media item to a folder.                                                           |
+| **DELETE** | `/v1/folder/{id}/media/{mediaId}`           | Remove a media item's assignment from a folder.                                            |
+| **GET**    | `/v1/folder/{id}/permission`                | List the grants effective on a folder (its own grants plus inherited ancestor grants).     |
+| **POST**   | `/v1/folder/{id}/permission`                | Add an access grant to a folder.                                                           |
+| **DELETE** | `/v1/folder/{id}/permission/{permissionId}` | Remove a grant from a folder.                                                              |
+
+#### Folder permissions
+
+By default, any user with the `Write` role may modify any folder and its media. A folder becomes
+**restricted** as soon as it (or one of its ancestors) carries at least one grant: from then on
+only granted subjects (and `Admin` users) may write to it and its descendants. Grants are inherited
+downwards. Managing a folder's grants requires write access to that folder, so editors with access
+can delegate it without involving an administrator. Reading is always open to any authenticated
+user.
+
+A grant targets exactly one subject: a user, a team, or a role, so a `POST` body must set exactly
+one of `oidcSub`, `teamId`, or `role`. `canWrite` defaults to `true`.
+
+```bash
+curl --request POST \
+  --url http://localhost:8080/v1/folder/{id}/permission \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $TOKEN" \
+  --data '{"teamId": "team-123", "canWrite": true}'
+```
+
+| Field      | Type      | Description                                                                                  |
+|------------|-----------|----------------------------------------------------------------------------------------------|
+| `oidcSub`  | `string`  | Grant for a single user (their OIDC subject). Mutually exclusive.                            |
+| `teamId`   | `string`  | Grant for all members of a team. Mutually exclusive.                                         |
+| `role`     | `string`  | Grant for all holders of a role (e.g. re-open a subtree to all editors). Mutually exclusive. |
+| `canWrite` | `boolean` | Whether the grant confers write access. Defaults to `true`.                                  |
+
+#### Team API
+
+Teams group users so a single folder grant can cover many people. Listing teams and their members
+requires the `Write` role (e.g. to pick grant subjects); creating or deleting teams and managing
+membership requires the `Admin` role. You can find all the definitions
+in [TeamRoute.kt][team-route-kt].
+
+| Method     | Endpoint                         | Role    | Description                                            |
+|------------|----------------------------------|---------|--------------------------------------------------------|
+| **GET**    | `/v1/team`                       | `Write` | List teams (supports `limit` and `offset`).            |
+| **GET**    | `/v1/team/{id}`                  | `Write` | Retrieve a specific team by ID.                        |
+| **GET**    | `/v1/team/{id}/member`           | `Write` | List a team's members (supports `limit` and `offset`). |
+| **POST**   | `/v1/team`                       | `Admin` | Create a team (body: `{ "name": "..." }`).             |
+| **DELETE** | `/v1/team/{id}`                  | `Admin` | Delete a team.                                         |
+| **POST**   | `/v1/team/{id}/member`           | `Admin` | Add a member (body: `{ "oidcSub": "..." }`).           |
+| **DELETE** | `/v1/team/{id}/member/{oidcSub}` | `Admin` | Remove a member from a team.                           |
+
+#### User API
+
+Users are provisioned from the OIDC provider on login. Listing users requires the `Write` role
+(e.g. to pick grant subjects); inspecting a user's active sessions requires the `Admin` role.
+You can find all the definitions in [UserRoute.kt][user-route-kt].
+
+| Method  | Endpoint                | Role    | Description                                                |
+|---------|-------------------------|---------|------------------------------------------------------------|
+| **GET** | `/v1/user`              | `Write` | List users (supports `limit` and `offset`).                |
+| **GET** | `/v1/user/{id}`         | `Write` | Retrieve a specific user by OIDC subject.                  |
+| **GET** | `/v1/user/{id}/session` | `Admin` | List a user's active sessions, most recently active first. |
 
 ### Player API (Public)
 
-The playback endpoints do not require a token and are open to all clients.
-Unlike the management API, these endpoints are **publicly accessible** (no Bearer token required).
-They support content negotiation via query parameters or custom headers.
+The playback endpoints do not require a token and are open to all clients, unlike the management
+API. They support content negotiation via query parameters or custom headers.
 You can find all the definitions in [PlayerMediaRoute.kt][player-media-route-kt].
 
 | Method  | Endpoint                       | Description                                                          |
@@ -164,8 +238,8 @@ level.
 Native levels (`L1`, `L2`, `L3`, `SL2000`, `SL3000`) are still accepted and passed through
 unchanged.
 
-[media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/MediaRoute.kt
-
-[folder-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/FolderRoute.kt
-
-[player-media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/PlayerMediaRoute.kt
+[folder-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRoute.kt
+[media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
+[player-media-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
+[team-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/TeamRoute.kt
+[user-route-kt]: ../src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/UserRoute.kt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ versions-plugin = "0.54.0"
 # Libs
 exposed = "1.3.0"
 flyway = "12.9.0"
-h2 = "2.4.240"
 hikaricp = "7.1.0"
 json-schema-validator = "3.0.5"
 jsoup = "1.22.2"
@@ -24,6 +23,7 @@ logback = "1.5.35"
 mock-oauth2-server = "3.0.3"
 mockk = "1.14.11"
 postgresql = "42.7.11"
+testcontainers = "2.0.5"
 
 [libraries]
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
@@ -57,7 +57,6 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 
 # Tests
-h2 = { module = "com.h2database:h2", version.ref = "h2" }
 json-schema-validator = { module = "com.networknt:json-schema-validator", version.ref = "json-schema-validator" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 kotest-assertions-ktor = { module = "io.kotest:kotest-assertions-ktor", version.ref = "kotest" }
@@ -67,6 +66,7 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 mock-oauth2-server = { module = "no.nav.security:mock-oauth2-server", version.ref = "mock-oauth2-server" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 
 [bundles]
 exposed = [

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -3,6 +3,7 @@ package ch.srgssr.pillarbox.backend
 import ch.srgssr.pillarbox.backend.auth.authenticationModule
 import ch.srgssr.pillarbox.backend.auth.configureOidc
 import ch.srgssr.pillarbox.backend.auth.installSession
+import ch.srgssr.pillarbox.backend.authz.authzModule
 import ch.srgssr.pillarbox.backend.db.databaseModule
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.auth
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.folder
@@ -69,6 +70,7 @@ fun Application.module() {
       jsonModule(),
       httpClientModule(),
       authenticationModule(),
+      authzModule(),
     )
   }
 
@@ -91,7 +93,7 @@ fun Application.module() {
   routing {
     auth(get(), get(), get(), get())
     media(get())
-    folder(get(), get())
+    folder(get(), get(), get(), get(), get())
     user(get(), get())
     team(get(), get())
     console(get(), get())

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/AuthzModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/AuthzModule.kt
@@ -1,0 +1,22 @@
+package ch.srgssr.pillarbox.backend.authz
+
+import org.koin.dsl.module
+
+/**
+ * Defines the Koin module for authorization.
+ *
+ * Provides the [PermissionChecker] used to evaluate folder and media write access for the
+ * authenticated user.
+ *
+ * @return A Koin [Module] containing the authorization infrastructure definitions.
+ */
+fun authzModule() =
+  module {
+    single {
+      PermissionChecker(
+        folderPermissionRepository = get(),
+        folderRepository = get(),
+        teamRepository = get(),
+      )
+    }
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/PermissionChecker.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/PermissionChecker.kt
@@ -1,0 +1,130 @@
+package ch.srgssr.pillarbox.backend.authz
+
+import ch.srgssr.pillarbox.backend.domain.model.Folder
+import ch.srgssr.pillarbox.backend.domain.model.FolderPermission
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.domain.model.User
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+
+/**
+ * Evaluates whether a user may modify a folder or a media item.
+ *
+ * Administrators may always write and users without the [Role.WRITE] role never may.
+ * Editors may write everywhere by default; a folder becomes restricted once it or an
+ * ancestor carries explicit [FolderPermission] grants, and from then on only granted
+ * subjects may write to it. Media outside any folder is unrestricted.
+ *
+ * @property folderPermissionRepository Repository used to read the grants of a folder chain.
+ * @property folderRepository Repository used to resolve the folder of a media item.
+ * @property teamRepository Repository used to resolve the team memberships of a user.
+ */
+class PermissionChecker(
+  private val folderPermissionRepository: FolderPermissionRepository,
+  private val folderRepository: FolderRepository,
+  private val teamRepository: TeamRepository,
+) {
+  /**
+   * Whether [user] may modify the folder identified by [folderId] and its content.
+   *
+   * @param user The authenticated user.
+   * @param folderId The target folder, or `null` for the unrestricted root scope.
+   * @return `true` if the user may write, `false` otherwise.
+   */
+  suspend fun canWriteFolder(
+    user: User,
+    folderId: String?,
+  ): Boolean =
+    when {
+      user.hasAnyRole(setOf(Role.ADMIN)) -> {
+        true
+      }
+
+      !user.hasAnyRole(setOf(Role.WRITE)) -> {
+        false
+      }
+
+      folderId == null -> {
+        true
+      }
+
+      else -> {
+        val grants = folderPermissionRepository.findGrantsInChain(folderId)
+        grants.isEmpty() || isGranted(user, grants, user.teamIdsFor(grants))
+      }
+    }
+
+  /**
+   * Whether [user] may modify each of the given folders.
+   *
+   * Effective grants for every folder are resolved in a single query, so a set of
+   * folders costs one grant lookup regardless of their depth.
+   *
+   * @param user The authenticated user.
+   * @param folders The folders to evaluate.
+   * @return A map from folder id to whether [user] may write it.
+   */
+  suspend fun canWriteFolders(
+    user: User,
+    folders: List<Folder>,
+  ): Map<String, Boolean> =
+    when {
+      folders.isEmpty() -> {
+        emptyMap()
+      }
+
+      user.hasAnyRole(setOf(Role.ADMIN)) -> {
+        folders.associate { it.id to true }
+      }
+
+      !user.hasAnyRole(setOf(Role.WRITE)) -> {
+        folders.associate { it.id to false }
+      }
+
+      else -> {
+        val grantsByFolder = folderPermissionRepository.findGrantsInChains(folders.map { it.id })
+        val teamIds = user.teamIdsFor(grantsByFolder.values.flatten())
+
+        folders.associate { folder ->
+          val grants = grantsByFolder[folder.id].orEmpty()
+          folder.id to (grants.isEmpty() || isGranted(user, grants, teamIds))
+        }
+      }
+    }
+
+  /**
+   * Whether [user] may modify the media identified by [mediaId], based on the
+   * folder it is assigned to.
+   *
+   * @param user The authenticated user.
+   * @param mediaId The target media item.
+   * @return `true` if the user may write, `false` otherwise.
+   */
+  suspend fun canWriteMedia(
+    user: User,
+    mediaId: String,
+  ): Boolean = canWriteFolder(user, folderRepository.findFolderOf(mediaId)?.id)
+
+  private fun isGranted(
+    user: User,
+    grants: List<FolderPermission>,
+    teamIds: Set<String>,
+  ): Boolean =
+    grants.any { grant ->
+      grant.canWrite &&
+        when (val subject = grant.subject) {
+          is PermissionSubject.ForUser -> subject.oidcSub == user.oidcSub
+          is PermissionSubject.ForTeam -> subject.teamId in teamIds
+          is PermissionSubject.ForRole -> user.hasAnyRole(setOf(subject.role))
+        }
+    }
+
+  private suspend fun User.teamIdsFor(grants: List<FolderPermission>): Set<String> =
+    if (grants.any { it.subject is PermissionSubject.ForTeam }) {
+      teamRepository.findTeamsOf(oidcSub).map { it.id }.toSet()
+    } else {
+      emptySet()
+    }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/WriteAccess.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/WriteAccess.kt
@@ -1,0 +1,56 @@
+package ch.srgssr.pillarbox.backend.authz
+
+import ch.srgssr.pillarbox.backend.auth.user
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+import io.ktor.server.routing.RoutingContext
+import org.koin.ktor.ext.get
+
+/**
+ * The [PermissionChecker] for this call, resolved from the application's Koin container so it does
+ * not need to be threaded through every route.
+ */
+val ApplicationCall.permissionChecker: PermissionChecker
+  get() = application.get()
+
+/**
+ * Runs [block] only if the authenticated user may write every one of the given [folderIds],
+ * otherwise responds [HttpStatusCode.Forbidden] and skips it.
+ *
+ * A `null` id denotes the unrestricted root scope, so the block runs.
+ *
+ * @param folderIds The folders that must be writable; pass several to require write access to all.
+ * @param block The work to perform when access is granted.
+ */
+suspend fun RoutingContext.withFolderWrite(
+  vararg folderIds: String?,
+  block: suspend () -> Unit,
+) {
+  if (folderIds.all { call.permissionChecker.canWriteFolder(call.user, it) }) {
+    block()
+  } else {
+    call.respond(HttpStatusCode.Forbidden)
+  }
+}
+
+/**
+ * Runs [block] only if the authenticated user may write the media identified by [mediaId],
+ * otherwise responds [HttpStatusCode.Forbidden] and skips it.
+ *
+ * A `null` id means there is no existing media to protect (e.g. creating a new item), so the
+ * block runs.
+ *
+ * @param mediaId The media to protect, or `null` when there is nothing to check.
+ * @param block The work to perform when access is granted.
+ */
+suspend fun RoutingContext.withMediaWrite(
+  mediaId: String?,
+  block: suspend () -> Unit,
+) {
+  if (mediaId == null || call.permissionChecker.canWriteMedia(call.user, mediaId)) {
+    block()
+  } else {
+    call.respond(HttpStatusCode.Forbidden)
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseConfig.kt
@@ -18,7 +18,6 @@ import io.ktor.server.config.ApplicationConfigurationException
  * @property dataSourceProperties Additional vendor-specific properties passed to the JDBC driver.
  */
 data class DatabaseConfig(
-  val autoCreate: Boolean = false,
   val driverClassName: String,
   val jdbcUrl: String,
   val username: String,
@@ -59,7 +58,6 @@ fun ApplicationConfig.toDatabaseConfig(): DatabaseConfig {
   }
 
   return DatabaseConfig(
-    autoCreate = db.property("autoCreate").getString().toBoolean(),
     driverClassName = db.property("driverClassName").getString(),
     jdbcUrl = db.property("jdbcUrl").getString(),
     username = db.property("username").getString(),

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/DatabaseModule.kt
@@ -3,10 +3,7 @@ package ch.srgssr.pillarbox.backend.db
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.server.config.ApplicationConfig
-import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.dsl.module
 import org.koin.dsl.onClose
 import javax.sql.DataSource
@@ -55,19 +52,8 @@ fun databaseModule() =
     }
 
     single {
-      val dbConfig = get<DatabaseConfig>()
       val dataSource = get<DataSource>()
-      val db = Database.connect(dataSource)
-
-      if (dbConfig.autoCreate) {
-        val allTables = get<List<Table>>().toTypedArray()
-
-        transaction(db) {
-          SchemaUtils.create(*allTables)
-        }
-      } else {
-        dataSource.runMigration()
-      }
-      db
+      dataSource.runMigration()
+      Database.connect(dataSource)
     }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/FolderPermission.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/FolderPermission.kt
@@ -1,0 +1,56 @@
+package ch.srgssr.pillarbox.backend.domain.model
+
+import kotlin.time.Clock
+import kotlin.time.Instant
+import kotlin.uuid.ExperimentalUuidApi
+import kotlin.uuid.Uuid
+
+/**
+ * The subject a [FolderPermission] applies to. Exactly one identity is carried per grant.
+ */
+sealed interface PermissionSubject {
+  /** Grant for a single user identified by [oidcSub]. */
+  data class ForUser(
+    val oidcSub: String,
+  ) : PermissionSubject
+
+  /** Grant for all members of the team identified by [teamId]. */
+  data class ForTeam(
+    val teamId: String,
+  ) : PermissionSubject
+
+  /**
+   * Grant for all users holding [role], e.g. to re-open a folder
+   * to all editors inside an otherwise restricted subtree.
+   */
+  data class ForRole(
+    val role: Role,
+  ) : PermissionSubject
+}
+
+/**
+ * An explicit access grant on a folder.
+ *
+ * A folder without grants in its ancestor chain is unrestricted: every editor may write.
+ * The first grant on a folder restricts it, and from then on only granted subjects
+ * (and administrators) may write to it and its descendants. Grants are inherited
+ * downwards additively.
+ *
+ * Reading is always open to every authenticated user, so [canWrite] is the only level
+ * a grant carries: `true` grants write access to its subject, `false` records the
+ * subject without widening write access.
+ *
+ * @property id Unique identifier of the grant.
+ * @property folderId The folder this grant is attached to.
+ * @property subject Who the grant applies to.
+ * @property canWrite Whether the grant confers write access to its subject.
+ * @property createdAt Timestamp of the grant creation.
+ */
+@OptIn(ExperimentalUuidApi::class)
+data class FolderPermission(
+  val id: String = Uuid.random().toString(),
+  val folderId: String,
+  val subject: PermissionSubject,
+  val canWrite: Boolean = true,
+  val createdAt: Instant = Clock.System.now(),
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRoute.kt
@@ -1,17 +1,26 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.api
 
+import ch.srgssr.pillarbox.backend.auth.AuthenticatedUserPlugin
 import ch.srgssr.pillarbox.backend.auth.withRole
+import ch.srgssr.pillarbox.backend.authz.withFolderWrite
+import ch.srgssr.pillarbox.backend.authz.withMediaWrite
 import ch.srgssr.pillarbox.backend.db.map
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderPermissionRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toFolderPermissionResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toFolderResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toMediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toQuerySlice
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receive
@@ -30,16 +39,28 @@ import org.jetbrains.exposed.v1.core.eq
 /**
  * Configures the versioned folder-related routes.
  *
+ * Mutations are guarded by `withFolderWrite`/`withMediaWrite`: restricted folders only accept
+ * changes from granted editors and administrators. Folder grants themselves are managed by
+ * whoever can write the folder.
+ *
  * @param folderRepository Repository used to manage folder persistence.
  * @param mediaRepository Repository used to manage media persistence.
+ * @param folderPermissionRepository Repository used to manage folder grants.
+ * @param userRepository Repository used to validate user references in grants.
+ * @param teamRepository Repository used to validate team references in grants.
  */
 @SuppressWarnings("LongMethod", "CyclomaticComplexMethod")
 fun Route.folder(
   folderRepository: FolderRepository,
   mediaRepository: MediaRepository,
+  folderPermissionRepository: FolderPermissionRepository,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
 ) {
   authenticate("pillarbox-jwt", "pillarbox-session") {
     route("v1/folder") {
+      install(AuthenticatedUserPlugin)
+
       get {
         val filter =
           call.request.queryParameters["parentId"]?.let {
@@ -90,28 +111,36 @@ fun Route.folder(
       withRole(Role.WRITE) {
         post {
           val folder = call.receive<FolderRequestV1>().toFolder()
-          call.respond(
-            HttpStatusCode.Created,
-            folderRepository.save(folder).toFolderResponseV1(),
-          )
+          withFolderWrite(folder.parentId) {
+            call.respond(
+              HttpStatusCode.Created,
+              folderRepository.save(folder).toFolderResponseV1(),
+            )
+          }
         }
 
         patch("/{id}") {
           val id = call.parameters.getOrFail("id")
-          if (!folderRepository.exists(id)) return@patch call.respond(HttpStatusCode.NotFound)
+          val existing = folderRepository.find(id) ?: return@patch call.respond(HttpStatusCode.NotFound)
 
           val folder = call.receive<FolderRequestV1>().toFolder().copy(id = id)
-          call.respond(
-            HttpStatusCode.Created,
-            folderRepository.save(folder).toFolderResponseV1(),
-          )
+          // Moving additionally requires write access to the new parent.
+          val moved = folder.parentId != existing.parentId
+          withFolderWrite(id, folder.parentId.takeIf { moved }) {
+            call.respond(
+              HttpStatusCode.Created,
+              folderRepository.save(folder).toFolderResponseV1(),
+            )
+          }
         }
 
         delete("/{id}") {
           val id = call.parameters.getOrFail("id")
-          when (folderRepository.delete(id)) {
-            true -> call.respond(HttpStatusCode.NoContent)
-            false -> call.respond(HttpStatusCode.NotFound)
+          withFolderWrite(id) {
+            when (folderRepository.delete(id)) {
+              true -> call.respond(HttpStatusCode.NoContent)
+              false -> call.respond(HttpStatusCode.NotFound)
+            }
           }
         }
 
@@ -119,26 +148,95 @@ fun Route.folder(
           val id = call.parameters.getOrFail("id")
           if (!folderRepository.exists(id)) return@post call.respond(HttpStatusCode.NotFound, "Folder not found")
 
-          with(call.receive<AssignMediaRequestV1>()) {
-            if (!mediaRepository.exists(mediaId)) {
-              return@post call.respond(
-                HttpStatusCode.UnprocessableEntity,
-                "Referenced Media id does not exist",
-              )
-            }
+          val request = call.receive<AssignMediaRequestV1>()
+          if (!mediaRepository.exists(request.mediaId)) {
+            return@post call.respond(HttpStatusCode.UnprocessableEntity, "Referenced Media id does not exist")
+          }
 
-            folderRepository.assignMedia(id, mediaId)
-            call.respond(HttpStatusCode.Created)
+          withFolderWrite(id) {
+            withMediaWrite(request.mediaId) {
+              folderRepository.assignMedia(id, request.mediaId)
+              call.respond(HttpStatusCode.Created)
+            }
           }
         }
 
         delete("/{id}/media/{mediaId}") {
           val id = call.parameters.getOrFail("id")
           val mediaId = call.parameters.getOrFail("mediaId")
+          withFolderWrite(id) {
+            when (folderRepository.removeMediaAssignment(id, mediaId)) {
+              true -> call.respond(HttpStatusCode.NoContent)
+              false -> call.respond(HttpStatusCode.NotFound)
+            }
+          }
+        }
 
-          when (folderRepository.removeMediaAssignment(id, mediaId)) {
-            true -> call.respond(HttpStatusCode.NoContent)
-            false -> call.respond(HttpStatusCode.NotFound)
+        get("/{id}/permission") {
+          val id = call.parameters.getOrFail("id")
+          if (!folderRepository.exists(id)) return@get call.respond(HttpStatusCode.NotFound)
+
+          withFolderWrite(id) {
+            call.respond(
+              folderPermissionRepository
+                .findGrantsInChain(id)
+                .map { it.toFolderPermissionResponseV1() },
+            )
+          }
+        }
+
+        post("/{id}/permission") {
+          val id = call.parameters.getOrFail("id")
+          if (!folderRepository.exists(id)) return@post call.respond(HttpStatusCode.NotFound)
+
+          withFolderWrite(id) {
+            val permission =
+              call.receive<FolderPermissionRequestV1>().toFolderPermission(id)
+            if (permission == null) {
+              call.respond(HttpStatusCode.BadRequest, "Exactly one of oidcSub, teamId or role must be provided")
+              return@withFolderWrite
+            }
+
+            when (val subject = permission.subject) {
+              is PermissionSubject.ForUser -> {
+                if (!userRepository.exists(subject.oidcSub)) {
+                  call.respond(HttpStatusCode.UnprocessableEntity, "Referenced user does not exist")
+                  return@withFolderWrite
+                }
+              }
+
+              is PermissionSubject.ForTeam -> {
+                if (!teamRepository.exists(subject.teamId)) {
+                  call.respond(HttpStatusCode.UnprocessableEntity, "Referenced team does not exist")
+                  return@withFolderWrite
+                }
+              }
+
+              is PermissionSubject.ForRole -> {
+                Unit
+              }
+            }
+
+            call.respond(
+              HttpStatusCode.Created,
+              folderPermissionRepository.save(permission).toFolderPermissionResponseV1(),
+            )
+          }
+        }
+
+        delete("/{id}/permission/{permissionId}") {
+          val id = call.parameters.getOrFail("id")
+          val permissionId = call.parameters.getOrFail("permissionId")
+
+          withFolderWrite(id) {
+            val permission = folderPermissionRepository.find(permissionId)
+            if (permission == null || permission.folderId != id) {
+              call.respond(HttpStatusCode.NotFound)
+              return@withFolderWrite
+            }
+
+            folderPermissionRepository.delete(permissionId)
+            call.respond(HttpStatusCode.NoContent)
           }
         }
       }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
@@ -1,10 +1,10 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.api
 
+import ch.srgssr.pillarbox.backend.auth.AuthenticatedUserPlugin
 import ch.srgssr.pillarbox.backend.auth.withRole
-import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.authz.withMediaWrite
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaRequestV1
-import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toMediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toQuerySlice
@@ -27,107 +27,90 @@ import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 
 /**
- * Generic helper to register standard Media CRUD endpoints.
- *
- * This function abstracts the web layer logic (Ktor parameters, status codes, logging)
- * from the specific DTO types used. It allows the same endpoint logic to be reused
- * for different API versions or entry points.
- *
- * @param Req The Request DTO type.
- * @param Res The Response DTO type.
- * @param TagReq The DTO type used for tag update operations.
- * @param mediaRepository The repository for persistence operations.
- * @param toDomain Function to map the Request DTO to the [Media] domain model.
- * @param toResponse Function to map the [Media] domain model to the Response DTO.
- * @param applyTags Logic to apply [TagReq] to an existing list of tags.
- */
-inline fun <reified Req : Any, reified Res : Any, reified TagReq : Any> Route.mediaEndpoints(
-  mediaRepository: MediaRepository,
-  crossinline toDomain: (Req) -> Media,
-  crossinline toResponse: (Media) -> Res,
-  crossinline applyTags: (TagReq, List<String>) -> List<String>,
-) {
-  get {
-    with(call.request.queryParameters.toQuerySlice()) {
-      call.respond(
-        mediaRepository
-          .getAll(
-            limit,
-            offset,
-            filter = { MediaTable.deleted eq false },
-          ).map { toResponse(it) }
-          .toList(),
-      )
-    }
-  }
-
-  get("/{id}") {
-    val id = call.parameters.getOrFail("id")
-
-    val media =
-      mediaRepository.findOne {
-        (MediaTable.id eq id) and (MediaTable.deleted eq false)
-      } ?: return@get call.respond(HttpStatusCode.NotFound)
-
-    call.respond(toResponse(media))
-  }
-
-  withRole(Role.WRITE) {
-    post {
-      val dto = call.receive<Req>()
-      val media = toDomain(dto)
-
-      mediaRepository.save(media)
-      call.respond(HttpStatusCode.Created, toResponse(media))
-    }
-
-    patch("/{id}/tags") {
-      val id = call.parameters.getOrFail("id")
-      val request = call.receive<TagReq>()
-
-      mediaRepository
-        .updateTags(id) { applyTags(request, it) }
-        ?.let { call.respond(HttpStatusCode.OK, it) }
-        ?: call.respond(HttpStatusCode.NotFound)
-    }
-
-    delete("/{id}") {
-      val id = call.parameters.getOrFail("id")
-
-      mediaRepository
-        .softDelete(id)
-        .takeIf { it }
-        ?.let { call.respond(HttpStatusCode.NoContent) }
-        ?: call.respond(HttpStatusCode.NotFound)
-    }
-
-    post("/{id}/restore") {
-      val id = call.parameters.getOrFail("id")
-
-      mediaRepository
-        .restore(id)
-        .takeIf { it }
-        ?.let { call.respond(HttpStatusCode.Created) }
-        ?: call.respond(HttpStatusCode.NotFound)
-    }
-  }
-}
-
-/**
  * Configures the versioned media management routes.
+ *
+ * Mutations are guarded by `withMediaWrite`: media in restricted folders only accepts changes
+ * from granted editors and administrators.
  *
  * @param mediaRepository The repository used to manage media entities.
  */
+@SuppressWarnings("LongMethod")
 fun Route.media(mediaRepository: MediaRepository) {
-  // Entry point for the V1 media API.
   authenticate("pillarbox-jwt", "pillarbox-session") {
     route("v1/media") {
-      mediaEndpoints<MediaRequestV1, MediaResponseV1, TagBatchUpdateRequestV1>(
-        mediaRepository = mediaRepository,
-        toDomain = { it.toMedia() },
-        toResponse = { it.toMediaResponseV1() },
-        applyTags = { dto, tags -> dto.apply(tags) },
-      )
+      install(AuthenticatedUserPlugin)
+
+      get {
+        with(call.request.queryParameters.toQuerySlice()) {
+          call.respond(
+            mediaRepository
+              .getAll(
+                limit,
+                offset,
+                filter = { MediaTable.deleted eq false },
+              ).map { it.toMediaResponseV1() }
+              .toList(),
+          )
+        }
+      }
+
+      get("/{id}") {
+        val id = call.parameters.getOrFail("id")
+
+        val media =
+          mediaRepository.findOne {
+            (MediaTable.id eq id) and (MediaTable.deleted eq false)
+          } ?: return@get call.respond(HttpStatusCode.NotFound)
+
+        call.respond(media.toMediaResponseV1())
+      }
+
+      withRole(Role.WRITE) {
+        post {
+          val media = call.receive<MediaRequestV1>().toMedia()
+
+          // Saving is an upsert: overwriting an existing media is governed by its folder,
+          // while a brand-new id has nothing to protect yet.
+          withMediaWrite(media.id.takeIf { mediaRepository.exists(it) }) {
+            mediaRepository.save(media)
+            call.respond(HttpStatusCode.Created, media.toMediaResponseV1())
+          }
+        }
+
+        patch("/{id}/tags") {
+          val id = call.parameters.getOrFail("id")
+          val request = call.receive<TagBatchUpdateRequestV1>()
+          withMediaWrite(id) {
+            mediaRepository
+              .updateTags(id) { request.apply(it) }
+              ?.let { call.respond(HttpStatusCode.OK, it) }
+              ?: call.respond(HttpStatusCode.NotFound)
+          }
+        }
+
+        delete("/{id}") {
+          val id = call.parameters.getOrFail("id")
+          withMediaWrite(id) {
+            mediaRepository
+              .softDelete(id)
+              .takeIf { it }
+              ?.let { call.respond(HttpStatusCode.NoContent) }
+              ?: call.respond(HttpStatusCode.NotFound)
+          }
+        }
+      }
+
+      withRole(Role.ADMIN) {
+        post("/{id}/restore") {
+          val id = call.parameters.getOrFail("id")
+
+          mediaRepository
+            .restore(id)
+            .takeIf { it }
+            ?.let { call.respond(HttpStatusCode.Created) }
+            ?: call.respond(HttpStatusCode.NotFound)
+        }
+      }
     }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/TeamRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/TeamRoute.kt
@@ -23,7 +23,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 
 /**
- * Configures the versioned team-related routes, restricted to administrators.
+ * Configures the versioned team-related routes.
+ *
+ * Listing teams and members is available to editors (e.g. to pick folder grant
+ * subjects); creating and deleting teams and managing membership is restricted
+ * to administrators.
  *
  * @param teamRepository Repository used to manage team persistence.
  * @param userRepository Repository used to validate team member references.
@@ -34,8 +38,8 @@ fun Route.team(
   userRepository: UserRepository,
 ) {
   authenticate("pillarbox-jwt", "pillarbox-session") {
-    withRole(Role.ADMIN) {
-      route("v1/team") {
+    route("v1/team") {
+      withRole(Role.WRITE) {
         get {
           with(call.request.queryParameters.toQuerySlice()) {
             call.respond(
@@ -68,7 +72,9 @@ fun Route.team(
             )
           }
         }
+      }
 
+      withRole(Role.ADMIN) {
         post {
           val team = call.receive<TeamRequestV1>().toTeam()
           call.respond(

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/UserRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/UserRoute.kt
@@ -25,7 +25,10 @@ import org.jetbrains.exposed.v1.core.greater
 import kotlin.time.Clock
 
 /**
- * Configures the versioned user-related routes, restricted to administrators.
+ * Configures the versioned user-related routes.
+ *
+ * Listing users is available to editors (e.g. to pick folder grant subjects);
+ * session data is restricted to administrators.
  *
  * @param userRepository Repository used to read user records.
  * @param sessionRepository Repository used to read user sessions.
@@ -35,8 +38,8 @@ fun Route.user(
   sessionRepository: SessionRepository,
 ) {
   authenticate("pillarbox-jwt", "pillarbox-session") {
-    withRole(Role.ADMIN) {
-      route("v1/user") {
+    route("v1/user") {
+      withRole(Role.WRITE) {
         get {
           with(call.request.queryParameters.toQuerySlice()) {
             call.respond(
@@ -56,7 +59,9 @@ fun Route.user(
             else -> call.respond(user)
           }
         }
+      }
 
+      withRole(Role.ADMIN) {
         get("/{id}/session") {
           val id = call.parameters.getOrFail("id")
           if (!userRepository.exists(id)) return@get call.respond(HttpStatusCode.NotFound)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/EditorRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/EditorRoute.kt
@@ -1,6 +1,8 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
 import ch.srgssr.pillarbox.backend.auth.withRole
+import ch.srgssr.pillarbox.backend.authz.withFolderWrite
+import ch.srgssr.pillarbox.backend.authz.withMediaWrite
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.log.debug
@@ -37,22 +39,30 @@ fun Route.editorPage(
 ) {
   withRole(Role.WRITE) {
     get("editor/{id?}") {
-      val media =
-        call.parameters["id"]
-          ?.let { mediaRepository.find(it) }
-          ?.also { logger.debug { "Opening editor for media: $it" } }
+      val mediaId = call.parameters["id"]
       val folder = call.queryParameters["folderId"]?.takeIf { it.isNotBlank() }?.let { folderRepository.find(it) }
-      call.respondWithContext(
-        "modules/editor/editor.page.peb",
-        buildMap {
-          media?.let { put("item", media) }
-          folder?.let {
-            put("folderId", it.id)
-            put("folder", it)
-            put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
-          }
-        },
-      )
+
+      val renderEditor: suspend () -> Unit = {
+        val media = mediaId?.let { mediaRepository.find(it) }?.also { logger.debug { "Opening editor for media: $it" } }
+        call.respondWithContext(
+          "modules/editor/editor.page.peb",
+          buildMap {
+            media?.let { put("item", media) }
+            folder?.let {
+              put("folderId", it.id)
+              put("folder", it)
+              put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
+            }
+          },
+        )
+      }
+
+      // Editing targets the media's folder; creating new media targets the destination folder.
+      if (mediaId != null) {
+        withMediaWrite(mediaId, renderEditor)
+      } else {
+        withFolderWrite(folder?.id, block = renderEditor)
+      }
     }
 
     get("editor/{id}/duplicate") {
@@ -63,17 +73,21 @@ fun Route.editorPage(
           ?.also { logger.debug { "Opening editor with duplicate data from original ID: $id" } }
           ?: return@get call.respond(HttpStatusCode.NotFound)
       val folder = call.queryParameters["folderId"]?.takeIf { it.isNotBlank() }?.let { folderRepository.find(it) }
-      call.respondWithContext(
-        "modules/editor/editor.page.peb",
-        buildMap {
-          put("item", media.copy(id = ""))
-          folder?.let {
-            put("folderId", it.id)
-            put("folder", it)
-            put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
-          }
-        },
-      )
+
+      // Duplicating creates a new media in the destination folder.
+      withFolderWrite(folder?.id) {
+        call.respondWithContext(
+          "modules/editor/editor.page.peb",
+          buildMap {
+            put("item", media.copy(id = ""))
+            folder?.let {
+              put("folderId", it.id)
+              put("folder", it)
+              put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
+            }
+          },
+        )
+      }
     }
 
     hx.get("/fragments/editor/{fragment}") {
@@ -95,13 +109,19 @@ fun Route.editorPage(
     hx.post("actions/media") {
       val request = call.receive<Media>()
       val folderId = call.parameters["folderId"]?.takeIf { it.isNotBlank() }
-      logger.info { "Saving media: ${request.id}, folderId=$folderId" }
-      val media = mediaRepository.save(request)
-      folderId?.let { folderRepository.assignMedia(it, media.id) }
 
-      val redirect = if (folderId != null) "/console?folderId=$folderId" else "/console"
-      call.response.headers.append("HX-Redirect", redirect)
-      call.respond(HttpStatusCode.OK)
+      // Overwriting an existing media is governed by its folder; the destination folder gates the save.
+      withMediaWrite(request.id.takeIf { mediaRepository.exists(it) }) {
+        withFolderWrite(folderId) {
+          logger.info { "Saving media: ${request.id}, folderId=$folderId" }
+          val media = mediaRepository.save(request)
+          folderId?.let { folderRepository.assignMedia(it, media.id) }
+
+          val redirect = if (folderId != null) "/console?folderId=$folderId" else "/console"
+          call.response.headers.append("HX-Redirect", redirect)
+          call.respond(HttpStatusCode.OK)
+        }
+      }
     }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
@@ -1,6 +1,10 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
+import ch.srgssr.pillarbox.backend.auth.user
 import ch.srgssr.pillarbox.backend.auth.withRole
+import ch.srgssr.pillarbox.backend.authz.permissionChecker
+import ch.srgssr.pillarbox.backend.authz.withFolderWrite
+import ch.srgssr.pillarbox.backend.authz.withMediaWrite
 import ch.srgssr.pillarbox.backend.domain.model.Folder
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.log.debug
@@ -46,13 +50,13 @@ fun Route.homePage(
     logger.debug { "Fetching home page: folderId=${folder?.id}" }
     call.respondWithContext(
       "modules/home/home.page.peb",
-      folder
-        ?.let {
-          mapOf(
-            "folder" to folder,
-            "ancestors" to folderRepository.findAncestors(folder.id).dropLast(1),
-          )
-        }.orEmpty(),
+      buildMap {
+        put("canWrite", call.permissionChecker.canWriteFolder(call.user, folder?.id))
+        folder?.let {
+          put("folder", it)
+          put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
+        }
+      },
     )
   }
 
@@ -70,6 +74,10 @@ fun Route.homePage(
   withRole(Role.WRITE) {
     folderActions(mediaRepository, folderRepository)
     mediaGridActions(mediaRepository)
+  }
+
+  withRole(Role.ADMIN) {
+    mediaGridAdminActions(mediaRepository)
   }
 }
 
@@ -98,6 +106,7 @@ private fun Route.folderFragments(folderRepository: FolderRepository) {
       mapOf(
         "folders" to subFolders,
         "folderCounts" to folderCounts,
+        "folderWriteAccess" to call.permissionChecker.canWriteFolders(call.user, subFolders),
       ),
     )
   }
@@ -146,7 +155,7 @@ private fun Route.folderFragments(folderRepository: FolderRepository) {
  * @param folderRepository Repository used to persist folder and assignment changes.
  */
 @OptIn(ExperimentalKtorApi::class)
-@SuppressWarnings("LongMethod")
+@SuppressWarnings("LongMethod", "CyclomaticComplexMethod")
 private fun Route.folderActions(
   mediaRepository: MediaRepository,
   folderRepository: FolderRepository,
@@ -159,37 +168,42 @@ private fun Route.folderActions(
           parentId = params["parentId"]?.takeIf { it.isNotBlank() },
         )
       }
-    logger.info { "Creating folder: $folder" }
-    call.respondWithContext(
-      "modules/home/fragments/folder-card.fragment.peb",
-      mapOf(
-        "folder" to folderRepository.save(folder),
-        "count" to 0,
-      ),
-    )
+    withFolderWrite(folder.parentId) {
+      logger.info { "Creating folder: $folder" }
+      call.respondWithContext(
+        "modules/home/fragments/folder-card.fragment.peb",
+        mapOf(
+          "folder" to folderRepository.save(folder),
+          "count" to 0,
+        ),
+      )
+    }
   }
 
   hx.patch("actions/folder/{id}") {
     val id = call.parameters.getOrFail("id")
     val name = call.receiveParameters().getOrFail("name")
     val folder = folderRepository.find(id) ?: return@patch call.respond(HttpStatusCode.NotFound)
-
-    logger.info { "Renaming folder $id to '$name'" }
-    call.respondWithContext(
-      "modules/home/fragments/folder-card.fragment.peb",
-      mapOf(
-        "folder" to folderRepository.save(folder.copy(name = name)),
-        "count" to folderRepository.countMediaIn(id),
-      ),
-    )
+    withFolderWrite(id) {
+      logger.info { "Renaming folder $id to '$name'" }
+      call.respondWithContext(
+        "modules/home/fragments/folder-card.fragment.peb",
+        mapOf(
+          "folder" to folderRepository.save(folder.copy(name = name)),
+          "count" to folderRepository.countMediaIn(id),
+        ),
+      )
+    }
   }
 
   hx.delete("actions/folder/{id}") {
     val id = call.parameters.getOrFail("id")
-    logger.info { "Deleting folder with ID: $id" }
-    when (folderRepository.delete(id)) {
-      true -> call.respond(HttpStatusCode.OK)
-      false -> call.respond(HttpStatusCode.NotFound)
+    withFolderWrite(id) {
+      logger.info { "Deleting folder with ID: $id" }
+      when (folderRepository.delete(id)) {
+        true -> call.respond(HttpStatusCode.OK)
+        false -> call.respond(HttpStatusCode.NotFound)
+      }
     }
   }
 
@@ -203,18 +217,22 @@ private fun Route.folderActions(
     if (!mediaRepository.exists(mediaId)) return@post call.respond(HttpStatusCode.UnprocessableEntity)
     if (folderRepository.isMediaInFolder(id, mediaId)) return@post call.respond(HttpStatusCode.OK)
 
-    folderRepository.assignMedia(id, mediaId)
+    withFolderWrite(id) {
+      withMediaWrite(mediaId) {
+        folderRepository.assignMedia(id, mediaId)
 
-    call.response.headers.append("HX-Retarget", "[id='media-card-$mediaId']")
-    call.response.headers.append("HX-Reswap", "delete")
-    call.respondWithContext(
-      "modules/home/fragments/folder-card.fragment.peb",
-      mapOf(
-        "folder" to folder,
-        "count" to folderRepository.countMediaIn(id),
-        "oob" to true,
-      ),
-    )
+        call.response.headers.append("HX-Retarget", "[id='media-card-$mediaId']")
+        call.response.headers.append("HX-Reswap", "delete")
+        call.respondWithContext(
+          "modules/home/fragments/folder-card.fragment.peb",
+          mapOf(
+            "folder" to folder,
+            "count" to folderRepository.countMediaIn(id),
+            "oob" to true,
+          ),
+        )
+      }
+    }
   }
 
   hx.delete("actions/folder/{id}/media/{mediaId}") {
@@ -222,25 +240,26 @@ private fun Route.folderActions(
     val mediaId = call.parameters.getOrFail("mediaId")
 
     val previousFolder = folderRepository.find(id) ?: return@delete call.respond(HttpStatusCode.NotFound)
+    withFolderWrite(id) {
+      logger.info { "Removing folder assignment for media $mediaId" }
 
-    logger.info { "Removing folder assignment for media $mediaId" }
+      when (folderRepository.removeMediaAssignment(id, mediaId)) {
+        true -> {
+          call.response.headers.append("HX-Retarget", "[id='media-card-$mediaId']")
+          call.response.headers.append("HX-Reswap", "delete")
+          call.respondWithContext(
+            "modules/home/fragments/folder-card.fragment.peb",
+            mapOf(
+              "folder" to previousFolder,
+              "count" to folderRepository.countMediaIn(previousFolder.id),
+              "oob" to true,
+            ),
+          )
+        }
 
-    when (folderRepository.removeMediaAssignment(id, mediaId)) {
-      true -> {
-        call.response.headers.append("HX-Retarget", "[id='media-card-$mediaId']")
-        call.response.headers.append("HX-Reswap", "delete")
-        call.respondWithContext(
-          "modules/home/fragments/folder-card.fragment.peb",
-          mapOf(
-            "folder" to previousFolder,
-            "count" to folderRepository.countMediaIn(previousFolder.id),
-            "oob" to true,
-          ),
-        )
-      }
-
-      false -> {
-        call.respond(HttpStatusCode.NotFound)
+        false -> {
+          call.respond(HttpStatusCode.NotFound)
+        }
       }
     }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRoute.kt
@@ -1,5 +1,9 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
+import ch.srgssr.pillarbox.backend.auth.user
+import ch.srgssr.pillarbox.backend.authz.permissionChecker
+import ch.srgssr.pillarbox.backend.authz.withMediaWrite
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
 import ch.srgssr.pillarbox.backend.log.debug
 import ch.srgssr.pillarbox.backend.log.info
@@ -42,12 +46,19 @@ fun Route.mediaGridFragments(mediaRepository: MediaRepository) {
           else -> mediaRepository.findMediaWithoutFolder(limit, offset)
         }
 
+      val canWrite =
+        when {
+          deleted -> call.user.hasAnyRole(setOf(Role.ADMIN))
+          else -> call.permissionChecker.canWriteFolder(call.user, folderId)
+        }
+
       call.respondWithContext(
         "shared/fragments/media-grid.fragment.peb",
         buildMap {
           put("result", result)
           put("nextPage", nextPage)
           put("deleted", deleted)
+          put("canWrite", canWrite)
           folderId?.let { put("folderId", folderId) }
         },
       )
@@ -64,15 +75,25 @@ fun Route.mediaGridFragments(mediaRepository: MediaRepository) {
 fun Route.mediaGridActions(mediaRepository: MediaRepository) {
   hx.delete("actions/media/{id}") {
     val id = call.parameters.getOrFail("id")
-    logger.info { "Attempting to delete media with ID: $id" }
-    when (mediaRepository.softDelete(id)) {
-      true -> call.respond(HttpStatusCode.OK)
-      false -> call.respond(HttpStatusCode.NotFound)
+    withMediaWrite(id) {
+      logger.info { "Attempting to delete media with ID: $id" }
+      when (mediaRepository.softDelete(id)) {
+        true -> call.respond(HttpStatusCode.OK)
+        false -> call.respond(HttpStatusCode.NotFound)
+      }
     }
   }
+}
 
+/**
+ * Registers HTMX admin action endpoints for the paginated media-grid fragment.
+ *
+ * @param mediaRepository Repository used to apply soft-delete and restore operations.
+ */
+fun Route.mediaGridAdminActions(mediaRepository: MediaRepository) {
   hx.post("actions/media/{id}/restore") {
     val id = call.parameters.getOrFail("id")
+
     logger.info { "Attempting to restore media with ID: $id" }
     when (mediaRepository.restore(id)) {
       true -> call.respond(HttpStatusCode.OK)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderPermissionRequestV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderPermissionRequestV1.kt
@@ -1,0 +1,45 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.dto
+
+import ch.srgssr.pillarbox.backend.domain.model.FolderPermission
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import kotlinx.serialization.Serializable
+
+/**
+ * Data Transfer Object (V1) representing a request to grant folder access to a subject.
+ *
+ * Exactly one of [oidcSub], [teamId] or [role] must be provided.
+ *
+ * @property oidcSub The OIDC sub of the user to grant access to.
+ * @property teamId The ID of the team to grant access to.
+ * @property role The role to grant access to.
+ * @property canWrite Whether the grant confers write access to its subject.
+ */
+@Serializable
+data class FolderPermissionRequestV1(
+  val oidcSub: String? = null,
+  val teamId: String? = null,
+  val role: Role? = null,
+  val canWrite: Boolean = true,
+) {
+  /**
+   * Maps the [FolderPermissionRequestV1] DTO to the internal [FolderPermission] domain model.
+   *
+   * @param folderId The folder the grant is attached to.
+   * @return A [FolderPermission] instance, or `null` if not exactly one subject was provided.
+   */
+  fun toFolderPermission(folderId: String): FolderPermission? {
+    val subject =
+      listOfNotNull(
+        oidcSub?.let { PermissionSubject.ForUser(it) },
+        teamId?.let { PermissionSubject.ForTeam(it) },
+        role?.let { PermissionSubject.ForRole(it) },
+      ).singleOrNull() ?: return null
+
+    return FolderPermission(
+      folderId = folderId,
+      subject = subject,
+      canWrite = canWrite,
+    )
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderPermissionResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/FolderPermissionResponseV1.kt
@@ -1,0 +1,49 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.dto
+
+import ch.srgssr.pillarbox.backend.domain.model.FolderPermission
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+/**
+ * API response representation of a folder access grant for the V1 endpoint.
+ *
+ * Exactly one of [oidcSub], [teamId] or [role] is set. The [folderId] identifies the
+ * folder the grant is attached to, which for inherited grants is an ancestor of the
+ * requested folder.
+ *
+ * @property id Unique identifier of the grant.
+ * @property folderId The folder the grant is attached to.
+ * @property oidcSub The OIDC sub of the granted user, if a user grant.
+ * @property teamId The ID of the granted team, if a team grant.
+ * @property role The granted role, if a role grant.
+ * @property canWrite Whether the grant confers write access to its subject.
+ * @property createdAt Timestamp of the grant creation.
+ */
+@Serializable
+data class FolderPermissionResponseV1(
+  val id: String,
+  val folderId: String,
+  val oidcSub: String? = null,
+  val teamId: String? = null,
+  val role: Role? = null,
+  val canWrite: Boolean,
+  val createdAt: Instant,
+)
+
+/**
+ * Converts a [FolderPermission] domain model to its V1 API response representation.
+ *
+ * @return A [FolderPermissionResponseV1] containing the domain model's data.
+ */
+fun FolderPermission.toFolderPermissionResponseV1() =
+  FolderPermissionResponseV1(
+    id = this.id,
+    folderId = this.folderId,
+    oidcSub = (this.subject as? PermissionSubject.ForUser)?.oidcSub,
+    teamId = (this.subject as? PermissionSubject.ForTeam)?.teamId,
+    role = (this.subject as? PermissionSubject.ForRole)?.role,
+    canWrite = this.canWrite,
+    createdAt = this.createdAt,
+  )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/PersistenceModule.kt
@@ -1,18 +1,11 @@
 package ch.srgssr.pillarbox.backend.persistence
 
-import ch.srgssr.pillarbox.backend.persistence.folder.FolderMediaTable
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
-import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
-import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
 import ch.srgssr.pillarbox.backend.persistence.session.SessionRepository
-import ch.srgssr.pillarbox.backend.persistence.session.SessionTable
-import ch.srgssr.pillarbox.backend.persistence.team.TeamMemberTable
 import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
-import ch.srgssr.pillarbox.backend.persistence.team.TeamTable
 import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
-import ch.srgssr.pillarbox.backend.persistence.user.UserTable
-import org.jetbrains.exposed.v1.core.Table
 import org.koin.dsl.module
 
 /**
@@ -27,12 +20,10 @@ import org.koin.dsl.module
  */
 fun persistenceModule() =
   module {
-    single<List<Table>> {
-      listOf(MediaTable, SessionTable, UserTable, FolderTable, FolderMediaTable, TeamTable, TeamMemberTable)
-    }
     single { MediaRepository(get()) }
     single { SessionRepository(get(), get()) }
     single { UserRepository(get()) }
     single { FolderRepository(get()) }
+    single { FolderPermissionRepository(get()) }
     single { TeamRepository(get()) }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderPermissionRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderPermissionRepository.kt
@@ -1,0 +1,135 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.db.ExposedRepository
+import ch.srgssr.pillarbox.backend.domain.model.FolderPermission
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
+import ch.srgssr.pillarbox.backend.domain.model.Role.Companion.toRole
+import ch.srgssr.pillarbox.backend.time.toKotlinInstant
+import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
+import org.jetbrains.exposed.v1.core.statements.UpdateStatement
+import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.selectAll
+
+/**
+ * Repository responsible for the persistence and retrieval of [FolderPermission] grants using Exposed.
+ *
+ * This implementation maps the [FolderPermission] domain model to the [FolderPermissionTable] schema.
+ * Grant inheritance is resolved through the `v_folder_ancestors` recursive view ([FolderAncestorView]),
+ * so the grants effective on a folder are read in a single query regardless of folder depth.
+ *
+ * @param db The [Database] instance used for all transactions.
+ */
+class FolderPermissionRepository(
+  db: Database,
+) : ExposedRepository<FolderPermission, String>(
+    db = db,
+    table = FolderPermissionTable,
+    idColumn = FolderPermissionTable.id,
+  ) {
+  /**
+   * Decodes a [ResultRow] from the [FolderPermissionTable] into a [FolderPermission] domain object.
+   */
+  override fun ResultRow.decode() =
+    FolderPermission(
+      id = this[FolderPermissionTable.id],
+      folderId = this[FolderPermissionTable.folderId],
+      subject = decodeSubject(),
+      canWrite = this[FolderPermissionTable.canWrite],
+      createdAt = this[FolderPermissionTable.createdAt].toKotlinInstant(),
+    )
+
+  /**
+   * Encodes a [FolderPermission] domain object into an [UpdateBuilder] for inserts.
+   */
+  override fun Table.encode(
+    builder: UpdateBuilder<*>,
+    item: FolderPermission,
+  ) {
+    builder[FolderPermissionTable.id] = item.id
+    builder[FolderPermissionTable.folderId] = item.folderId
+    builder[FolderPermissionTable.oidcSub] = (item.subject as? PermissionSubject.ForUser)?.oidcSub
+    builder[FolderPermissionTable.teamId] = (item.subject as? PermissionSubject.ForTeam)?.teamId
+    builder[FolderPermissionTable.role] = (item.subject as? PermissionSubject.ForRole)?.role?.key
+    builder[FolderPermissionTable.canWrite] = item.canWrite
+    builder[FolderPermissionTable.createdAt] = item.createdAt.toUtcOffsetDateTime()
+  }
+
+  /**
+   * Encodes a [FolderPermission] for updates, leaving the immutable [FolderPermissionTable.createdAt]
+   * and subject columns untouched so re-saving a grant only adjusts its access level.
+   */
+  override fun encodeOnUpdate(item: FolderPermission): (UpsertBuilder.(UpdateStatement) -> Unit) =
+    {
+      it[FolderPermissionTable.canWrite] = item.canWrite
+    }
+
+  /**
+   * Retrieves all grants attached to the given folder or any of its ancestors, in a single query
+   * via the [FolderAncestorView].
+   *
+   * An empty result means the folder is unrestricted.
+   *
+   * @param folderId The ID of the folder whose effective grants should be retrieved.
+   * @return The grants on the folder and its ancestors, each carrying the folder it is attached to.
+   */
+  suspend fun findGrantsInChain(folderId: String): List<FolderPermission> =
+    query(readOnly = true) {
+      grantsJoinedWithAncestors()
+        .where { FolderAncestorView.descendantId eq folderId }
+        .map { it.decode() }
+    }
+
+  /**
+   * Retrieves the grants effective on each of the given folders, grouped by folder, in a single query.
+   *
+   * Each value holds the grants attached to that folder or any of its ancestors. Folders with no
+   * effective grant are absent from the map and should be treated as unrestricted.
+   *
+   * @param folderIds The folders whose effective grants should be retrieved.
+   * @return A map from folder id to the grants effective on it.
+   */
+  suspend fun findGrantsInChains(folderIds: Collection<String>): Map<String, List<FolderPermission>> =
+    query(readOnly = true) {
+      if (folderIds.isEmpty()) {
+        emptyMap()
+      } else {
+        grantsJoinedWithAncestors()
+          .where { FolderAncestorView.descendantId inList folderIds }
+          .groupBy({ it[FolderAncestorView.descendantId] }) { it.decode() }
+      }
+    }
+
+  private fun grantsJoinedWithAncestors() =
+    FolderPermissionTable
+      .join(FolderAncestorView, JoinType.INNER) { FolderPermissionTable.folderId eq FolderAncestorView.id }
+      .selectAll()
+
+  private fun ResultRow.decodeSubject(): PermissionSubject {
+    val oidcSub = this[FolderPermissionTable.oidcSub]
+    val teamId = this[FolderPermissionTable.teamId]
+    val role = this[FolderPermissionTable.role]
+
+    return when {
+      oidcSub != null -> {
+        PermissionSubject.ForUser(oidcSub)
+      }
+
+      teamId != null -> {
+        PermissionSubject.ForTeam(teamId)
+      }
+
+      else -> {
+        PermissionSubject.ForRole(
+          requireNotNull(role?.toRole()) { "Grant ${this[FolderPermissionTable.id]} has no valid subject" },
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderPermissionTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderPermissionTable.kt
@@ -1,0 +1,43 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.persistence.team.TeamTable
+import ch.srgssr.pillarbox.backend.persistence.user.UserTable
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.datetime.timestampWithTimeZone
+
+/**
+ * Exposed table definition for folder access grants.
+ *
+ * Each row carries exactly one subject ([oidcSub], [teamId] or [role]); the others are
+ * `null`. The exclusive-arc CHECK constraint is enforced by the SQL migration, while the
+ * domain model guarantees it structurally. Deleting the referenced folder, user or team
+ * cascades to this table.
+ */
+object FolderPermissionTable : Table("pb_folder_permission") {
+  /** Unique identifier of the grant. */
+  val id = varchar("id", 255)
+
+  /** The folder this grant is attached to. */
+  val folderId = varchar("folder_id", 255).references(FolderTable.id, onDelete = ReferenceOption.CASCADE)
+
+  /** OIDC sub of the granted user, or `null` for team and role grants. */
+  val oidcSub = varchar("oidc_sub", 255).references(UserTable.oidcSub, onDelete = ReferenceOption.CASCADE).nullable()
+
+  /** Identifier of the granted team, or `null` for user and role grants. */
+  val teamId = varchar("team_id", 255).references(TeamTable.id, onDelete = ReferenceOption.CASCADE).nullable()
+
+  /** App role key of the granted role, or `null` for user and team grants. */
+  val role = varchar("role", 255).nullable()
+
+  /** Whether the grant confers write access to its subject. */
+  val canWrite = bool("can_write")
+
+  /** Timestamp of the grant creation. */
+  val createdAt = timestampWithTimeZone("created_at")
+
+  override val primaryKey = PrimaryKey(id)
+
+  // Uniqueness of (folder_id, oidc_sub, team_id, role) is enforced by the
+  // `UNIQUE NULLS NOT DISTINCT` constraint in V7__Add_Folder_Permissions.sql
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
@@ -30,6 +30,7 @@ import kotlin.time.Clock
  *
  * @param db The [Database] instance used for all transactions.
  */
+@SuppressWarnings("TooManyFunctions")
 class FolderRepository(
   db: Database,
 ) : ExposedRepository<Folder, String>(db = db, table = FolderTable, idColumn = FolderTable.id) {
@@ -74,7 +75,7 @@ class FolderRepository(
    * folder in parameter.
    *
    * @param folderId The ID of the folder whose ancestors should be retrieved.
-   * @return A list of ancestor [Folder] entities, from the most distant (root) to the closest (parent).
+   * @return A list of [Folder] entities from the root down to the folder itself.
    */
   suspend fun findAncestors(folderId: String): List<Folder> =
     query(readOnly = true) {
@@ -91,6 +92,21 @@ class FolderRepository(
             updatedAt = row[FolderAncestorView.updatedAt].toKotlinInstant(),
           )
         }
+    }
+
+  /**
+   * Finds the folder a media item is assigned to.
+   *
+   * @param mediaId The media ID to look up.
+   * @return The [Folder], or `null` if the media is not assigned to any folder.
+   */
+  suspend fun findFolderOf(mediaId: String): Folder? =
+    query(readOnly = true) {
+      (FolderTable innerJoin FolderMediaTable)
+        .selectAll()
+        .where { FolderMediaTable.mediaId eq mediaId }
+        .singleOrNull()
+        ?.decode()
     }
 
   /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/team/TeamRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/team/TeamRepository.kt
@@ -100,6 +100,20 @@ class TeamRepository(
     }
 
   /**
+   * Retrieves all teams the given user is a member of.
+   *
+   * @param oidcSub The OIDC sub of the user.
+   * @return The list of [Team] entities, empty if the user belongs to no team.
+   */
+  suspend fun findTeamsOf(oidcSub: String): List<Team> =
+    query(readOnly = true) {
+      (TeamTable innerJoin TeamMemberTable)
+        .selectAll()
+        .where { TeamMemberTable.oidcSub eq oidcSub }
+        .map { it.decode() }
+    }
+
+  /**
    * Retrieves the members of a team as [User] entities, paginated.
    *
    * @param teamId The ID of the team whose members should be retrieved.

--- a/src/main/resources/db/migration/V7__Add_Folder_Permissions.sql
+++ b/src/main/resources/db/migration/V7__Add_Folder_Permissions.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS pb_folder_permission (
+  id VARCHAR(255) PRIMARY KEY,
+  folder_id VARCHAR(255) NOT NULL REFERENCES pb_folders(id) ON DELETE CASCADE,
+  oidc_sub VARCHAR(255) REFERENCES pb_user(oidc_sub) ON DELETE CASCADE,
+  team_id VARCHAR(255) REFERENCES pb_team(id) ON DELETE CASCADE,
+  role VARCHAR(255),
+  can_write BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CHECK (
+    (CASE WHEN oidc_sub IS NULL THEN 0 ELSE 1 END
+   + CASE WHEN team_id IS NULL THEN 0 ELSE 1 END
+   + CASE WHEN role IS NULL THEN 0 ELSE 1 END) = 1
+  ),
+  UNIQUE NULLS NOT DISTINCT (folder_id, oidc_sub, team_id, role)
+);
+
+CREATE INDEX idx_folder_permission_folder ON pb_folder_permission(folder_id);

--- a/src/main/resources/templates/modules/home/folder-card.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-card.macros.peb
@@ -40,14 +40,14 @@
 </div>
 {% endmacro %}
 
-{% macro folderList(folders, folderCounts, readOnly = false) %}
+{% macro folderList(folders, folderCounts, writeAccess) %}
 {# @pebvariable name="folders" type="java.util.List<ch.srgssr.pillarbox.backend.domain.model.Folder>" #}
 {# @pebvariable name="folderCounts" type="java.util.Map<java.lang.String, java.lang.Long>" #}
-{# @pebvariable name="readOnly" type="java.lang.Boolean" #}
+{# @pebvariable name="writeAccess" type="java.util.Map<java.lang.String, java.lang.Boolean>" #}
 
 <section class="folder-grid" id="folder-grid">
 {%- for folder in folders -%}
-  {{ folderCard(folder, folderCounts[folder.id] | default(0), readOnly) }}
+  {{ folderCard(folder, folderCounts[folder.id] | default(0), not (writeAccess[folder.id] | default(false))) }}
 {%- endfor -%}
 </section>
 {% endmacro %}

--- a/src/main/resources/templates/modules/home/fragments/folder-grid.fragment.peb
+++ b/src/main/resources/templates/modules/home/fragments/folder-grid.fragment.peb
@@ -1,7 +1,7 @@
 {% import "../folder-card.macros.peb" %}
 {# @pebvariable name="folders" type="java.util.List<ch.srgssr.pillarbox.backend.domain.model.Folder>" #}
 {# @pebvariable name="folderCounts" type="java.util.Map<java.lang.String, java.lang.Long>" #}
-{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
+{# @pebvariable name="folderWriteAccess" type="java.util.Map<java.lang.String, java.lang.Boolean>" #}
 
-{{ folderList(folders, folderCounts, not (user.roles contains "WRITE")) }}
+{{ folderList(folders, folderCounts, folderWriteAccess) }}
 

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -2,6 +2,7 @@
 {# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
 {# @pebvariable name="ancestors" type="java.util.List<ch.srgssr.pillarbox.backend.domain.model.Folder>" #}
 {# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
+{# @pebvariable name="canWrite" type="java.lang.Boolean" #}
 
 {% block head %}
 <link rel="stylesheet" href="/static/css/modules/home/home.page.css">
@@ -18,7 +19,7 @@
         <span class="material-symbols-outlined">delete</span>
         Recently Deleted
       </a>
-      {% if user.roles contains "WRITE" %}
+      {% if canWrite %}
       <button class="btn btn-primary" type="button" popovertarget="new-menu" aria-expanded="false">
         <span class="material-symbols-outlined">add</span>
         New

--- a/src/main/resources/templates/shared/fragments/media-grid.fragment.peb
+++ b/src/main/resources/templates/shared/fragments/media-grid.fragment.peb
@@ -4,10 +4,10 @@
 {# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Media>" #}
 {# @pebvariable name="nextPage" type="java.lang.Integer" #}
 {# @pebvariable name="folderId" type="java.lang.String" #}
-{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
+{# @pebvariable name="canWrite" type="java.lang.Boolean" #}
 
 {% set hasMore = (nextPage * result.limit) < result.totalCount %}
 {% set folderParam = folderId is not empty ? "&folderId=" + folderId : "" %}
 {% set nextUrl = hasMore ? "/console/fragments/media-grid?page=" + nextPage + "&pageSize=" + result.limit + "&deleted=" + deleted + folderParam : null %}
 
-{{ mediaList(result, nextUrl, not (user.roles contains "WRITE"), folderId) }}
+{{ mediaList(result, nextUrl, not canWrite, folderId) }}

--- a/src/main/resources/templates/shared/macros/media-card.macros.peb
+++ b/src/main/resources/templates/shared/macros/media-card.macros.peb
@@ -66,7 +66,7 @@
               hx-delete="/console/actions/media/{{ media.id }}"
               hx-target="[id='media-card-{{ media.id }}']"
               hx-swap="outerHTML"
-              hx-confirm="Move '{{ media.metadata.title }}' to the Bin? It can be restored later.">
+              hx-confirm="Move '{{ media.metadata.title }}' to the Bin? Only an administrator can restore it.">
         <span class="material-symbols-outlined">delete</span>
         Delete
       </button>

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderPermissionRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderPermissionRouteTest.kt
@@ -1,0 +1,354 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.api
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AddTeamMemberRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderPermissionRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderPermissionResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TeamRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TeamResponseV1
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.seedUser
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
+import ch.srgssr.pillarbox.backend.test.tokenFor
+import ch.srgssr.pillarbox.backend.test.tokenWithRoles
+import ch.srgssr.pillarbox.backend.test.userFixture
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+
+private val adminRoles = setOf(Role.ADMIN)
+
+class FolderPermissionRouteTest :
+  ShouldSpec({
+    should("manage folder grants as an editor with access") {
+      testApplicationContext {
+        val editor = tokenFor("user-1")
+        seedUser(userFixture(oidcSub = "user-1"))
+        val folder = client.createFolderV1("Folder", editor)
+
+        val grant =
+          client
+            .grantV1(folder.id, editor, FolderPermissionRequestV1(oidcSub = "user-1"))
+            .also { it shouldHaveStatus HttpStatusCode.Created }
+            .body<FolderPermissionResponseV1>()
+
+        grant.folderId shouldBe folder.id
+        grant.oidcSub shouldBe "user-1"
+        grant.canWrite shouldBe true
+
+        val grants =
+          client
+            .get("/v1/folder/${folder.id}/permission") { bearerAuth(editor) }
+            .body<List<FolderPermissionResponseV1>>()
+        grants.map { it.id } shouldBe listOf(grant.id)
+
+        client.delete("/v1/folder/${folder.id}/permission/${grant.id}") {
+          bearerAuth(editor)
+        } shouldHaveStatus HttpStatusCode.NoContent
+
+        client
+          .get("/v1/folder/${folder.id}/permission") { bearerAuth(editor) }
+          .body<List<FolderPermissionResponseV1>>()
+          .shouldBeEmpty()
+      }
+    }
+
+    should("return BAD_REQUEST when not exactly one subject is provided") {
+      testApplicationContext {
+        val editor = tokenFor("user-1")
+        seedUser(userFixture(oidcSub = "user-1"))
+        val folder = client.createFolderV1("Folder", editor)
+
+        client.grantV1(folder.id, editor, FolderPermissionRequestV1()) shouldHaveStatus
+          HttpStatusCode.BadRequest
+        client.grantV1(
+          folder.id,
+          editor,
+          FolderPermissionRequestV1(oidcSub = "user-1", role = Role.WRITE),
+        ) shouldHaveStatus HttpStatusCode.BadRequest
+      }
+    }
+
+    should("return NOT_FOUND for grants on a non-existent folder") {
+      testApplicationContext {
+        val editor = tokenFor("user-1")
+        seedUser(userFixture(oidcSub = "user-1"))
+
+        client.get("/v1/folder/does-not-exist/permission") { bearerAuth(editor) } shouldHaveStatus
+          HttpStatusCode.NotFound
+        client.grantV1(
+          "does-not-exist",
+          editor,
+          FolderPermissionRequestV1(oidcSub = "user-1"),
+        ) shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("return UNPROCESSABLE_ENTITY for unknown user or team subjects") {
+      testApplicationContext {
+        val editor = tokenFor("user-1")
+        val folder = client.createFolderV1("Folder", editor)
+
+        client.grantV1(folder.id, editor, FolderPermissionRequestV1(oidcSub = "ghost")) shouldHaveStatus
+          HttpStatusCode.UnprocessableEntity
+        client.grantV1(folder.id, editor, FolderPermissionRequestV1(teamId = "ghost-team")) shouldHaveStatus
+          HttpStatusCode.UnprocessableEntity
+      }
+    }
+
+    should("return NOT_FOUND when deleting a grant that belongs to another folder") {
+      testApplicationContext {
+        val editor = tokenFor("user-1")
+        seedUser(userFixture(oidcSub = "user-1"))
+        val folder = client.createFolderV1("Folder", editor)
+        val other = client.createFolderV1("Other", editor)
+
+        val grant =
+          client
+            .grantV1(folder.id, editor, FolderPermissionRequestV1(oidcSub = "user-1"))
+            .body<FolderPermissionResponseV1>()
+
+        client.delete("/v1/folder/${other.id}/permission/${grant.id}") {
+          bearerAuth(editor)
+        } shouldHaveStatus HttpStatusCode.NotFound
+        client.delete("/v1/folder/${folder.id}/permission/does-not-exist") {
+          bearerAuth(editor)
+        } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("restrict folder mutations to granted users") {
+      testApplicationContext {
+        val admin = tokenWithRoles(adminRoles)
+        val granted = tokenFor("user-1")
+        val stranger = tokenFor("user-2")
+        seedUser(userFixture(oidcSub = "user-1"))
+
+        val folder = client.createFolderV1("Restricted", stranger)
+        client.grantV1(folder.id, admin, FolderPermissionRequestV1(oidcSub = "user-1")) shouldHaveStatus
+          HttpStatusCode.Created
+
+        client.renameFolderV1(folder.id, "Nope", stranger) shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/folder/${folder.id}") { bearerAuth(stranger) } shouldHaveStatus
+          HttpStatusCode.Forbidden
+        client.post("/v1/folder") {
+          bearerAuth(stranger)
+          contentType(ContentType.Application.Json)
+          setBody(FolderRequestV1(name = "Child", parentId = folder.id))
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/folder/${folder.id}/permission") { bearerAuth(stranger) } shouldHaveStatus
+          HttpStatusCode.Forbidden
+        client.grantV1(folder.id, stranger, FolderPermissionRequestV1(oidcSub = "user-2")) shouldHaveStatus
+          HttpStatusCode.Forbidden
+
+        client.renameFolderV1(folder.id, "Renamed by granted", granted) shouldHaveStatus
+          HttpStatusCode.Created
+        client.renameFolderV1(folder.id, "Renamed by admin", admin) shouldHaveStatus HttpStatusCode.Created
+      }
+    }
+
+    should("restrict media mutations to the folder grants") {
+      testApplicationContext {
+        val admin = tokenWithRoles(adminRoles)
+        val granted = tokenFor("user-1")
+        val stranger = tokenFor("user-2")
+        seedUser(userFixture(oidcSub = "user-1"))
+
+        val folder = client.createFolderV1("Restricted", stranger)
+        val open = client.createFolderV1("Open", stranger)
+
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          bearerAuth(stranger)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.post("/v1/folder/${folder.id}/media") {
+          bearerAuth(stranger)
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = media.id))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.grantV1(folder.id, admin, FolderPermissionRequestV1(oidcSub = "user-1")) shouldHaveStatus
+          HttpStatusCode.Created
+
+        // The stranger can no longer overwrite, delete, or move the media out.
+        client.post("/v1/media") {
+          bearerAuth(stranger)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/media/${media.id}") { bearerAuth(stranger) } shouldHaveStatus
+          HttpStatusCode.Forbidden
+        client.post("/v1/folder/${open.id}/media") {
+          bearerAuth(stranger)
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = media.id))
+        } shouldHaveStatus HttpStatusCode.Forbidden
+
+        client.delete("/v1/media/${media.id}") { bearerAuth(granted) } shouldHaveStatus
+          HttpStatusCode.NoContent
+      }
+    }
+
+    should("inherit grants from ancestor folders") {
+      testApplicationContext {
+        val admin = tokenWithRoles(adminRoles)
+        val granted = tokenFor("user-1")
+        val stranger = tokenFor("user-2")
+        seedUser(userFixture(oidcSub = "user-1"))
+
+        val parent = client.createFolderV1("Parent", stranger)
+        client.grantV1(parent.id, admin, FolderPermissionRequestV1(oidcSub = "user-1")) shouldHaveStatus
+          HttpStatusCode.Created
+
+        val child = client.createFolderV1("Child", granted, parentId = parent.id)
+
+        client.renameFolderV1(child.id, "Nope", stranger, parentId = parent.id) shouldHaveStatus
+          HttpStatusCode.Forbidden
+        client.renameFolderV1(child.id, "Renamed", granted, parentId = parent.id) shouldHaveStatus
+          HttpStatusCode.Created
+
+        val grants =
+          client
+            .get("/v1/folder/${child.id}/permission") { bearerAuth(granted) }
+            .body<List<FolderPermissionResponseV1>>()
+        grants.map { it.folderId } shouldBe listOf(parent.id)
+      }
+    }
+
+    should("re-open a restricted subtree with a role grant") {
+      testApplicationContext {
+        val admin = tokenWithRoles(adminRoles)
+        val granted = tokenFor("user-1")
+        val stranger = tokenFor("user-2")
+        seedUser(userFixture(oidcSub = "user-1"))
+
+        val parent = client.createFolderV1("Parent", stranger)
+        client.grantV1(parent.id, admin, FolderPermissionRequestV1(oidcSub = "user-1")) shouldHaveStatus
+          HttpStatusCode.Created
+        val child = client.createFolderV1("Child", granted, parentId = parent.id)
+
+        client.renameFolderV1(child.id, "Nope", stranger, parentId = parent.id) shouldHaveStatus
+          HttpStatusCode.Forbidden
+
+        client.grantV1(child.id, granted, FolderPermissionRequestV1(role = Role.WRITE)) shouldHaveStatus
+          HttpStatusCode.Created
+
+        client.renameFolderV1(child.id, "Open again", stranger, parentId = parent.id) shouldHaveStatus
+          HttpStatusCode.Created
+        client.renameFolderV1(parent.id, "Still locked", stranger) shouldHaveStatus
+          HttpStatusCode.Forbidden
+      }
+    }
+
+    should("grant write access through team membership") {
+      testApplicationContext {
+        val admin = tokenWithRoles(adminRoles)
+        val member = tokenFor("user-3")
+        val stranger = tokenFor("user-2")
+        seedUser(userFixture(oidcSub = "user-3"))
+
+        val team =
+          client
+            .post("/v1/team") {
+              bearerAuth(admin)
+              contentType(ContentType.Application.Json)
+              setBody(TeamRequestV1(name = "Test Team"))
+            }.body<TeamResponseV1>()
+        client.post("/v1/team/${team.id}/member") {
+          bearerAuth(admin)
+          contentType(ContentType.Application.Json)
+          setBody(AddTeamMemberRequestV1(oidcSub = "user-3"))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val folder = client.createFolderV1("Team Folder", admin)
+        client.grantV1(folder.id, admin, FolderPermissionRequestV1(teamId = team.id)) shouldHaveStatus
+          HttpStatusCode.Created
+
+        client.renameFolderV1(folder.id, "Nope", stranger) shouldHaveStatus HttpStatusCode.Forbidden
+        client.renameFolderV1(folder.id, "Renamed by member", member) shouldHaveStatus
+          HttpStatusCode.Created
+      }
+    }
+
+    should("never allow users without the WRITE role, even when granted") {
+      testApplicationContext {
+        val admin = tokenWithRoles(adminRoles)
+        val reader = tokenFor("reader", emptySet())
+        seedUser(userFixture(oidcSub = "reader"))
+
+        val folder = client.createFolderV1("Folder", admin)
+        client.grantV1(folder.id, admin, FolderPermissionRequestV1(oidcSub = "reader")) shouldHaveStatus
+          HttpStatusCode.Created
+
+        client.renameFolderV1(folder.id, "Nope", reader) shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/folder/${folder.id}/permission") { bearerAuth(reader) } shouldHaveStatus
+          HttpStatusCode.Forbidden
+      }
+    }
+
+    should("return 401 on permission endpoints when no token is provided") {
+      testApplicationContext {
+        client.get("/v1/folder/any-id/permission") shouldHaveStatus HttpStatusCode.Unauthorized
+        client.post("/v1/folder/any-id/permission") {
+          contentType(ContentType.Application.Json)
+        } shouldHaveStatus HttpStatusCode.Unauthorized
+        client.delete("/v1/folder/any-id/permission/any-grant") shouldHaveStatus
+          HttpStatusCode.Unauthorized
+      }
+    }
+  })
+
+private suspend fun HttpClient.createFolderV1(
+  name: String,
+  token: String,
+  parentId: String? = null,
+): FolderResponseV1 =
+  post("/v1/folder") {
+    bearerAuth(token)
+    contentType(ContentType.Application.Json)
+    setBody(FolderRequestV1(name = name, parentId = parentId))
+  }.also { it shouldHaveStatus HttpStatusCode.Created }
+    .body()
+
+private suspend fun HttpClient.renameFolderV1(
+  folderId: String,
+  name: String,
+  token: String,
+  parentId: String? = null,
+): HttpResponse =
+  patch("/v1/folder/$folderId") {
+    bearerAuth(token)
+    contentType(ContentType.Application.Json)
+    setBody(FolderRequestV1(name = name, parentId = parentId))
+  }
+
+private suspend fun HttpClient.grantV1(
+  folderId: String,
+  token: String,
+  request: FolderPermissionRequestV1,
+): HttpResponse =
+  post("/v1/folder/$folderId/permission") {
+    bearerAuth(token)
+    contentType(ContentType.Application.Json)
+    setBody(request)
+  }

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRouteTest.kt
@@ -307,27 +307,27 @@ class FolderRouteTest :
 
     should("allow read access but return 403 on write endpoints when authenticated with no roles") {
       testApplicationContext {
-        val t = tokenWithRoles(emptySet())
+        val readerToken = tokenWithRoles(emptySet())
 
-        client.get("/v1/folder") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.OK
-        client.get("/v1/folder/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.NotFound
-        client.get("/v1/folder/any-id/media") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.NotFound
+        client.get("/v1/folder") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/folder/any-id") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.NotFound
+        client.get("/v1/folder/any-id/media") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.NotFound
         client.post("/v1/folder") {
-          bearerAuth(t)
+          bearerAuth(readerToken)
           contentType(ContentType.Application.Json)
           setBody(FolderRequestV1(name = "Test Folder"))
         } shouldHaveStatus HttpStatusCode.Forbidden
         client.patch("/v1/folder/any-id") {
-          bearerAuth(t)
+          bearerAuth(readerToken)
           contentType(ContentType.Application.Json)
           setBody(FolderRequestV1(name = "Test Folder"))
         } shouldHaveStatus HttpStatusCode.Forbidden
-        client.delete("/v1/folder/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/folder/any-id") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
         client.post("/v1/folder/any-id/media") {
-          bearerAuth(t)
+          bearerAuth(readerToken)
           contentType(ContentType.Application.Json)
         } shouldHaveStatus HttpStatusCode.Forbidden
-        client.delete("/v1/folder/any-id/media/any-media-id") { bearerAuth(t) } shouldHaveStatus
+        client.delete("/v1/folder/any-id/media/any-media-id") { bearerAuth(readerToken) } shouldHaveStatus
           HttpStatusCode.Forbidden
       }
     }

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRouteTest.kt
@@ -1,5 +1,6 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.api
 
+import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagActionV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.TagBatchUpdateRequestV1
@@ -147,10 +148,10 @@ class MediaRouteTest :
       }
     }
 
-    should("return NOT_FOUND when restoring a non-existent media") {
+    should("return NOT_FOUND when an admin restores a non-existent media") {
       testApplicationContext {
         client.post("/v1/media/does-not-exist/restore") {
-          bearerAuth(token)
+          bearerAuth(tokenWithRoles(setOf(Role.ADMIN)))
         } shouldHaveStatus HttpStatusCode.NotFound
       }
     }
@@ -214,25 +215,25 @@ class MediaRouteTest :
 
     should("allow read access but return 403 on write endpoints when authenticated with no roles") {
       testApplicationContext {
-        val t = tokenWithRoles(emptySet())
+        val readerToken = tokenWithRoles(emptySet())
 
         client.get("/v1/media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
         client.get("/v1/media/any-media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.NotFound
         client.post("/v1/media") {
-          bearerAuth(t)
+          bearerAuth(readerToken)
           contentType(ContentType.Application.Json)
           setBody(mediaFixture().toMediaRequestV1())
         } shouldHaveStatus HttpStatusCode.Forbidden
         client.patch("/v1/media/any-id/tags") {
-          bearerAuth(t)
+          bearerAuth(readerToken)
           contentType(ContentType.Application.Json)
         } shouldHaveStatus HttpStatusCode.Forbidden
-        client.delete("/v1/media/any-id") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.post("/v1/media/any-id/restore") { bearerAuth(t) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/media/any-id") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/media/any-id/restore") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
       }
     }
 
-    should("allow WRITE token to access all endpoints") {
+    should("let a WRITE token write but reserve restoring from the bin for admins") {
       testApplicationContext {
         val fixture = mediaFixture { id = "auth-test-id" }
 
@@ -245,11 +246,11 @@ class MediaRouteTest :
         client.get("/v1/media") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
         client.get("/v1/media/${fixture.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
         client.delete("/v1/media/${fixture.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.NoContent
-        client.post("/v1/media/${fixture.id}/restore") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Created
+        client.post("/v1/media/${fixture.id}/restore") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
       }
     }
 
-    should("successfully restore a deleted media item") {
+    should("successfully restore a deleted media item as an admin") {
       testApplicationContext {
         val fixture = mediaFixture()
         val request = fixture.toMediaRequestV1()
@@ -269,7 +270,7 @@ class MediaRouteTest :
         } shouldHaveStatus HttpStatusCode.NotFound
 
         client.post("/v1/media/${fixture.id}/restore") {
-          bearerAuth(token)
+          bearerAuth(tokenWithRoles(setOf(Role.ADMIN)))
         } shouldHaveStatus HttpStatusCode.Created
 
         val restoredMedia =

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/TeamRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/TeamRouteTest.kt
@@ -239,24 +239,42 @@ class TeamRouteTest :
       }
     }
 
-    should("return 403 on all endpoints when authenticated without the ADMIN role") {
+    should("allow editors to list teams and members but not to modify them") {
       testApplicationContext {
-        client.get("/v1/team") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("/v1/team/any-id") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("/v1/team/any-id/member") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
+        val team = client.createTeamV1("Test Team", tokenWithRoles(adminRoles))
+
+        client.get("/v1/team") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/team/${team.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/team/${team.id}/member") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
         client.post("/v1/team") {
           bearerAuth(token)
           contentType(ContentType.Application.Json)
-          setBody(TeamRequestV1(name = "Test Team"))
+          setBody(TeamRequestV1(name = "Another Team"))
         } shouldHaveStatus HttpStatusCode.Forbidden
-        client.delete("/v1/team/any-id") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.post("/v1/team/any-id/member") {
+        client.delete("/v1/team/${team.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/team/${team.id}/member") {
           bearerAuth(token)
           contentType(ContentType.Application.Json)
           setBody(AddTeamMemberRequestV1(oidcSub = "any-user"))
         } shouldHaveStatus HttpStatusCode.Forbidden
-        client.delete("/v1/team/any-id/member/any-user") { bearerAuth(token) } shouldHaveStatus
+        client.delete("/v1/team/${team.id}/member/any-user") { bearerAuth(token) } shouldHaveStatus
           HttpStatusCode.Forbidden
+      }
+    }
+
+    should("return 403 on all endpoints when authenticated without roles") {
+      testApplicationContext {
+        val readerToken = tokenWithRoles(emptySet())
+
+        client.get("/v1/team") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/team/any-id") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/team/any-id/member") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.post("/v1/team") {
+          bearerAuth(readerToken)
+          contentType(ContentType.Application.Json)
+          setBody(TeamRequestV1(name = "Test Team"))
+        } shouldHaveStatus HttpStatusCode.Forbidden
+        client.delete("/v1/team/any-id") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
       }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/UserRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/UserRouteTest.kt
@@ -202,11 +202,23 @@ class UserRouteTest :
       }
     }
 
-    should("return 403 on all endpoints when authenticated without the ADMIN role") {
+    should("allow editors to list users but not sessions") {
       testApplicationContext {
-        client.get("/v1/user") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("/v1/user/any-id") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
-        client.get("/v1/user/any-id/session") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
+        seedUser(userFixture(oidcSub = "user-1"))
+
+        client.get("/v1/user") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/user/user-1") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.OK
+        client.get("/v1/user/user-1/session") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("return 403 on all endpoints when authenticated without roles") {
+      testApplicationContext {
+        val readerToken = tokenWithRoles(emptySet())
+
+        client.get("/v1/user") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/user/any-id") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("/v1/user/any-id/session") { bearerAuth(readerToken) } shouldHaveStatus HttpStatusCode.Forbidden
       }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsolePermissionGuardTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsolePermissionGuardTest.kt
@@ -1,0 +1,152 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderPermissionRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
+import ch.srgssr.pillarbox.backend.test.count
+import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.seedUser
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.userFixture
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import org.jsoup.Jsoup
+
+class ConsolePermissionGuardTest :
+  ShouldSpec({
+    should("show folder actions only on folders the editor can write") {
+      testApplicationContext {
+        login()
+        seedUser(userFixture(oidcSub = "other"))
+
+        val writable = client.createFolderV1("Writable")
+        val restricted = client.createFolderV1("Restricted")
+        client.restrictTo(restricted.id, "other")
+
+        val doc = Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/folder-grid").bodyAsText())
+
+        doc.count("#folder-menu-${writable.id}") shouldBe 1
+        doc.count("#folder-menu-${restricted.id}") shouldBe 0
+      }
+    }
+
+    should("hide media actions when the media's folder is restricted") {
+      testApplicationContext {
+        login()
+        seedUser(userFixture(oidcSub = "other"))
+
+        val folder = client.createFolderV1("Restricted")
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          contentType(ContentType.Application.Json)
+          setBody(media)
+        } shouldHaveStatus HttpStatusCode.Created
+        client.assign(folder.id, media.id)
+        client.restrictTo(folder.id, "other")
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/media-grid?folderId=${folder.id}").bodyAsText(),
+          )
+
+        doc.count(".media-card") shouldBe 1
+        doc.count(".media-card .actions") shouldBe 0
+      }
+    }
+
+    should("show media actions in a folder the editor can write") {
+      testApplicationContext {
+        login()
+
+        val folder = client.createFolderV1("Writable")
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          contentType(ContentType.Application.Json)
+          setBody(media)
+        } shouldHaveStatus HttpStatusCode.Created
+        client.assign(folder.id, media.id)
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/media-grid?folderId=${folder.id}").bodyAsText(),
+          )
+
+        doc.count(".media-card .actions") shouldBe 1
+      }
+    }
+
+    should("hide the New menu when the current folder is restricted") {
+      testApplicationContext {
+        login()
+        seedUser(userFixture(oidcSub = "other"))
+
+        val folder = client.createFolderV1("Restricted")
+        client.restrictTo(folder.id, "other")
+
+        Jsoup
+          .parse(client.get("${Navigation.CONSOLE}?folderId=${folder.id}").bodyAsText())
+          .count("#new-menu") shouldBe 0
+        Jsoup
+          .parse(client.get(Navigation.CONSOLE).bodyAsText())
+          .count("#new-menu") shouldBe 1
+      }
+    }
+
+    should("return FORBIDDEN when opening the editor for a restricted folder or media") {
+      testApplicationContext {
+        login()
+        seedUser(userFixture(oidcSub = "other"))
+
+        val folder = client.createFolderV1("Restricted")
+        val media = mediaFixture()
+        client.post("/v1/media") {
+          contentType(ContentType.Application.Json)
+          setBody(media)
+        } shouldHaveStatus HttpStatusCode.Created
+        client.assign(folder.id, media.id)
+        client.restrictTo(folder.id, "other")
+
+        client.get("${Navigation.CONSOLE}/editor?folderId=${folder.id}") shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("${Navigation.CONSOLE}/editor/${media.id}") shouldHaveStatus HttpStatusCode.Forbidden
+        client.get("${Navigation.CONSOLE}/editor/${media.id}/duplicate?folderId=${folder.id}") shouldHaveStatus
+          HttpStatusCode.Forbidden
+      }
+    }
+  })
+
+private suspend fun HttpClient.createFolderV1(name: String): FolderResponseV1 =
+  post("/v1/folder") {
+    contentType(ContentType.Application.Json)
+    setBody(FolderRequestV1(name = name))
+  }.also { it shouldHaveStatus HttpStatusCode.Created }
+    .body()
+
+private suspend fun HttpClient.assign(
+  folderId: String,
+  mediaId: String,
+) = post("/v1/folder/$folderId/media") {
+  contentType(ContentType.Application.Json)
+  setBody(AssignMediaRequestV1(mediaId = mediaId))
+} shouldHaveStatus HttpStatusCode.Created
+
+private suspend fun HttpClient.restrictTo(
+  folderId: String,
+  oidcSub: String,
+) = post("/v1/folder/$folderId/permission") {
+  contentType(ContentType.Application.Json)
+  setBody(FolderPermissionRequestV1(oidcSub = oidcSub))
+} shouldHaveStatus HttpStatusCode.Created

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRouteTest.kt
@@ -2,17 +2,27 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderPermissionRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
 import ch.srgssr.pillarbox.backend.test.count
 import ch.srgssr.pillarbox.backend.test.hxDelete
 import ch.srgssr.pillarbox.backend.test.hxGet
 import ch.srgssr.pillarbox.backend.test.hxPost
 import ch.srgssr.pillarbox.backend.test.login
 import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.seedUser
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.tokenWithRoles
+import ch.srgssr.pillarbox.backend.test.userFixture
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
@@ -59,6 +69,40 @@ class MediaGridRouteTest :
       }
     }
 
+    should("return FORBIDDEN when deleting media in a folder restricted to someone else") {
+      testApplicationContext {
+        login()
+
+        val media = mediaFixture()
+        client.hxPost("${Navigation.CONSOLE}/actions/media") {
+          contentType(ContentType.Application.Json)
+          setBody(media)
+        }
+
+        // The session cookie also authenticates against the V1 API.
+        val folder =
+          client
+            .post("/v1/folder") {
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Locked"))
+            }.body<FolderResponseV1>()
+        client.post("/v1/folder/${folder.id}/media") {
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = media.id))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        seedUser(userFixture(oidcSub = "someone-else"))
+        client.post("/v1/folder/${folder.id}/permission") {
+          bearerAuth(tokenWithRoles(setOf(Role.ADMIN)))
+          contentType(ContentType.Application.Json)
+          setBody(FolderPermissionRequestV1(oidcSub = "someone-else"))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.hxDelete("${Navigation.CONSOLE}/actions/media/${media.id}") shouldHaveStatus
+          HttpStatusCode.Forbidden
+      }
+    }
+
     should("return NOT_FOUND when deleting a non-existing media") {
       testApplicationContext {
         login()
@@ -67,9 +111,9 @@ class MediaGridRouteTest :
       }
     }
 
-    should("return NOT_FOUND when restoring a non-existing media") {
+    should("return NOT_FOUND when an admin restores a non-existing media") {
       testApplicationContext {
-        login()
+        login(roles = setOf(Role.ADMIN))
 
         client.hxPost("${Navigation.CONSOLE}/actions/media/not-a-media/restore") shouldHaveStatus
           HttpStatusCode.NotFound
@@ -104,7 +148,7 @@ class MediaGridRouteTest :
 
     should("show media in the active grid and hide it from the deleted grid after restoring") {
       testApplicationContext {
-        login()
+        login(roles = setOf(Role.ADMIN))
         val media = mediaFixture()
 
         client.hxPost("${Navigation.CONSOLE}/actions/media") {
@@ -138,12 +182,20 @@ class MediaGridRouteTest :
       }
     }
 
-    should("allow WRITE user to access all endpoints") {
+    should("let a WRITE user delete but reserve restoring from the bin for admins") {
       testApplicationContext {
         login(roles = setOf(Role.WRITE))
 
         client.hxGet("${Navigation.CONSOLE}/fragments/media-grid") shouldHaveStatus HttpStatusCode.OK
         client.hxDelete("${Navigation.CONSOLE}/actions/media/any-id") shouldHaveStatus HttpStatusCode.NotFound
+        client.hxPost("${Navigation.CONSOLE}/actions/media/any-id/restore") shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("let an admin restore from the bin") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+
         client.hxPost("${Navigation.CONSOLE}/actions/media/any-id/restore") shouldHaveStatus HttpStatusCode.NotFound
       }
     }

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepositoryTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepositoryTest.kt
@@ -1,0 +1,35 @@
+package ch.srgssr.pillarbox.backend.persistence.folder
+
+import ch.srgssr.pillarbox.backend.domain.model.Folder
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.testDb
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+
+class FolderRepositoryTest :
+  ShouldSpec({
+    val repository = FolderRepository(testDb)
+
+    should("return ancestors from the root down to the folder itself") {
+      testApplicationContext {
+        startApplication()
+
+        val root = repository.save(Folder(name = "Root"))
+        val mid = repository.save(Folder(name = "Mid", parentId = root.id))
+        val leaf = repository.save(Folder(name = "Leaf", parentId = mid.id))
+
+        repository.findAncestors(leaf.id).map { it.id } shouldBe listOf(root.id, mid.id, leaf.id)
+        repository.findAncestors(mid.id).map { it.id } shouldBe listOf(root.id, mid.id)
+        repository.findAncestors(root.id).map { it.id } shouldBe listOf(root.id)
+      }
+    }
+
+    should("return an empty list for an unknown folder") {
+      testApplicationContext {
+        startApplication()
+
+        repository.findAncestors("does-not-exist").shouldBeEmpty()
+      }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionRepositoryTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/session/SessionRepositoryTest.kt
@@ -3,9 +3,11 @@ package ch.srgssr.pillarbox.backend.persistence.session
 import ch.srgssr.pillarbox.backend.db.EncryptionService
 import ch.srgssr.pillarbox.backend.domain.model.Session
 import ch.srgssr.pillarbox.backend.test.seedSession
+import ch.srgssr.pillarbox.backend.test.seedUser
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import ch.srgssr.pillarbox.backend.test.testDatabaseConfig
 import ch.srgssr.pillarbox.backend.test.testDb
+import ch.srgssr.pillarbox.backend.test.userFixture
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -21,6 +23,7 @@ class SessionRepositoryTest :
 
     should("save, find and delete a session by its stored id") {
       testApplicationContext {
+        seedUser(userFixture(oidcSub = "test-sub"))
         val session =
           seedSession(
             Session(
@@ -46,6 +49,7 @@ class SessionRepositoryTest :
 
     should("store the tokens encrypted at rest") {
       testApplicationContext {
+        seedUser(userFixture(oidcSub = "test-sub"))
         val session =
           seedSession(
             Session(

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestDatabase.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestDatabase.kt
@@ -1,0 +1,43 @@
+package ch.srgssr.pillarbox.backend.test
+
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Shared PostgreSQL container backing the test suite.
+ *
+ * A single container is started lazily on first use and reused across every test, so the suite
+ * exercises the real Flyway migrations and PostgreSQL production behaviour. Per-test isolation
+ * is achieved by [truncateAll] rather than by recreating the schema.
+ *
+ * Requires a running Docker daemon.
+ */
+object TestDatabase {
+  val container: PostgreSQLContainer<*> by lazy {
+    PostgreSQLContainer(DockerImageName.parse("postgres:16-alpine")).apply { start() }
+  }
+
+  /**
+   * Empties every data table in the `public` schema, leaving the migrated schema and Flyway
+   * history intact so the next test starts from a clean slate.
+   */
+  fun truncateAll() {
+    container.createConnection("").use { connection ->
+      connection.createStatement().use { statement ->
+        val tables = mutableListOf<String>()
+        statement
+          .executeQuery(
+            "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> 'flyway_schema_history'",
+          ).use { rows ->
+            while (rows.next()) {
+              tables += rows.getString(1)
+            }
+          }
+
+        if (tables.isNotEmpty()) {
+          statement.execute("TRUNCATE TABLE ${tables.joinToString(", ") { "\"$it\"" }} RESTART IDENTITY CASCADE")
+        }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -15,9 +15,6 @@ import io.ktor.util.AttributeKey
 import kotlinx.serialization.json.Json
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.jetbrains.exposed.v1.core.Table
-import org.jetbrains.exposed.v1.jdbc.SchemaUtils
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.koin.core.context.GlobalContext
 
 val writeRoles: Set<Role> = setOf(Role.WRITE)
@@ -26,11 +23,12 @@ val writeRoles: Set<Role> = setOf(Role.WRITE)
  * Executes an integration test within a managed Ktor application environment.
  *
  * This utility automates the integration testing by:
- *    1. Loading the standard `application.conf` to configure the server and database.
+ *    1. Loading the standard `application.conf` and pointing the database at the shared
+ *       [TestDatabase] PostgreSQL container, so the real Flyway migrations are exercised.
  *    2. Providing a pre-configured [HttpClient] with JSON support for API calls.
  *    3. Overriding `oidc.issuer` in the config to point to the mock server.
- *    4. Ensuring database isolation between tests by dropping and recreating all
- *       registered [Table] schemas after each test execution.
+ *    4. Ensuring database isolation between tests by truncating all tables after each
+ *       test execution.
  *
  * @param block The test logic to execute, provides access to the [ApplicationTestBuilder]
  *              and a pre-configured `client` with JSON support.
@@ -44,6 +42,10 @@ fun testApplicationContext(
   testApplication {
     configure("application.conf") {
       this["ktor.deployment.enable_forwarded_headers"] = enableProxyHeaders.toString()
+      this["database.driverClassName"] = "org.postgresql.Driver"
+      this["database.jdbcUrl"] = TestDatabase.container.jdbcUrl
+      this["database.username"] = TestDatabase.container.username
+      this["database.password"] = TestDatabase.container.password
       this["oidc.issuer"] = oAuthServer.issuerUrl("pillarbox-realm").toString()
       this["oidc.discovery_path"] = ".well-known/openid-configuration"
       this["oidc.client_id"] = "pillarbox-test-client"
@@ -67,16 +69,7 @@ fun testApplicationContext(
       application.attributes.put(MockServerKey, oAuthServer)
       block()
     } finally {
-      val allTables =
-        GlobalContext
-          .get()
-          .get<List<Table>>()
-          .toTypedArray()
-      transaction {
-        SchemaUtils.drop(*allTables)
-        SchemaUtils.create(*allTables)
-      }
-
+      TestDatabase.truncateAll()
       oAuthServer.shutdown()
     }
   }
@@ -98,6 +91,23 @@ fun ApplicationTestBuilder.tokenWithRoles(roles: Set<Role>): String =
       issuerId = "pillarbox-realm",
       audience = "pillarbox-test-client",
       claims = mapOf("roles" to roles.map { it.key }),
+    ).serialize()
+
+fun ApplicationTestBuilder.tokenFor(
+  subject: String,
+  roles: Set<Role> = writeRoles,
+): String =
+  mockServer
+    .issueToken(
+      issuerId = "pillarbox-realm",
+      clientId = "pillarbox-test-client",
+      tokenCallback =
+        DefaultOAuth2TokenCallback(
+          issuerId = "pillarbox-realm",
+          subject = subject,
+          audience = listOf("pillarbox-test-client"),
+          claims = mapOf("roles" to roles.map { it.key }),
+        ),
     ).serialize()
 
 suspend fun ApplicationTestBuilder.login(roles: Set<Role> = writeRoles): HttpResponse {

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/UserFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/UserFixtures.kt
@@ -11,21 +11,22 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 
 /**
- * Connection to the same in-memory H2 database used by the application under test.
+ * Connection to the same [TestDatabase] PostgreSQL container used by the application under test.
  *
  * The Ktor test engine loads application classes in a child classloader, so repository
  * instances obtained from the application's Koin context cannot be used directly from
- * test code. Seeding goes through this dedicated connection instead, configured to
- * match `src/test/resources/application.conf`.
+ * test code. Seeding goes through this dedicated connection instead, pointed at the same
+ * container so it shares the schema and data with the application.
  */
-val testDatabaseConfig =
+val testDatabaseConfig by lazy {
   DatabaseConfig(
-    driverClassName = "org.h2.Driver",
-    jdbcUrl = "jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
-    username = "sa",
-    password = "",
+    driverClassName = "org.postgresql.Driver",
+    jdbcUrl = TestDatabase.container.jdbcUrl,
+    username = TestDatabase.container.username,
+    password = TestDatabase.container.password,
     encryptionKey = "test-encryption-key-32-chars-long!!",
   )
+}
 
 val testDb by lazy {
   with(testDatabaseConfig) {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,11 +1,10 @@
 database {
-  autoCreate = true
-  driverClassName = "org.h2.Driver"
-  jdbcUrl = "jdbc:h2:mem:test_db;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
-  username = "sa"
-  password = ""
+  driverClassName = "org.postgresql.Driver"
+  jdbcUrl = "jdbc:postgresql://localhost:5432/test"
+  username = "test"
+  password = "test"
   encryptionKey = "test-encryption-key-32-chars-long!!"
-  poolSize = 5
+  poolSize = 2
 }
 
 session {


### PR DESCRIPTION
## Description

Lets content be locked down to specific people. By default any editor may write anywhere; a folder becomes restricted as soon as it (or an ancestor) carries a grant, and from then on only granted subjects and administrators may change it or its media. Reading stays open to every authenticated user.

## Changes Made

- Add a folder permission API to grant, list and revoke write access for a user, a team or a role; grants are inherited by subfolders and can be managed by anyone who can already write the folder.
- Enforce write access consistently across the media and folder APIs and the web console (create, edit, move, delete and assignment) through a single reusable guard, and surface it in the console so restricted items render read-only.
- Reserve restoring media from the bin for administrators.
- Refresh the development and API documentation to match.
- Run the test suite against a real PostgreSQL through Testcontainers and the actual Flyway migrations instead of in-memory H2, so tests exercise the same schema and constraints as production.
- Simplify MediaRoute versioning.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
