### PR TITLE
feat(console): manage folder permissions from the web console

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -96,7 +96,7 @@ fun Application.module() {
     folder(get(), get(), get(), get(), get())
     user(get(), get())
     team(get(), get())
-    console(get(), get())
+    console(get(), get(), get(), get(), get())
     playerMedia(get(), get())
   }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
@@ -2,8 +2,11 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
 import ch.srgssr.pillarbox.backend.auth.AuthenticatedUserPlugin
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import io.ktor.server.auth.authenticate
 import io.ktor.server.http.content.staticResources
 import io.ktor.server.routing.Route
@@ -14,10 +17,16 @@ import io.ktor.server.routing.route
  *
  * @param mediaRepository Repository used to read and persist media items.
  * @param folderRepository Repository used to read and persist folder structure.
+ * @param folderPermissionRepository Repository used to read and manage folder grants.
+ * @param userRepository Repository used to resolve and search users for grants.
+ * @param teamRepository Repository used to resolve and search teams for grants.
  */
 fun Route.console(
   mediaRepository: MediaRepository,
   folderRepository: FolderRepository,
+  folderPermissionRepository: FolderPermissionRepository,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
 ) {
   authenticate("pillarbox-session") {
     install(AuthenticatedUserPlugin)
@@ -25,7 +34,7 @@ fun Route.console(
     staticResources("/static", "static")
 
     route(Navigation.CONSOLE) {
-      homePage(mediaRepository, folderRepository)
+      homePage(mediaRepository, folderRepository, folderPermissionRepository, userRepository, teamRepository)
       editorPage(mediaRepository, folderRepository)
     }
   }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/DatalistOption.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/DatalistOption.kt
@@ -1,0 +1,15 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+/**
+ * A single `<option>` for a datalist-backed autocomplete input.
+ *
+ * @property value Text filled into the input (and shown) when the option is chosen.
+ * @property label Optional hint shown next to the value in the suggestion dropdown.
+ * @property id Optional stable identifier, rendered as `data-id` so a script can submit it
+ *   instead of the free-typed [value].
+ */
+data class DatalistOption(
+  val value: String,
+  val label: String? = null,
+  val id: String? = null,
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/FolderPermissionRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/FolderPermissionRoute.kt
@@ -1,0 +1,267 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.authz.withFolderWrite
+import ch.srgssr.pillarbox.backend.domain.model.FolderPermission
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.log.info
+import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamTable
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserTable
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.htmx.hx
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.post
+import io.ktor.server.util.getOrFail
+import io.ktor.utils.io.ExperimentalKtorApi
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.lowerCase
+
+private object ConsolePermissionRoute
+
+private val logger = ConsolePermissionRoute.logger()
+
+/**
+ * Registers the read-only HTMX fragments backing the folder permissions dialog.
+ *
+ * @param folderRepository Repository used to resolve folders.
+ * @param folderPermissionRepository Repository used to read folder grants.
+ * @param userRepository Repository used to resolve and search users.
+ * @param teamRepository Repository used to resolve and search teams.
+ */
+@OptIn(ExperimentalKtorApi::class)
+fun Route.folderPermissionFragments(
+  folderRepository: FolderRepository,
+  folderPermissionRepository: FolderPermissionRepository,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
+) {
+  hx.get("fragments/folder-permissions") {
+    val folderId = call.queryParameters.getOrFail("folderId")
+    val folder = folderRepository.find(folderId) ?: return@get call.respond(HttpStatusCode.NotFound)
+    withFolderWrite(folderId) {
+      call.respondWithContext("modules/home/fragments/folder-permissions.fragment.peb", mapOf("folder" to folder))
+    }
+  }
+
+  hx.get("fragments/folder-permissions-list") {
+    val folderId = call.queryParameters.getOrFail("folderId")
+    val folder = folderRepository.find(folderId) ?: return@get call.respond(HttpStatusCode.NotFound)
+    withFolderWrite(folderId) {
+      val rows = permissionRows(folderId, folderPermissionRepository, userRepository, teamRepository)
+      call.respondWithContext(
+        "modules/home/fragments/folder-permissions-list.fragment.peb",
+        mapOf("folder" to folder, "rows" to rows),
+      )
+    }
+  }
+
+  hx.get("fragments/subject-options") {
+    val query = call.queryParameters["subject"].orEmpty().trim()
+    call.respondWithContext(
+      "shared/fragments/datalist-options.fragment.peb",
+      mapOf("options" to searchSubjects(query, userRepository, teamRepository)),
+    )
+  }
+}
+
+/**
+ * Registers the HTMX actions that create, update and revoke a folder's grants.
+ *
+ * @param folderRepository Repository used to resolve folders.
+ * @param folderPermissionRepository Repository used to persist folder grants.
+ * @param userRepository Repository used to resolve and validate users.
+ * @param teamRepository Repository used to resolve and validate teams.
+ */
+@OptIn(ExperimentalKtorApi::class)
+@Suppress("LongMethod")
+fun Route.folderPermissionActions(
+  folderRepository: FolderRepository,
+  folderPermissionRepository: FolderPermissionRepository,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
+) {
+  hx.post("actions/folder/{id}/permission") {
+    val id = call.parameters.getOrFail("id")
+    val folder = folderRepository.find(id) ?: return@post call.respond(HttpStatusCode.NotFound)
+    val params = call.receiveParameters()
+    val canWrite = params["level"] == "write"
+
+    withFolderWrite(id) {
+      val resolved = resolveSubject(params["subjectRef"].orEmpty(), userRepository, teamRepository)
+      if (resolved == null) {
+        call.respond(HttpStatusCode.UnprocessableEntity, "Select a user or team from the suggestions")
+        return@withFolderWrite
+      }
+
+      logger.info { "Granting ${if (canWrite) "write" else "view"} on folder $id to ${resolved.subject}" }
+      val key = subjectKey(resolved.subject)
+      val replacesExistingRow = folderPermissionRepository.findGrantsInChain(id).any { subjectKey(it.subject) == key }
+      folderPermissionRepository.save(FolderPermission(folderId = id, subject = resolved.subject, canWrite = canWrite))
+      val row = PermissionRow(key, resolved.label, canWrite, inherited = false)
+      call.respondWithContext(
+        "modules/home/fragments/permission-row.fragment.peb",
+        mapOf("folder" to folder, "row" to row, "oob" to replacesExistingRow),
+      )
+    }
+  }
+
+  hx.patch("actions/folder/{id}/permission/{subject}") {
+    val id = call.parameters.getOrFail("id")
+    val subjectRef = call.parameters.getOrFail("subject")
+    folderRepository.find(id) ?: return@patch call.respond(HttpStatusCode.NotFound)
+    val canWrite = call.receiveParameters()["level"] == "write"
+
+    withFolderWrite(id) {
+      val subject =
+        if (subjectRef == "editor") {
+          PermissionSubject.ForRole(Role.WRITE)
+        } else {
+          subjectRef.toSubject()?.takeIf { folderPermissionRepository.findGrant(id, it) != null }
+        }
+      if (subject == null) {
+        call.respond(HttpStatusCode.NotFound)
+      } else {
+        folderPermissionRepository.save(FolderPermission(folderId = id, subject = subject, canWrite = canWrite))
+        call.respond(HttpStatusCode.NoContent)
+      }
+    }
+  }
+
+  hx.delete("actions/folder/{id}/permission/{subject}") {
+    val id = call.parameters.getOrFail("id")
+    val subjectRef = call.parameters.getOrFail("subject")
+
+    withFolderWrite(id) {
+      val grant = subjectRef.toSubject()?.let { folderPermissionRepository.findGrant(id, it) }
+      if (grant == null) {
+        call.respond(HttpStatusCode.NotFound)
+        return@withFolderWrite
+      }
+
+      logger.info { "Revoking ${grant.subject} on folder $id" }
+      folderPermissionRepository.delete(grant.id)
+
+      val inherited =
+        folderPermissionRepository.findGrantsInChain(id).firstOrNull { subjectKey(it.subject) == subjectRef }
+      val folder = inherited?.let { folderRepository.find(id) }
+      when {
+        inherited == null -> {
+          call.respond(HttpStatusCode.NoContent)
+        }
+
+        folder == null -> {
+          call.respond(HttpStatusCode.NotFound)
+        }
+
+        else -> {
+          val label = resolveSubject(subjectRef, userRepository, teamRepository)?.label ?: subjectRef
+          val row = PermissionRow(subjectRef, label, inherited.canWrite, inherited = true)
+          call.response.headers.append("HX-Reswap", "outerHTML")
+          call.respondWithContext(
+            "modules/home/fragments/permission-row.fragment.peb",
+            mapOf("folder" to folder, "row" to row, "oob" to false),
+          )
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Searches users and teams with the same query and merges them into one name-sorted suggestion list.
+ *
+ * @param query The text typed into the search box; blank lists the most recently updated subjects.
+ * @param userRepository Repository used to search users by display name.
+ * @param teamRepository Repository used to search teams by name.
+ * @param limit The maximum number of suggestions to return.
+ * @return Up to [limit] options, each carrying a `User`/`Team` label and a `type:id` reference.
+ */
+private suspend fun searchSubjects(
+  query: String,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
+  limit: Int = 20,
+): List<DatalistOption> {
+  val term = query.takeIf { it.isNotBlank() }?.lowercase()
+  val users =
+    userRepository
+      .getAll(
+        limit = limit,
+        filter = term?.let { { UserTable.displayName.lowerCase() like "%$it%" } },
+        sort = listOf(UserTable.updatedAt to SortOrder.DESC),
+      ).toList()
+      .map { DatalistOption(it.displayName, "User", "user:${it.oidcSub}") }
+  val teams =
+    teamRepository
+      .getAll(
+        limit = limit,
+        filter = term?.let { { TeamTable.name.lowerCase() like "%$it%" } },
+        sort = listOf(TeamTable.createdAt to SortOrder.DESC),
+      ).toList()
+      .map { DatalistOption(it.name, "Team", "team:${it.id}") }
+  return (teams + users).sortedBy { it.value.lowercase() }.take(limit)
+}
+
+/** A subject reference resolved against the directory, carrying the display name for its first row. */
+private data class ResolvedSubject(
+  val subject: PermissionSubject,
+  val label: String,
+)
+
+/**
+ * Resolves a `user:id`/`team:id` reference to an existing subject, fetching its display name in the
+ * same lookup that confirms it exists.
+ *
+ * @param ref The `type:id` reference to resolve.
+ * @param userRepository Repository used to resolve a referenced user.
+ * @param teamRepository Repository used to resolve a referenced team.
+ * @return The subject with its label, or `null` when the reference is malformed or unknown.
+ */
+private suspend fun resolveSubject(
+  ref: String,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
+): ResolvedSubject? =
+  when (val subject = ref.toSubject()) {
+    is PermissionSubject.ForUser -> {
+      userRepository
+        .find(
+          subject.oidcSub,
+        )?.let { ResolvedSubject(subject, it.displayName) }
+    }
+
+    is PermissionSubject.ForTeam -> {
+      teamRepository.find(subject.teamId)?.let { ResolvedSubject(subject, it.name) }
+    }
+
+    else -> {
+      null
+    }
+  }
+
+/**
+ * Parses a `user:<id>` or `team:<id>` reference into a [PermissionSubject].
+ *
+ * @receiver The `type:id` reference to parse.
+ * @return The subject, or `null` when the receiver is not a user or team reference.
+ */
+private fun String.toSubject(): PermissionSubject? {
+  val (type, id) = split(":", limit = 2).takeIf { it.size == 2 } ?: return null
+  return when (type) {
+    "user" -> PermissionSubject.ForUser(id)
+    "team" -> PermissionSubject.ForTeam(id)
+    else -> null
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
@@ -10,9 +10,12 @@ import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.log.debug
 import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.htmx.hx
 import io.ktor.server.request.receiveParameters
@@ -37,10 +40,16 @@ private val logger = HomeRoute.logger()
  *
  * @param mediaRepository Repository used to read and soft-delete media items.
  * @param folderRepository Repository used to read, create, and manage folder structure.
+ * @param folderPermissionRepository Repository used to read and manage folder grants.
+ * @param userRepository Repository used to resolve and search users for grants.
+ * @param teamRepository Repository used to resolve and search teams for grants.
  */
 fun Route.homePage(
   mediaRepository: MediaRepository,
   folderRepository: FolderRepository,
+  folderPermissionRepository: FolderPermissionRepository,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
 ) {
   get {
     val folder =
@@ -74,6 +83,8 @@ fun Route.homePage(
   withRole(Role.WRITE) {
     folderActions(mediaRepository, folderRepository)
     mediaGridActions(mediaRepository)
+    folderPermissionFragments(folderRepository, folderPermissionRepository, userRepository, teamRepository)
+    folderPermissionActions(folderRepository, folderPermissionRepository, userRepository, teamRepository)
   }
 
   withRole(Role.ADMIN) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/PermissionRow.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/PermissionRow.kt
@@ -1,0 +1,138 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.domain.model.FolderPermission
+import ch.srgssr.pillarbox.backend.domain.model.PermissionSubject
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamTable
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserTable
+import kotlinx.coroutines.flow.toList
+import org.jetbrains.exposed.v1.core.inList
+
+/**
+ * A single row rendered in the permissions dialog.
+ *
+ * @property subject Role key (`admin`/`editor`/`viewer`) or `user:id`/`team:id` reference; also the edit/delete key.
+ * @property label Display name shown for the subject.
+ * @property canWrite Whether the row grants write access.
+ * @property inherited Whether the grant comes from an ancestor folder, in which case it is shown read-only.
+ */
+data class PermissionRow(
+  val subject: String,
+  val label: String,
+  val canWrite: Boolean,
+  val inherited: Boolean,
+)
+
+/**
+ * Builds the rows shown in the dialog: the three fixed role rows, then the folder's own user and
+ * team grants, then the grants inherited from ancestor folders that the folder does not itself
+ * override. Administrators always write and the viewer baseline is always read-only; editors write
+ * unless a `ForRole(WRITE)` grant in the chain holds them to view.
+ *
+ * @param folderId The folder whose permission rows are built.
+ * @param folderPermissionRepository Repository used to read the folder's grant chain.
+ * @param userRepository Repository used to resolve user display names.
+ * @param teamRepository Repository used to resolve team names.
+ * @return The role rows, then own grant rows, then inherited grant rows, each group ordered by creation.
+ */
+suspend fun permissionRows(
+  folderId: String,
+  folderPermissionRepository: FolderPermissionRepository,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
+): List<PermissionRow> {
+  val chain = folderPermissionRepository.findGrantsInChain(folderId)
+  val (own, inherited) = chain.partition { it.folderId == folderId }
+
+  val ownGrants = own.subjectGrants()
+  val ownKeys = ownGrants.mapTo(mutableSetOf()) { subjectKey(it.subject) }
+  val inheritedGrants = inherited.subjectGrants().filterNot { subjectKey(it.subject) in ownKeys }
+
+  val labels = resolveLabels(ownGrants + inheritedGrants, userRepository, teamRepository)
+
+  val roles =
+    listOf(
+      PermissionRow("admin", "Admin", canWrite = true, inherited = false),
+      PermissionRow("editor", "Editor", canWrite = chain.editorsCanWrite(), inherited = false),
+      PermissionRow("viewer", "Viewer", canWrite = false, inherited = false),
+    )
+
+  return roles +
+    ownGrants.map { it.toRow(inherited = false, labels) } +
+    inheritedGrants.map { it.toRow(inherited = true, labels) }
+}
+
+/**
+ * Builds the `type:id` reference identifying a subject in the dialog.
+ *
+ * @param subject The grant subject to encode.
+ * @return `user:<oidcSub>`, `team:<teamId>` or the role key.
+ */
+internal fun subjectKey(subject: PermissionSubject): String =
+  when (subject) {
+    is PermissionSubject.ForUser -> "user:${subject.oidcSub}"
+    is PermissionSubject.ForTeam -> "team:${subject.teamId}"
+    is PermissionSubject.ForRole -> subject.role.key
+  }
+
+/** The user and team grants in this list ordered by creation; role grants are dropped. */
+private fun List<FolderPermission>.subjectGrants(): List<FolderPermission> =
+  filter { it.subject !is PermissionSubject.ForRole }.sortedBy { it.createdAt }
+
+/**
+ * Whether editors may write the folder this grant chain belongs to, mirroring the permission
+ * checker: editors write an unrestricted folder, or a restricted one only while a `ForRole(WRITE)`
+ * grant in the chain still confers write — so an editor restriction set on an ancestor is reflected.
+ */
+private fun List<FolderPermission>.editorsCanWrite(): Boolean =
+  isEmpty() || any { (it.subject as? PermissionSubject.ForRole)?.role == Role.WRITE && it.canWrite }
+
+private fun FolderPermission.toRow(
+  inherited: Boolean,
+  labels: Map<String, String>,
+): PermissionRow {
+  val key = subjectKey(subject)
+  return PermissionRow(key, labels[key] ?: rawId(subject), canWrite, inherited)
+}
+
+/** The bare identifier of a subject, used as a label fallback when the user or team is gone. */
+private fun rawId(subject: PermissionSubject): String =
+  when (subject) {
+    is PermissionSubject.ForUser -> subject.oidcSub
+    is PermissionSubject.ForTeam -> subject.teamId
+    is PermissionSubject.ForRole -> subject.role.name
+  }
+
+/**
+ * Resolves the display names of every user and team grant in [grants] in two batched queries,
+ * keyed by [subjectKey] so a row can look its label up without a per-row lookup.
+ *
+ * @return A map from each grant's `type:id` reference to its display name; subjects whose user or
+ *   team no longer exists are absent and fall back to their raw id.
+ */
+private suspend fun resolveLabels(
+  grants: List<FolderPermission>,
+  userRepository: UserRepository,
+  teamRepository: TeamRepository,
+): Map<String, String> {
+  val userIds = grants.mapNotNull { (it.subject as? PermissionSubject.ForUser)?.oidcSub }.distinct()
+  val teamIds = grants.mapNotNull { (it.subject as? PermissionSubject.ForTeam)?.teamId }.distinct()
+
+  return buildMap {
+    if (userIds.isNotEmpty()) {
+      userRepository
+        .getAll(limit = userIds.size, filter = { UserTable.oidcSub inList userIds })
+        .toList()
+        .forEach { put("user:${it.oidcSub}", it.displayName) }
+    }
+    if (teamIds.isNotEmpty()) {
+      teamRepository
+        .getAll(limit = teamIds.size, filter = { TeamTable.id inList teamIds })
+        .toList()
+        .forEach { put("team:${it.id}", it.name) }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderPermissionRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderPermissionRepository.kt
@@ -9,6 +9,7 @@ import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
@@ -16,6 +17,7 @@ import org.jetbrains.exposed.v1.core.statements.UpdateStatement
 import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.upsert
 
 /**
  * Repository responsible for the persistence and retrieval of [FolderPermission] grants using Exposed.
@@ -68,6 +70,54 @@ class FolderPermissionRepository(
   override fun encodeOnUpdate(item: FolderPermission): (UpsertBuilder.(UpdateStatement) -> Unit) =
     {
       it[FolderPermissionTable.canWrite] = item.canWrite
+    }
+
+  /**
+   * Upserts a grant on its natural key — the unique `(folder_id, oidc_sub, team_id, role)` tuple —
+   * rather than the surrogate [FolderPermissionTable.id]. Re-granting a subject that already has a
+   * grant (e.g. toggling the editor role) therefore updates its access level in place instead of
+   * inserting a conflicting row.
+   *
+   * @param item The grant to insert or update.
+   * @return The persisted grant.
+   */
+  override suspend fun save(item: FolderPermission): FolderPermission =
+    query {
+      val statement =
+        FolderPermissionTable.upsert(
+          FolderPermissionTable.folderId,
+          FolderPermissionTable.oidcSub,
+          FolderPermissionTable.teamId,
+          FolderPermissionTable.role,
+          onUpdate = encodeOnUpdate(item),
+        ) { encode(it, item) }
+      FolderPermissionTable
+        .selectAll()
+        .where { FolderPermissionTable.id eq statement[FolderPermissionTable.id] }
+        .single()
+        .decode()
+    }
+
+  /**
+   * Finds the folder's own grant for [subject], looking only at the folder itself and matching the
+   * subject columns directly, so editing or revoking a single grant costs one indexed lookup
+   * instead of reading the whole ancestor chain.
+   *
+   * @param folderId The folder whose own grant is searched.
+   * @param subject The subject the grant must apply to.
+   * @return The matching own grant, or `null` when the folder has no own grant for the subject.
+   */
+  suspend fun findGrant(
+    folderId: String,
+    subject: PermissionSubject,
+  ): FolderPermission? =
+    findOne {
+      (FolderPermissionTable.folderId eq folderId) and
+        when (subject) {
+          is PermissionSubject.ForUser -> FolderPermissionTable.oidcSub eq subject.oidcSub
+          is PermissionSubject.ForTeam -> FolderPermissionTable.teamId eq subject.teamId
+          is PermissionSubject.ForRole -> FolderPermissionTable.role eq subject.role.key
+        }
     }
 
   /**

--- a/src/main/resources/static/css/layouts/_forms.css
+++ b/src/main/resources/static/css/layouts/_forms.css
@@ -23,12 +23,12 @@
   font-size: var(--font-size-1);
   color: var(--text-1);
 
-  background: var(--surface-2);
+  background-color: var(--surface-2);
   outline: none;
 
   transition:
     border-color 0.2s var(--ease-out-3),
-    background 0.15s var(--ease-out-3),
+    background-color 0.15s var(--ease-out-3),
     box-shadow 0.2s var(--ease-out-3);
 }
 
@@ -37,17 +37,33 @@
   opacity: 0.6;
 }
 
+/* Custom chevron — appearance:none lets us inset it from the right edge. */
+.field select {
+  padding-inline-end: calc(var(--size-3) + var(--size-6));
+
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238a8a8a' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--size-3) center;
+  background-size: 1em;
+}
+
+/* Drop Chrome's datalist dropdown arrow; typing and the Down key still open it. */
+.field input[list]::-webkit-calendar-picker-indicator {
+  display: none !important;
+}
+
 /* ── Hover ── */
 
 .field :is(input:not([type="checkbox"], [type="radio"]), textarea, select):hover {
-  background: var(--surface-3);
+  background-color: var(--surface-3);
 }
 
 /* ── Focus ── */
 
 .field :is(input:not([type="checkbox"], [type="radio"]), textarea, select):focus {
   border-color: var(--accent);
-  background: var(--surface-1);
+  background-color: var(--surface-1);
   box-shadow: 0 0 0 3px var(--accent-softer);
 }
 
@@ -81,7 +97,7 @@ label.checkbox {
   cursor: not-allowed;
   color: var(--text-2);
   opacity: 0.5;
-  background: var(--surface-1);
+  background-color: var(--surface-1);
 }
 
 /* ── Error state — CSS-only, no classes on fields ── */
@@ -89,7 +105,7 @@ label.checkbox {
 /* Live feedback after user interacts with a field, or after a submit attempt */
 .field :is(input:not([type="checkbox"], [type="radio"]), textarea, select):user-invalid,
 form[data-submitted] .field :is(input:not([type="checkbox"], [type="radio"]), textarea, select):invalid {
-  background: color-mix(in srgb, var(--red-6) 8%, var(--surface-2));
+  background-color: color-mix(in srgb, var(--red-6) 8%, var(--surface-2));
 }
 
 .field :is(input:not([type="checkbox"], [type="radio"]), textarea, select):user-invalid:focus,

--- a/src/main/resources/static/css/modules/home/folder-permissions.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-permissions.fragment.css
@@ -1,0 +1,143 @@
+.folder-permissions-dialog {
+  inline-size: min(92vw, 46rem);
+  max-inline-size: 46rem;
+}
+
+.permissions-dialog {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4);
+}
+
+/* ── Permission tables ── */
+.permission-table {
+  display: flex;
+  flex-direction: column;
+}
+
+.permission-table + .permission-table {
+  margin-block-start: var(--size-3);
+}
+
+/* Append target for new grants; transparent to the table's row layout. */
+#permission-grants {
+  display: contents;
+}
+
+.permission-row-head,
+.permission-row {
+  display: grid;
+  grid-template-columns: 1fr minmax(7rem, 11rem) var(--size-7);
+  gap: var(--size-3);
+  align-items: center;
+}
+
+.permission-row-head {
+  padding: 0 var(--size-3) var(--size-2);
+  font-size: var(--font-size-0);
+  font-weight: var(--font-weight-6);
+  color: var(--text-2);
+}
+
+.permission-head-level {
+  grid-column: 2;
+}
+
+.permission-row {
+  padding: var(--size-2) var(--size-3);
+  border-radius: var(--radius-2);
+}
+
+.permission-row:hover {
+  background: var(--surface-2);
+}
+
+.permission-subject {
+  display: flex;
+  gap: var(--size-2);
+  align-items: center;
+  min-inline-size: 0;
+}
+
+.permission-avatar {
+  display: grid;
+  place-items: center;
+
+  inline-size: var(--size-7);
+  block-size: var(--size-7);
+  border-radius: var(--radius-round);
+
+  color: var(--text-2);
+
+  background: var(--surface-3);
+}
+
+.permission-avatar .material-symbols-outlined {
+  font-size: 18px;
+}
+
+.permission-name {
+  overflow: hidden;
+  color: var(--text-1);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.permission-lock {
+  cursor: help;
+  justify-self: center;
+  font-size: 18px;
+  color: var(--text-3);
+}
+
+.permission-lock:focus-visible {
+  border-radius: var(--radius-1);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.permission-delete {
+  justify-self: center;
+  color: var(--text-3);
+}
+
+.permission-delete:hover {
+  color: var(--accent-text);
+}
+
+/* ── Add a permission (native <details> disclosure) ── */
+.permission-add {
+  align-self: stretch;
+  background: transparent;
+}
+
+.permission-add-toggle {
+  display: flex;
+  width: fit-content;
+  margin-inline-start: auto;
+  list-style: none;
+}
+
+.permission-add-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.permission-add[open] .permission-add-toggle {
+  margin-block-end: var(--size-3);
+}
+
+.permission-add-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-2);
+  align-items: center;
+}
+
+.permission-subject-field {
+  flex: 1 1 var(--size-12);
+  min-inline-size: var(--size-12);
+}
+
+.permission-level {
+  min-inline-size: var(--size-11);
+}

--- a/src/main/resources/static/css/modules/home/home.page.css
+++ b/src/main/resources/static/css/modules/home/home.page.css
@@ -3,6 +3,7 @@
 @import url("../../shared/components/snackbar.component.css");
 @import url("./folder-grid.fragment.css");
 @import url("./folder-picker.fragment.css");
+@import url("./folder-permissions.fragment.css");
 
 /* ── Main content layout ── */
 #main-container {

--- a/src/main/resources/static/js/modules/home/fragments/folder-permissions.fragment.js
+++ b/src/main/resources/static/js/modules/home/fragments/folder-permissions.fragment.js
@@ -1,0 +1,35 @@
+/**
+ * Opens the permissions dialog once its fragment has loaded.
+ * @listens document#htmx:afterRequest
+ */
+document.addEventListener("htmx:afterRequest", function(e) {
+  if (!e.target.hasAttribute("data-open-permissions") || !e.detail.successful) return;
+
+  document.getElementById("folder-permissions-dialog").showModal();
+});
+
+/**
+ * Mirrors the chosen suggestion's stable id (data-id) into the hidden subjectRef field, so the
+ * grant is submitted by id rather than by the free-typed name.
+ * @listens document#input
+ */
+document.addEventListener("input", function(e) {
+  const input = e.target;
+
+  if (!input.hasAttribute("data-subject-search")) return;
+
+  const option = [...input.list.options].find((o) => o.value === input.value);
+
+  input.form.querySelector("[name='subjectRef']").value = option ? option.dataset.id : "";
+});
+
+/**
+ * Resets and collapses the add-permission form after a grant is saved.
+ * @listens document#htmx:afterRequest
+ */
+document.addEventListener("htmx:afterRequest", function(e) {
+  if (!e.target.classList.contains("permission-add-form") || !e.detail.successful) return;
+
+  e.target.reset();
+  e.target.closest("details").open = false;
+});

--- a/src/main/resources/static/js/modules/home/home.page.js
+++ b/src/main/resources/static/js/modules/home/home.page.js
@@ -1,6 +1,7 @@
 import { showSnackbar } from "../../shared/components/snackbar.component.js";
 import "./fragments/folder-grid.fragment.js";
 import "./fragments/folder-picker.fragment.js";
+import "./fragments/folder-permissions.fragment.js";
 import "../../shared/fragments/media-grid.fragment.js";
 
 /**

--- a/src/main/resources/templates/modules/home/folder-permissions.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-permissions.macros.peb
@@ -1,0 +1,40 @@
+{% macro permissionRow(folder, row, oob=false) %}
+{# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
+{# @pebvariable name="row" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.PermissionRow" #}
+{% set isRole = row.subject == 'admin' or row.subject == 'editor' or row.subject == 'viewer' %}
+{% set editable = row.subject == 'editor' or (not isRole and not row.inherited) %}
+<div id="permission-grant-{{ row.subject | replace({':': '-'}) }}" class="permission-row{% if not editable %} permission-row-locked{% endif %}"{% if oob %} hx-swap-oob="outerHTML"{% endif %}>
+  <span class="permission-subject">
+    <span class="permission-avatar">
+      <span class="material-symbols-outlined">{% if row.subject.startsWith('team:') %}group{% elseif row.subject.startsWith('user:') %}person{% else %}shield{% endif %}</span>
+    </span>
+    <span class="permission-name">{{ row.label }}</span>
+  </span>
+  <div class="field">
+    {% if editable %}
+    <select name="level" aria-label="{{ row.label }} permission"
+            hx-patch="/console/actions/folder/{{ folder.id }}/permission/{{ row.subject }}"
+            hx-swap="none"
+            hx-trigger="change">
+      <option value="view" {% if not row.canWrite %}selected{% endif %}>View</option>
+      <option value="write" {% if row.canWrite %}selected{% endif %}>Write</option>
+    </select>
+    {% else %}
+    <select aria-label="{{ row.label }} permission" disabled>
+      <option selected>{{ row.canWrite ? 'Write' : 'View' }}</option>
+    </select>
+    {% endif %}
+  </div>
+  {% if not isRole and editable %}
+  <button type="button" class="btn-icon permission-delete" title="Remove {{ row.label }}" aria-label="Remove {{ row.label }}"
+          hx-delete="/console/actions/folder/{{ folder.id }}/permission/{{ row.subject }}"
+          hx-target="closest .permission-row"
+          hx-swap="delete">
+    <span class="material-symbols-outlined" aria-hidden="true">close</span>
+  </button>
+  {% elseif not editable %}
+  {% set hint = row.subject == 'admin' ? 'Administrators always have full access' : (row.subject == 'viewer' ? 'Everyone can view; only administrators and granted subjects can edit' : 'Inherited from a parent folder') %}
+  <span class="permission-lock material-symbols-outlined" tabindex="0" role="img" aria-label="{{ hint }}" title="{{ hint }}">lock</span>
+  {% endif %}
+</div>
+{% endmacro %}

--- a/src/main/resources/templates/modules/home/fragments/folder-permissions-list.fragment.peb
+++ b/src/main/resources/templates/modules/home/fragments/folder-permissions-list.fragment.peb
@@ -1,0 +1,20 @@
+{% import "../folder-permissions.macros.peb" %}
+{# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
+{# @pebvariable name="rows" type="java.util.List<ch.srgssr.pillarbox.backend.entrypoint.web.console.PermissionRow>" #}
+<div class="permission-table">
+  <div class="permission-row-head">
+    <span>Role</span>
+    <span class="permission-head-level">Permission</span>
+  </div>
+  {%- for row in rows -%}{% if row.subject == 'admin' or row.subject == 'editor' or row.subject == 'viewer' %}{{ permissionRow(folder, row) }}{% endif %}{%- endfor -%}
+</div>
+
+<div class="permission-table">
+  <div class="permission-row-head">
+    <span>User &amp; Team</span>
+    <span class="permission-head-level">Permission</span>
+  </div>
+  <div id="permission-grants">
+    {%- for row in rows -%}{% if row.subject != 'admin' and row.subject != 'editor' and row.subject != 'viewer' %}{{ permissionRow(folder, row) }}{% endif %}{%- endfor -%}
+  </div>
+</div>

--- a/src/main/resources/templates/modules/home/fragments/folder-permissions.fragment.peb
+++ b/src/main/resources/templates/modules/home/fragments/folder-permissions.fragment.peb
@@ -1,0 +1,45 @@
+{# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
+<div class="permissions-dialog">
+  <h3>Manage permissions</h3>
+
+  <div id="permission-list"
+       hx-get="/console/fragments/folder-permissions-list?folderId={{ folder.id }}"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <p>Loading…</p>
+  </div>
+
+  <details class="permission-add">
+    <summary class="btn btn-icon permission-add-toggle">
+      <span class="material-symbols-outlined">add</span>
+      Add a permission
+    </summary>
+
+    <form class="permission-add-form"
+          hx-post="/console/actions/folder/{{ folder.id }}/permission"
+          hx-target="#permission-grants"
+          hx-swap="beforeend">
+      <div class="field permission-subject-field">
+        <input type="text" name="subject" autocomplete="off" required data-subject-search
+               list="permission-subject-options"
+               aria-label="Search for a user or team"
+               placeholder="Search for a user or team…"
+               hx-get="/console/fragments/subject-options"
+               hx-target="#permission-subject-options"
+               hx-swap="innerHTML"
+               hx-trigger="input changed delay:200ms">
+        <input type="hidden" name="subjectRef">
+        <datalist id="permission-subject-options"></datalist>
+      </div>
+
+      <div class="field permission-level">
+        <select name="level" aria-label="Permission level">
+          <option value="view">View</option>
+          <option value="write" selected>Write</option>
+        </select>
+      </div>
+
+      <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+  </details>
+</div>

--- a/src/main/resources/templates/modules/home/fragments/permission-row.fragment.peb
+++ b/src/main/resources/templates/modules/home/fragments/permission-row.fragment.peb
@@ -1,0 +1,5 @@
+{% import "../folder-permissions.macros.peb" %}
+{# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
+{# @pebvariable name="row" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.PermissionRow" #}
+{# @pebvariable name="oob" type="java.lang.Boolean" #}
+{{ permissionRow(folder, row, oob) }}

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -20,6 +20,33 @@
         Recently Deleted
       </a>
       {% if canWrite %}
+      {% if folder is not empty %}
+      <button class="btn" type="button" popovertarget="folder-actions-menu" aria-expanded="false">
+        <span class="material-symbols-outlined">folder_managed</span>
+        Folder Actions
+        <span class="material-symbols-outlined dropdown-chevron">expand_more</span>
+      </button>
+      <div class="dropdown" popover id="folder-actions-menu">
+        <button class="btn dropdown-item" type="button"
+                data-open-permissions
+                hx-get="/console/fragments/folder-permissions?folderId={{ folder.id }}"
+                hx-target="#folder-permissions-dialog"
+                hx-swap="innerHTML"
+                onclick="this.closest('[popover]').hidePopover()">
+          <span class="material-symbols-outlined">key</span>
+          Manage permissions
+        </button>
+        <button class="btn dropdown-item danger" type="button"
+                hx-delete="/console/actions/folder/{{ folder.id }}"
+                hx-swap="none"
+                hx-confirm="Delete folder '{{ folder.name }}'? Media inside will remain but be unassigned."
+                hx-on::after-request="if(event.detail.successful) window.location.href='/console{% if folder.parentId is not empty %}?folderId={{ folder.parentId }}{% endif %}'"
+                onclick="this.closest('[popover]').hidePopover()">
+          <span class="material-symbols-outlined">delete</span>
+          Delete this folder
+        </button>
+      </div>
+      {% endif %}
       <button class="btn btn-primary" type="button" popovertarget="new-menu" aria-expanded="false">
         <span class="material-symbols-outlined">add</span>
         New
@@ -74,6 +101,7 @@
 </template>
 
 <dialog closedby="any" id="move-folder-dialog" class="move-folder-dialog"></dialog>
+<dialog closedby="any" id="folder-permissions-dialog" class="folder-permissions-dialog"></dialog>
 <dialog closedby="any" id="new-folder-dialog" class="new-folder-dialog">
   <form hx-post="/console/actions/folder"
         hx-target="#folder-grid"

--- a/src/main/resources/templates/shared/fragments/datalist-options.fragment.peb
+++ b/src/main/resources/templates/shared/fragments/datalist-options.fragment.peb
@@ -1,0 +1,4 @@
+{# @pebvariable name="options" type="java.util.List<ch.srgssr.pillarbox.backend.entrypoint.web.console.DatalistOption>" #}
+{%- for option in options -%}
+<option value="{{ option.value }}"{% if option.label %} label="{{ option.label }}"{% endif %}{% if option.id %} data-id="{{ option.id }}"{% endif %}>
+{%- endfor -%}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsolePermissionDialogTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsolePermissionDialogTest.kt
@@ -1,0 +1,372 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
+import ch.srgssr.pillarbox.backend.test.count
+import ch.srgssr.pillarbox.backend.test.hxDelete
+import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.hxPatch
+import ch.srgssr.pillarbox.backend.test.hxPost
+import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.seedTeam
+import ch.srgssr.pillarbox.backend.test.seedUser
+import ch.srgssr.pillarbox.backend.test.teamFixture
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.userFixture
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.formUrlEncode
+import org.jsoup.Jsoup
+
+class ConsolePermissionDialogTest :
+  ShouldSpec({
+    should("render a dialog skeleton that lazy-loads the permission list") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        val folder = client.createFolderV1("Shows")
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions?folderId=${folder.id}").bodyAsText(),
+          )
+
+        doc.count("#permission-list[hx-get*=folder-permissions-list]") shouldBe 1
+        doc.count("[data-subject-search]") shouldBe 1
+      }
+    }
+
+    should("render the permission list with the provisioned role rows") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        val folder = client.createFolderV1("Shows")
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${folder.id}").bodyAsText(),
+          )
+
+        doc.text() shouldContain "Admin"
+        doc.text() shouldContain "Editor"
+        doc.text() shouldContain "Viewer"
+        doc.count("select[hx-patch\$=/permission/editor]") shouldBe 1
+      }
+    }
+
+    should("list selectable subjects as labelled datalist options") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+
+        val response = client.hxGet("${Navigation.CONSOLE}/fragments/subject-options?subject=grace")
+        val doc = Jsoup.parse(response.bodyAsText())
+
+        doc.count("option") shouldBe 1
+        doc.select("option").attr("value") shouldBe "Grace Grantee"
+        doc.select("option").attr("label") shouldBe "User"
+        doc.select("option").attr("data-id") shouldBe "user:grantee"
+      }
+    }
+
+    should("add a grant returning its row, then revoke it") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val folder = client.createFolderV1("Shows")
+
+        val added =
+          client.hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("subjectRef" to "user:grantee", "level" to "write").formUrlEncode())
+          }
+        added shouldHaveStatus HttpStatusCode.OK
+        val addedBody = added.bodyAsText()
+        addedBody shouldContain "Grace Grantee"
+
+        val deleteUrl = Jsoup.parse(addedBody).select(".permission-delete").attr("hx-delete")
+        deleteUrl shouldContain "/permission/user:grantee"
+
+        val revoked = client.hxDelete(deleteUrl)
+        revoked shouldHaveStatus HttpStatusCode.NoContent
+
+        val list = client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${folder.id}")
+        list.bodyAsText() shouldNotContain "Grace Grantee"
+      }
+    }
+
+    should("show grants inherited from an ancestor folder as locked") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val parent = client.createFolderV1("Parent")
+        val child = client.createFolderV1("Child", parentId = parent.id)
+
+        client.hxPost("${Navigation.CONSOLE}/actions/folder/${parent.id}/permission") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("subjectRef" to "user:grantee", "level" to "write").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.OK
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${child.id}").bodyAsText(),
+          )
+
+        doc.text() shouldContain "Grace Grantee"
+        doc.count(".permission-delete") shouldBe 0
+      }
+    }
+
+    should("restrict editors to view through the editor toggle") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        val folder = client.createFolderV1("Shows")
+
+        val response =
+          client.hxPatch("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission/editor") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("level" to "view").formUrlEncode())
+          }
+        response shouldHaveStatus HttpStatusCode.NoContent
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${folder.id}").bodyAsText(),
+          )
+        doc.count("select[hx-patch\$=/permission/editor] option[value=view][selected]") shouldBe 1
+      }
+    }
+
+    should("reflect an editor restriction inherited from an ancestor") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        val parent = client.createFolderV1("Parent")
+        val child = client.createFolderV1("Child", parentId = parent.id)
+
+        client.hxPatch("${Navigation.CONSOLE}/actions/folder/${parent.id}/permission/editor") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("level" to "view").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.NoContent
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${child.id}").bodyAsText(),
+          )
+        doc.count("select[hx-patch\$=/permission/editor] option[value=view][selected]") shouldBe 1
+      }
+    }
+
+    should("show a subject granted on both the folder and an ancestor only once, as editable") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val parent = client.createFolderV1("Parent")
+        val child = client.createFolderV1("Child", parentId = parent.id)
+
+        listOf(parent.id, child.id).forEach { folderId ->
+          client.hxPost("${Navigation.CONSOLE}/actions/folder/$folderId/permission") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("subjectRef" to "user:grantee", "level" to "write").formUrlEncode())
+          } shouldHaveStatus HttpStatusCode.OK
+        }
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${child.id}").bodyAsText(),
+          )
+
+        doc.select(".permission-name").count { it.text() == "Grace Grantee" } shouldBe 1
+        doc.count("[hx-delete\$=/permission/user:grantee]") shouldBe 1
+      }
+    }
+
+    should("update an existing grant in place when its subject is granted again") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val folder = client.createFolderV1("Shows")
+
+        listOf("write", "view").forEach { level ->
+          client.hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("subjectRef" to "user:grantee", "level" to level).formUrlEncode())
+          } shouldHaveStatus HttpStatusCode.OK
+        }
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${folder.id}").bodyAsText(),
+          )
+
+        doc.count("[hx-delete\$=/permission/user:grantee]") shouldBe 1
+        doc.count("select[hx-patch\$=/permission/user:grantee] option[value=view][selected]") shouldBe 1
+      }
+    }
+
+    should("swap an existing grant row in place instead of appending a duplicate when re-granting its subject") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val folder = client.createFolderV1("Shows")
+
+        val firstBody =
+          client
+            .hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+              contentType(ContentType.Application.FormUrlEncoded)
+              setBody(listOf("subjectRef" to "user:grantee", "level" to "write").formUrlEncode())
+            }.bodyAsText()
+        // A new subject is appended to the list, so its row must not be an out-of-band swap.
+        Jsoup.parse(firstBody).count("[hx-swap-oob]") shouldBe 0
+
+        val secondBody =
+          client
+            .hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+              contentType(ContentType.Application.FormUrlEncoded)
+              setBody(listOf("subjectRef" to "user:grantee", "level" to "view").formUrlEncode())
+            }.bodyAsText()
+        // The subject already has a row, so it is swapped in place rather than appended again.
+        Jsoup.parse(secondBody).count("#permission-grant-user-grantee[hx-swap-oob]") shouldBe 1
+      }
+    }
+
+    should("reveal the inherited grant as locked when its overriding own grant is revoked") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val parent = client.createFolderV1("Parent")
+        val child = client.createFolderV1("Child", parentId = parent.id)
+
+        // Grant on the parent (inherited by the child), then override it on the child itself.
+        listOf(parent.id to "write", child.id to "view").forEach { (folderId, level) ->
+          client.hxPost("${Navigation.CONSOLE}/actions/folder/$folderId/permission") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("subjectRef" to "user:grantee", "level" to level).formUrlEncode())
+          } shouldHaveStatus HttpStatusCode.OK
+        }
+
+        val revoked = client.hxDelete("${Navigation.CONSOLE}/actions/folder/${child.id}/permission/user:grantee")
+
+        revoked shouldHaveStatus HttpStatusCode.OK
+        // The row is replaced in place rather than deleted, since the ancestor's grant still applies.
+        revoked.headers["HX-Reswap"] shouldBe "outerHTML"
+        val doc = Jsoup.parse(revoked.bodyAsText())
+        doc.count("#permission-grant-user-grantee") shouldBe 1
+        doc.count(".permission-lock") shouldBe 1
+        doc.count(".permission-delete") shouldBe 0
+      }
+    }
+
+    should("swap an inherited grant row in place when the subject is granted on the folder itself") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grantee", displayName = "Grace Grantee"))
+        val parent = client.createFolderV1("Parent")
+        val child = client.createFolderV1("Child", parentId = parent.id)
+
+        client.hxPost("${Navigation.CONSOLE}/actions/folder/${parent.id}/permission") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("subjectRef" to "user:grantee", "level" to "write").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.OK
+
+        val body =
+          client
+            .hxPost("${Navigation.CONSOLE}/actions/folder/${child.id}/permission") {
+              contentType(ContentType.Application.FormUrlEncoded)
+              setBody(listOf("subjectRef" to "user:grantee", "level" to "view").formUrlEncode())
+            }.bodyAsText()
+
+        // The child already shows the subject as an inherited (locked) row, so the new own grant
+        // replaces it in place rather than appending a duplicate.
+        Jsoup.parse(body).count("#permission-grant-user-grantee[hx-swap-oob]") shouldBe 1
+      }
+    }
+
+    should("grant a team and list it as a team subject") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedTeam(teamFixture(id = "team-news", name = "Newsroom"))
+        val folder = client.createFolderV1("Shows")
+
+        val options =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/subject-options?subject=news").bodyAsText())
+        options.count("option") shouldBe 1
+        options.select("option").attr("data-id") shouldBe "team:team-news"
+
+        val added =
+          client.hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("subjectRef" to "team:team-news", "level" to "view").formUrlEncode())
+          }
+        added shouldHaveStatus HttpStatusCode.OK
+        added.bodyAsText() shouldContain "Newsroom"
+
+        val doc =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/folder-permissions-list?folderId=${folder.id}").bodyAsText(),
+          )
+        doc.count("[hx-delete\$=/permission/team:team-news]") shouldBe 1
+      }
+    }
+
+    should("reject a grant whose subject is unknown") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        val folder = client.createFolderV1("Shows")
+
+        client.hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("subjectRef" to "user:ghost", "level" to "write").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.UnprocessableEntity
+      }
+    }
+
+    should("return not found when revoking a grant that does not exist") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        val folder = client.createFolderV1("Shows")
+
+        client.hxDelete(
+          "${Navigation.CONSOLE}/actions/folder/${folder.id}/permission/user:ghost",
+        ) shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("forbid managing the permissions of a folder the editor cannot write") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedUser(userFixture(oidcSub = "other", displayName = "Olive Other"))
+        val folder = client.createFolderV1("Shows")
+
+        // Restricting the folder to someone else locks the editor out of every subsequent request.
+        client.hxPost("${Navigation.CONSOLE}/actions/folder/${folder.id}/permission") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("subjectRef" to "user:other", "level" to "write").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.OK
+
+        client.hxGet(
+          "${Navigation.CONSOLE}/fragments/folder-permissions?folderId=${folder.id}",
+        ) shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+  })
+
+private suspend fun HttpClient.createFolderV1(
+  name: String,
+  parentId: String? = null,
+): FolderResponseV1 =
+  post("/v1/folder") {
+    contentType(ContentType.Application.Json)
+    setBody(FolderRequestV1(name = name, parentId = parentId))
+  }.also { it shouldHaveStatus HttpStatusCode.Created }
+    .body()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TeamFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TeamFixtures.kt
@@ -1,0 +1,18 @@
+package ch.srgssr.pillarbox.backend.test
+
+import ch.srgssr.pillarbox.backend.domain.model.Team
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import io.ktor.server.testing.ApplicationTestBuilder
+
+fun teamFixture(
+  id: String = "test-team",
+  name: String = "Test Team",
+) = Team(
+  id = id,
+  name = name,
+)
+
+suspend fun ApplicationTestBuilder.seedTeam(team: Team = teamFixture()): Team {
+  startApplication()
+  return TeamRepository(testDb).save(team)
+}


### PR DESCRIPTION
## Description

Resolves #25 by giving the console a UI for the folder grants the permission API already enforces. A "Manage permissions" dialog opens from the folder actions menu for anyone who can write the folder.

## Changes Made

- List the three role rows (admin, editor, viewer) followed by the folder's own user and team grants and the grants inherited from ancestor folders, which render read-only.
- Grant access by searching users and teams from a single datalist-backed autocomplete, submitting the chosen subject by stable id rather than the typed name; change a grant's level inline and revoke it in place.
- Add a custom select chevron and hide Chrome's datalist indicator.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
