### PR TITLE
feat(console): add teams and user directory to the web console

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -12,6 +12,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.api.playerMedia
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.team
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.user
 import ch.srgssr.pillarbox.backend.entrypoint.web.console.console
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.PillarboxPebbleExtension
 import ch.srgssr.pillarbox.backend.io.httpClientModule
 import ch.srgssr.pillarbox.backend.io.jsonModule
 import ch.srgssr.pillarbox.backend.ktor.plugins.configureDevelopmentDefaults
@@ -59,6 +60,7 @@ fun Application.module() {
         prefix = "templates"
       },
     )
+    extension(PillarboxPebbleExtension())
   }
 
   install(Koin) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
@@ -37,6 +37,7 @@ fun Route.console(
       homePage(mediaRepository, folderRepository, folderPermissionRepository, userRepository, teamRepository)
       editorPage(mediaRepository, folderRepository)
       usersPage(userRepository)
+      teamsPage(teamRepository)
     }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
@@ -37,7 +37,7 @@ fun Route.console(
       homePage(mediaRepository, folderRepository, folderPermissionRepository, userRepository, teamRepository)
       editorPage(mediaRepository, folderRepository)
       usersPage(userRepository)
-      teamsPage(teamRepository)
+      teamsPage(teamRepository, userRepository)
     }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
@@ -36,6 +36,7 @@ fun Route.console(
     route(Navigation.CONSOLE) {
       homePage(mediaRepository, folderRepository, folderPermissionRepository, userRepository, teamRepository)
       editorPage(mediaRepository, folderRepository)
+      usersPage(userRepository)
     }
   }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
@@ -60,6 +60,7 @@ fun Route.homePage(
     call.respondWithContext(
       "modules/home/home.page.peb",
       buildMap {
+        put("section", "library")
         put("canWrite", call.permissionChecker.canWriteFolder(call.user, folder?.id))
         folder?.let {
           put("folder", it)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/TeamsRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/TeamsRoute.kt
@@ -1,0 +1,56 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.auth.withRole
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
+import ch.srgssr.pillarbox.backend.log.debug
+import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.persistence.team.TeamTable
+import io.ktor.server.htmx.hx
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.utils.io.ExperimentalKtorApi
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.lowerCase
+
+private object ConsoleTeamRoute
+
+private val logger = ConsoleTeamRoute.logger()
+
+/**
+ * Registers the console teams page and its paginated table fragment, both restricted to users with
+ * write access.
+ *
+ * @param teamRepository Repository used to read, search and count the members of teams.
+ */
+@OptIn(ExperimentalKtorApi::class)
+fun Route.teamsPage(teamRepository: TeamRepository) {
+  withRole(Role.WRITE) {
+    get("teams") {
+      logger.debug { "Fetching teams page" }
+      call.respondWithContext("modules/teams/teams.page.peb", mapOf("section" to "teams"))
+    }
+
+    hx.get("fragments/team-table") {
+      val query = call.queryParameters["q"].orEmpty().trim()
+      with(call.queryParameters.toPageRequest()) {
+        val term = query.takeIf { it.isNotBlank() }?.lowercase()
+        logger.debug { "Fetching team table: pageRequest=$this, q='$query'" }
+        val result =
+          teamRepository.getAllPaginated(
+            limit = limit,
+            offset = offset,
+            filter = term?.let { { TeamTable.name.lowerCase() like "%$it%" } },
+            sort = listOf(TeamTable.updatedAt to SortOrder.DESC),
+          )
+        val memberCounts = teamRepository.countMembersOf(*result.items.map { it.id }.toTypedArray())
+        call.respondWithContext(
+          "modules/teams/fragments/team-table.fragment.peb",
+          mapOf("result" to result, "memberCounts" to memberCounts, "nextPage" to nextPage, "q" to query),
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/TeamsRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/TeamsRoute.kt
@@ -2,16 +2,29 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
 import ch.srgssr.pillarbox.backend.auth.withRole
 import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.domain.model.Team
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
 import ch.srgssr.pillarbox.backend.log.debug
+import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
 import ch.srgssr.pillarbox.backend.persistence.team.TeamTable
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserTable
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
 import io.ktor.server.htmx.hx
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.util.getOrFail
 import io.ktor.utils.io.ExperimentalKtorApi
+import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.like
 import org.jetbrains.exposed.v1.core.lowerCase
 
@@ -20,13 +33,17 @@ private object ConsoleTeamRoute
 private val logger = ConsoleTeamRoute.logger()
 
 /**
- * Registers the console teams page and its paginated table fragment, both restricted to users with
- * write access.
+ * Registers the console teams page and its fragments. The directory is visible to users with write
+ * access; creating teams and managing their members is reserved for administrators.
  *
- * @param teamRepository Repository used to read, search and count the members of teams.
+ * @param teamRepository Repository used to read, search, count and create teams.
+ * @param userRepository Repository used to search and resolve users when picking members.
  */
 @OptIn(ExperimentalKtorApi::class)
-fun Route.teamsPage(teamRepository: TeamRepository) {
+fun Route.teamsPage(
+  teamRepository: TeamRepository,
+  userRepository: UserRepository,
+) {
   withRole(Role.WRITE) {
     get("teams") {
       logger.debug { "Fetching teams page" }
@@ -53,4 +70,151 @@ fun Route.teamsPage(teamRepository: TeamRepository) {
       }
     }
   }
+
+  withRole(Role.ADMIN) {
+    teamFormFragments(teamRepository, userRepository)
+    teamActions(teamRepository, userRepository)
+  }
+}
+
+/**
+ * Registers the admin-only fragments backing the team dialog: the form itself (empty for a new team
+ * or populated for an existing one) and the member picker.
+ *
+ * @param teamRepository Repository used to resolve a team and its members.
+ * @param userRepository Repository used to search and resolve member users.
+ */
+@OptIn(ExperimentalKtorApi::class)
+private fun Route.teamFormFragments(
+  teamRepository: TeamRepository,
+  userRepository: UserRepository,
+) {
+  hx.get("fragments/team-form") {
+    val teamId =
+      call.queryParameters["teamId"] ?: return@get call.respondWithContext(
+        "modules/teams/fragments/team-form.fragment.peb",
+        mapOf("members" to emptyList<Any>()),
+      )
+
+    val team = teamRepository.find(teamId) ?: return@get call.respond(HttpStatusCode.NotFound)
+    call.respondWithContext(
+      "modules/teams/fragments/team-form.fragment.peb",
+      mapOf("team" to team, "members" to teamRepository.findMembers(teamId)),
+    )
+  }
+
+  hx.get("fragments/member-options") {
+    val query = call.queryParameters["q"].orEmpty().trim()
+    call.respondWithContext(
+      "shared/fragments/datalist-options.fragment.peb",
+      mapOf("options" to searchUsers(query, userRepository)),
+    )
+  }
+
+  hx.get("fragments/member-row") {
+    val oidcSub = call.queryParameters.getOrFail("oidcSub")
+    val member = userRepository.find(oidcSub) ?: return@get call.respond(HttpStatusCode.NotFound)
+    call.respondWithContext("modules/teams/fragments/member-row.fragment.peb", mapOf("member" to member))
+  }
+}
+
+/**
+ * Registers the admin-only actions that create and update a team together with its members.
+ *
+ * @param teamRepository Repository used to persist teams.
+ * @param userRepository Repository used to resolve the submitted members.
+ */
+@OptIn(ExperimentalKtorApi::class)
+private fun Route.teamActions(
+  teamRepository: TeamRepository,
+  userRepository: UserRepository,
+) {
+  hx.post("actions/team") {
+    val params = call.receiveParameters()
+    val name = params["name"]?.trim().orEmpty()
+    if (name.isBlank()) {
+      return@post call.respond(HttpStatusCode.UnprocessableEntity, "Enter a team name")
+    }
+
+    val members = resolveMembers(params, userRepository)
+    val team = teamRepository.save(Team(name = name))
+    teamRepository.replaceMembers(team.id, members)
+    logger.info { "Created team ${team.id} ('$name') with ${members.size} member(s)" }
+    call.respondTeamRow(team, members.size)
+  }
+
+  hx.post("actions/team/{id}") {
+    val id = call.parameters.getOrFail("id")
+    val existing = teamRepository.find(id) ?: return@post call.respond(HttpStatusCode.NotFound)
+    val params = call.receiveParameters()
+    val name = params["name"]?.trim().orEmpty()
+    if (name.isBlank()) {
+      return@post call.respond(HttpStatusCode.UnprocessableEntity, "Enter a team name")
+    }
+
+    val members = resolveMembers(params, userRepository)
+    val updated = teamRepository.save(existing.copy(name = name))
+    teamRepository.replaceMembers(updated.id, members)
+    logger.info { "Updated team ${updated.id} ('$name') with ${members.size} member(s)" }
+    call.respondTeamRow(updated, members.size)
+  }
+}
+
+/** Responds with the table row for [team], carrying its [memberCount]. */
+private suspend fun ApplicationCall.respondTeamRow(
+  team: Team,
+  memberCount: Int,
+) = respondWithContext(
+  "modules/teams/fragments/team-row.fragment.peb",
+  mapOf("team" to team, "memberCount" to memberCount.toLong()),
+)
+
+/**
+ * Resolves the submitted `memberId` values to the OIDC subs of existing users, dropping unknown ids.
+ *
+ * @param params The submitted form parameters.
+ * @param userRepository Repository used to confirm the members exist.
+ * @return The OIDC subs of the existing members, without blanks or duplicates.
+ */
+private suspend fun resolveMembers(
+  params: Parameters,
+  userRepository: UserRepository,
+): List<String> {
+  val requested =
+    params
+      .getAll("memberId")
+      .orEmpty()
+      .filter { it.isNotBlank() }
+      .distinct()
+  return if (requested.isEmpty()) {
+    emptyList()
+  } else {
+    userRepository
+      .getAll(limit = requested.size, filter = { UserTable.oidcSub inList requested })
+      .toList()
+      .map { it.oidcSub }
+  }
+}
+
+/**
+ * Searches users by display name for the member picker.
+ *
+ * @param query The text typed into the search box; blank lists the most recently updated users.
+ * @param userRepository Repository used to search users.
+ * @param limit The maximum number of suggestions to return.
+ * @return Up to [limit] options, each carrying the display name and the user's OIDC sub as its id.
+ */
+private suspend fun searchUsers(
+  query: String,
+  userRepository: UserRepository,
+  limit: Int = 20,
+): List<DatalistOption> {
+  val term = query.takeIf { it.isNotBlank() }?.lowercase()
+  return userRepository
+    .getAll(
+      limit = limit,
+      filter = term?.let { { UserTable.displayName.lowerCase() like "%$it%" } },
+      sort = listOf(UserTable.updatedAt to SortOrder.DESC),
+    ).toList()
+    .map { DatalistOption(it.displayName, "User", it.oidcSub) }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/UsersRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/UsersRoute.kt
@@ -1,0 +1,55 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.auth.withRole
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
+import ch.srgssr.pillarbox.backend.log.debug
+import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
+import ch.srgssr.pillarbox.backend.persistence.user.UserTable
+import io.ktor.server.htmx.hx
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.utils.io.ExperimentalKtorApi
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.like
+import org.jetbrains.exposed.v1.core.lowerCase
+
+private object ConsoleUserRoute
+
+private val logger = ConsoleUserRoute.logger()
+
+/**
+ * Registers the console users page and its paginated table fragment, both restricted to users with
+ * write access.
+ *
+ * @param userRepository Repository used to read and search users.
+ */
+@OptIn(ExperimentalKtorApi::class)
+fun Route.usersPage(userRepository: UserRepository) {
+  withRole(Role.WRITE) {
+    get("users") {
+      logger.debug { "Fetching users page" }
+      call.respondWithContext("modules/users/users.page.peb", mapOf("section" to "users"))
+    }
+
+    hx.get("fragments/user-table") {
+      val query = call.queryParameters["q"].orEmpty().trim()
+      with(call.queryParameters.toPageRequest()) {
+        val term = query.takeIf { it.isNotBlank() }?.lowercase()
+        logger.debug { "Fetching user table: pageRequest=$this, q='$query'" }
+        val result =
+          userRepository.getAllPaginated(
+            limit = limit,
+            offset = offset,
+            filter = term?.let { { UserTable.displayName.lowerCase() like "%$it%" } },
+            sort = listOf(UserTable.updatedAt to SortOrder.DESC),
+          )
+        call.respondWithContext(
+          "modules/users/fragments/user-table.fragment.peb",
+          mapOf("result" to result, "nextPage" to nextPage, "q" to query),
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/PillarboxPebbleExtension.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/PillarboxPebbleExtension.kt
@@ -1,0 +1,35 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.utils
+
+import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import io.pebbletemplates.pebble.extension.AbstractExtension
+import io.pebbletemplates.pebble.extension.Filter
+import io.pebbletemplates.pebble.template.EvaluationContext
+import io.pebbletemplates.pebble.template.PebbleTemplate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import kotlin.time.Instant
+
+/**
+ * Pebble extension registering the console's custom template filters.
+ */
+class PillarboxPebbleExtension : AbstractExtension() {
+  override fun getFilters(): Map<String, Filter> = mapOf("datetime" to DateTimeFilter())
+}
+
+/**
+ * Formats a Kotlin [Instant] as a human-readable UTC date and time, e.g. `6 Jun 2026, 14:32`.
+ * Any other input is returned unchanged.
+ */
+private class DateTimeFilter : Filter {
+  private val formatter = DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm", Locale.ENGLISH)
+
+  override fun getArgumentNames(): List<String>? = null
+
+  override fun apply(
+    input: Any?,
+    args: Map<String, Any>?,
+    self: PebbleTemplate?,
+    context: EvaluationContext?,
+    lineNumber: Int,
+  ): Any? = (input as? Instant)?.toUtcOffsetDateTime()?.format(formatter) ?: input
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/team/TeamRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/team/TeamRepository.kt
@@ -10,12 +10,15 @@ import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.Table
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.count
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.core.statements.UpdateStatement
 import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.upsert
 import kotlin.time.Clock
@@ -141,5 +144,28 @@ class TeamRepository(
             updatedAt = row[UserTable.updatedAt].toKotlinInstant(),
           )
         }
+    }
+
+  /**
+   * Counts the members of each of the given teams in a single query.
+   *
+   * @param teamIds The teams whose members should be counted.
+   * @return A map from team id to member count; teams with no members map to `0`.
+   */
+  suspend fun countMembersOf(vararg teamIds: String): Map<String, Long> =
+    query(readOnly = true) {
+      val named = teamIds.distinct()
+      val results = named.associateWith { 0L }.toMutableMap()
+      if (named.isNotEmpty()) {
+        val memberCount = TeamMemberTable.oidcSub.count()
+        TeamMemberTable
+          .select(TeamMemberTable.teamId, memberCount)
+          .where { TeamMemberTable.teamId inList named }
+          .groupBy(TeamMemberTable.teamId)
+          .forEach { row ->
+            results[row[TeamMemberTable.teamId]] = row[memberCount]
+          }
+      }
+      results
     }
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/team/TeamRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/team/TeamRepository.kt
@@ -17,6 +17,7 @@ import org.jetbrains.exposed.v1.core.statements.UpdateBuilder
 import org.jetbrains.exposed.v1.core.statements.UpdateStatement
 import org.jetbrains.exposed.v1.core.statements.UpsertBuilder
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.batchInsert
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -144,6 +145,30 @@ class TeamRepository(
             updatedAt = row[UserTable.updatedAt].toKotlinInstant(),
           )
         }
+    }
+
+  /**
+   * Replaces the entire membership of a team in a single transaction: every current member is removed
+   * and [memberOidcSubs] are inserted as the team's members in one batch.
+   *
+   * @param teamId The team whose members are replaced.
+   * @param memberOidcSubs The OIDC subs the team should have as members; blanks and duplicates are ignored.
+   */
+  suspend fun replaceMembers(
+    teamId: String,
+    memberOidcSubs: Collection<String>,
+  ): Unit =
+    query {
+      TeamMemberTable.deleteWhere { TeamMemberTable.teamId eq teamId }
+      val subs = memberOidcSubs.filter { it.isNotBlank() }.distinct()
+      if (subs.isNotEmpty()) {
+        val addedAt = Clock.System.now().toUtcOffsetDateTime()
+        TeamMemberTable.batchInsert(subs) { sub ->
+          this[TeamMemberTable.teamId] = teamId
+          this[TeamMemberTable.oidcSub] = sub
+          this[TeamMemberTable.addedAt] = addedAt
+        }
+      }
     }
 
   /**

--- a/src/main/resources/static/css/layouts/_button.css
+++ b/src/main/resources/static/css/layouts/_button.css
@@ -45,6 +45,15 @@ button:hover, .btn:hover {
   background: var(--surface-3);
 }
 
+/* A muted icon button that turns accent on hover — the cross ending a removable row. */
+.btn-remove {
+  color: var(--text-3);
+}
+
+.btn-remove:hover {
+  color: var(--accent-text);
+}
+
 .btn-primary {
   border-color: var(--accent);
   color: var(--gray-0);

--- a/src/main/resources/static/css/layouts/_forms.css
+++ b/src/main/resources/static/css/layouts/_forms.css
@@ -53,6 +53,26 @@
   display: none !important;
 }
 
+/* ── Search field — a leading icon, inset from a sibling material symbol ── */
+.field:has(input[type="search"]) {
+  position: relative;
+}
+
+.field input[type="search"] {
+  padding-inline-start: calc(var(--size-3) + var(--size-6));
+}
+
+.field:has(input[type="search"]) > .material-symbols-outlined {
+  pointer-events: none;
+
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: var(--size-3);
+  translate: 0 -50%;
+
+  color: var(--text-3);
+}
+
 /* ── Hover ── */
 
 .field :is(input:not([type="checkbox"], [type="radio"]), textarea, select):hover {

--- a/src/main/resources/static/css/layouts/_table.css
+++ b/src/main/resources/static/css/layouts/_table.css
@@ -56,6 +56,7 @@ tbody tr:hover td {
 
 .cell-name {
   overflow: hidden;
+
   min-inline-size: 0;
 
   font-weight: var(--font-weight-6);
@@ -65,4 +66,10 @@ tbody tr:hover td {
 
 .cell-muted {
   color: var(--text-2);
+}
+
+/* A trailing cell holding a row action; no ellipsis since it never overflows. */
+.cell-action {
+  text-align: end;
+  text-overflow: clip;
 }

--- a/src/main/resources/static/css/layouts/_table.css
+++ b/src/main/resources/static/css/layouts/_table.css
@@ -43,3 +43,26 @@ tbody tr:hover td {
   color: var(--text-2);
   text-align: center;
 }
+
+/* ── Cell content ── */
+
+/* An avatar beside a truncating label. */
+.cell-identity {
+  display: flex;
+  gap: var(--size-3);
+  align-items: center;
+  min-inline-size: 0;
+}
+
+.cell-name {
+  overflow: hidden;
+  min-inline-size: 0;
+
+  font-weight: var(--font-weight-6);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cell-muted {
+  color: var(--text-2);
+}

--- a/src/main/resources/static/css/layouts/_table.css
+++ b/src/main/resources/static/css/layouts/_table.css
@@ -1,0 +1,45 @@
+/* ── Table ── */
+
+table {
+  table-layout: fixed;
+  border-collapse: collapse;
+  inline-size: 100%;
+  text-align: start;
+}
+
+/* Cells truncate rather than wrap; columns get their width from table-layout: fixed. */
+th,
+td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+th {
+  padding: var(--size-2) var(--size-3);
+  border-block-end: var(--border-size-1) solid var(--surface-3);
+
+  font-size: var(--font-size-0);
+  font-weight: var(--font-weight-6);
+  color: var(--text-2);
+  text-align: start;
+}
+
+td {
+  padding-inline: var(--size-3);
+  border-block-end: var(--border-size-1) solid var(--surface-2);
+
+  font-size: var(--font-size-0);
+  color: var(--text-1);
+  text-align: start; /* override open-props normalize's :where(td:not([align])){text-align:center} */
+}
+
+tbody tr:hover td {
+  background-color: var(--surface-2);
+}
+
+.table-empty {
+  padding: var(--size-5);
+  color: var(--text-2);
+  text-align: center;
+}

--- a/src/main/resources/static/css/layouts/_theme.css
+++ b/src/main/resources/static/css/layouts/_theme.css
@@ -7,6 +7,7 @@
 @import url("_dropdown.css");
 @import url("_forms.css");
 @import url("_switch.css");
+@import url("_table.css");
 
 :focus-visible {
   outline: 2px solid var(--accent);

--- a/src/main/resources/static/css/layouts/dashboard.layout.css
+++ b/src/main/resources/static/css/layouts/dashboard.layout.css
@@ -2,6 +2,7 @@
 @import url("../shared/components/breadcrumbs.component.css");
 @import url("../shared/components/sidebar.component.css");
 @import url("../shared/components/user-menu.component.css");
+@import url("../shared/components/avatar.component.css");
 
 body {
   overflow: hidden;
@@ -40,4 +41,44 @@ section {
   display: grid;
   gap: var(--size-4);
   padding-block: var(--size-4);
+}
+
+/* ── Page shell (shared by every console page) ── */
+#main-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4);
+  padding: var(--size-5);
+}
+
+.main-header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--size-3);
+  align-items: center;
+
+  padding-bottom: var(--size-2);
+}
+
+.main-header h2 {
+  overflow: hidden;
+
+  margin: 0;
+
+  font-size: var(--font-size-4);
+  font-weight: var(--font-weight-6);
+  color: var(--text-1);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.main-header-actions {
+  display: flex;
+  gap: var(--size-2);
+}
+
+@media (width <= 768px) {
+  .main-header {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/main/resources/static/css/modules/home/folder-permissions.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-permissions.fragment.css
@@ -59,22 +59,6 @@
   min-inline-size: 0;
 }
 
-.permission-avatar {
-  display: grid;
-  place-items: center;
-
-  inline-size: var(--size-7);
-  block-size: var(--size-7);
-  border-radius: var(--radius-round);
-
-  color: var(--text-2);
-
-  background: var(--surface-3);
-}
-
-.permission-avatar .material-symbols-outlined {
-  font-size: 18px;
-}
 
 .permission-name {
   overflow: hidden;

--- a/src/main/resources/static/css/modules/home/folder-permissions.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-permissions.fragment.css
@@ -82,11 +82,6 @@
 
 .permission-delete {
   justify-self: center;
-  color: var(--text-3);
-}
-
-.permission-delete:hover {
-  color: var(--accent-text);
 }
 
 /* ── Add a permission (native <details> disclosure) ── */

--- a/src/main/resources/static/css/modules/home/home.page.css
+++ b/src/main/resources/static/css/modules/home/home.page.css
@@ -5,47 +5,6 @@
 @import url("./folder-picker.fragment.css");
 @import url("./folder-permissions.fragment.css");
 
-/* ── Main content layout ── */
-#main-container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-3);
-  padding: var(--size-5);
-}
-
-/* ── Page header row ── */
-.main-header {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: var(--size-3);
-  align-items: center;
-
-  padding-bottom: var(--size-3);
-}
-
-.main-header h2 {
-  overflow: hidden;
-
-  margin: 0;
-
-  font-size: var(--font-size-4);
-  font-weight: var(--font-weight-6);
-  color: var(--text-1);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.main-header-actions {
-  display: flex;
-  gap: var(--size-2);
-}
-
-@media (width <= 768px) {
-  .main-header {
-    grid-template-columns: 1fr;
-  }
-}
-
 /* ── Section labels ── */
 .section-label {
   margin-top: var(--size-2);

--- a/src/main/resources/static/css/modules/teams/teams.page.css
+++ b/src/main/resources/static/css/modules/teams/teams.page.css
@@ -1,0 +1,10 @@
+@import url("../../layouts/dashboard.layout.css");
+
+/* ── Columns ── */
+.col-members {
+  inline-size: 16%;
+}
+
+.col-date {
+  inline-size: 24%;
+}

--- a/src/main/resources/static/css/modules/teams/teams.page.css
+++ b/src/main/resources/static/css/modules/teams/teams.page.css
@@ -8,3 +8,43 @@
 .col-date {
   inline-size: 24%;
 }
+
+.col-actions {
+  inline-size: var(--size-9);
+}
+
+/* ── Team dialog ── */
+.team-dialog {
+  inline-size: min(92vw, 32rem);
+}
+
+.team-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4);
+}
+
+.team-form footer {
+  display: flex;
+  gap: var(--size-2);
+  justify-content: flex-end;
+}
+
+/* ── Member list ── */
+.member-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-1);
+  margin-block-start: var(--size-1);
+}
+
+.member-row {
+  display: flex;
+  gap: var(--size-2);
+  align-items: center;
+  padding: var(--size-1) var(--size-2);
+}
+
+.member-row .cell-name {
+  flex: 1;
+}

--- a/src/main/resources/static/css/modules/users/users.page.css
+++ b/src/main/resources/static/css/modules/users/users.page.css
@@ -1,0 +1,45 @@
+@import url("../../layouts/dashboard.layout.css");
+
+/* ── Columns ── */
+.col-roles {
+  inline-size: 18%;
+}
+
+.col-date {
+  inline-size: 24%;
+}
+
+/* ── User cells ── */
+.user-identity {
+  display: flex;
+  gap: var(--size-3);
+  align-items: center;
+  min-inline-size: 0;
+}
+
+.user-name {
+  overflow: hidden;
+
+  min-inline-size: 0;
+
+  font-weight: var(--font-weight-6);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-date {
+  color: var(--text-2);
+}
+
+.role-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--size-1);
+}
+
+.role-tag {
+  padding: 2px var(--size-2);
+  border-radius: var(--radius-2);
+  color: var(--text-2);
+  background-color: var(--surface-3);
+}

--- a/src/main/resources/static/css/modules/users/users.page.css
+++ b/src/main/resources/static/css/modules/users/users.page.css
@@ -9,28 +9,7 @@
   inline-size: 24%;
 }
 
-/* ── User cells ── */
-.user-identity {
-  display: flex;
-  gap: var(--size-3);
-  align-items: center;
-  min-inline-size: 0;
-}
-
-.user-name {
-  overflow: hidden;
-
-  min-inline-size: 0;
-
-  font-weight: var(--font-weight-6);
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.user-date {
-  color: var(--text-2);
-}
-
+/* ── Roles ── */
 .role-tags {
   display: inline-flex;
   flex-wrap: wrap;

--- a/src/main/resources/static/css/shared/components/avatar.component.css
+++ b/src/main/resources/static/css/shared/components/avatar.component.css
@@ -1,0 +1,33 @@
+.avatar {
+  display: grid;
+  flex-shrink: 0;
+  place-items: center;
+
+  inline-size: var(--size-7);
+  block-size: var(--size-7);
+  border-radius: var(--radius-round);
+
+  font-size: var(--font-size-0);
+  font-weight: var(--font-weight-7);
+  color: var(--text-2);
+
+  background: var(--surface-3);
+}
+
+.avatar .material-symbols-outlined {
+  font-size: 18px;
+}
+
+/* Clickable variant, e.g. the header user menu. */
+button.avatar {
+  cursor: pointer;
+
+  inline-size: var(--size-6);
+  block-size: var(--size-6);
+  padding: 0;
+  border: none;
+
+  color: var(--text-1);
+
+  background: light-dark(var(--gray-4), var(--gray-7));
+}

--- a/src/main/resources/static/css/shared/components/user-menu.component.css
+++ b/src/main/resources/static/css/shared/components/user-menu.component.css
@@ -1,22 +1,3 @@
-.user-avatar {
-  cursor: pointer;
-
-  display: grid;
-  place-content: center;
-
-  inline-size: var(--size-6);
-  block-size: var(--size-6);
-  padding: 0;
-  border: none;
-  border-radius: var(--radius-round);
-
-  font-size: var(--font-size-0);
-  font-weight: var(--font-weight-7);
-  color: var(--text-1);
-
-  background: light-dark(var(--gray-4), var(--gray-7));
-}
-
 .user-dropdown {
   min-width: var(--size-14);
 }

--- a/src/main/resources/static/js/modules/teams/fragments/team-form.fragment.js
+++ b/src/main/resources/static/js/modules/teams/fragments/team-form.fragment.js
@@ -1,0 +1,66 @@
+import htmx from "htmx.org";
+
+/**
+ * Opens the team dialog once its form fragment has loaded.
+ * @listens document#htmx:afterRequest
+ */
+document.addEventListener("htmx:afterRequest", function(e) {
+  if (!e.target.hasAttribute("data-open-team") || !e.detail.successful) return;
+
+  document.getElementById("team-dialog").showModal();
+});
+
+/**
+ * Keeps Enter in the member search from submitting the team form; members are picked, not typed.
+ * @listens document#keydown
+ */
+document.addEventListener("keydown", function(e) {
+  if (e.target.hasAttribute("data-member-search") && e.key === "Enter") e.preventDefault();
+});
+
+/**
+ * Adds the chosen user as a pending member row, fetched from the server so the row markup lives in
+ * one place. Skips users already in the list and clears the search box.
+ * @listens document#input
+ */
+document.addEventListener("input", function(e) {
+  const input = e.target;
+
+  if (!input.hasAttribute("data-member-search")) return;
+
+  const option = [...input.list.options].find((o) => o.value === input.value);
+
+  if (!option) return;
+
+  const oidcSub = option.dataset.id;
+  const list = input.closest("form").querySelector("#member-list");
+
+  input.value = "";
+
+  if (list.querySelector(`[data-member-id="${CSS.escape(oidcSub)}"]`)) return;
+
+  htmx.ajax("GET", `/console/fragments/member-row?oidcSub=${encodeURIComponent(oidcSub)}`, {
+    target: list,
+    swap: "beforeend",
+  });
+});
+
+/**
+ * Removes a pending member row; nothing is persisted until the team is saved.
+ * @listens document#click
+ */
+document.addEventListener("click", function(e) {
+  const remove = e.target.closest("[data-remove-member]");
+
+  if (remove) remove.closest(".member-row").remove();
+});
+
+/**
+ * Closes the dialog once the team is saved.
+ * @listens document#htmx:afterRequest
+ */
+document.addEventListener("htmx:afterRequest", function(e) {
+  if (!e.target.classList.contains("team-form") || !e.detail.successful) return;
+
+  e.target.closest("dialog").close();
+});

--- a/src/main/resources/static/js/modules/teams/teams.page.js
+++ b/src/main/resources/static/js/modules/teams/teams.page.js
@@ -1,0 +1,2 @@
+// The teams page is driven entirely by HTMX (search + infinite scroll); importing htmx bootstraps it.
+import "htmx.org";

--- a/src/main/resources/static/js/modules/teams/teams.page.js
+++ b/src/main/resources/static/js/modules/teams/teams.page.js
@@ -1,2 +1,2 @@
-// The teams page is driven entirely by HTMX (search + infinite scroll); importing htmx bootstraps it.
 import "htmx.org";
+import "./fragments/team-form.fragment.js";

--- a/src/main/resources/static/js/modules/users/users.page.js
+++ b/src/main/resources/static/js/modules/users/users.page.js
@@ -1,0 +1,2 @@
+// The users page is driven entirely by HTMX (search + infinite scroll); importing htmx bootstraps it.
+import "htmx.org";

--- a/src/main/resources/templates/modules/home/folder-permissions.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-permissions.macros.peb
@@ -5,9 +5,7 @@
 {% set editable = row.subject == 'editor' or (not isRole and not row.inherited) %}
 <div id="permission-grant-{{ row.subject | replace({':': '-'}) }}" class="permission-row{% if not editable %} permission-row-locked{% endif %}"{% if oob %} hx-swap-oob="outerHTML"{% endif %}>
   <span class="permission-subject">
-    <span class="permission-avatar">
-      <span class="material-symbols-outlined">{% if row.subject.startsWith('team:') %}group{% elseif row.subject.startsWith('user:') %}person{% else %}shield{% endif %}</span>
-    </span>
+    <span class="avatar"><span class="material-symbols-outlined" aria-hidden="true">{% if row.subject.startsWith('team:') %}group{% elseif row.subject.startsWith('user:') %}person{% else %}shield{% endif %}</span></span>
     <span class="permission-name">{{ row.label }}</span>
   </span>
   <div class="field">

--- a/src/main/resources/templates/modules/home/folder-permissions.macros.peb
+++ b/src/main/resources/templates/modules/home/folder-permissions.macros.peb
@@ -24,7 +24,7 @@
     {% endif %}
   </div>
   {% if not isRole and editable %}
-  <button type="button" class="btn-icon permission-delete" title="Remove {{ row.label }}" aria-label="Remove {{ row.label }}"
+  <button type="button" class="btn-icon btn-remove permission-delete" title="Remove {{ row.label }}" aria-label="Remove {{ row.label }}"
           hx-delete="/console/actions/folder/{{ folder.id }}/permission/{{ row.subject }}"
           hx-target="closest .permission-row"
           hx-swap="delete">

--- a/src/main/resources/templates/modules/teams/fragments/member-row.fragment.peb
+++ b/src/main/resources/templates/modules/teams/fragments/member-row.fragment.peb
@@ -1,0 +1,3 @@
+{% import "../team.macros.peb" %}
+{# @pebvariable name="member" type="ch.srgssr.pillarbox.backend.domain.model.User" #}
+{{ memberRow(member) }}

--- a/src/main/resources/templates/modules/teams/fragments/team-form.fragment.peb
+++ b/src/main/resources/templates/modules/teams/fragments/team-form.fragment.peb
@@ -1,0 +1,39 @@
+{% import "../team.macros.peb" %}
+{# @pebvariable name="team" type="ch.srgssr.pillarbox.backend.domain.model.Team" #}
+{# @pebvariable name="members" type="java.util.List<ch.srgssr.pillarbox.backend.domain.model.User>" #}
+{% set editing = team is not empty %}
+<form class="team-form"
+      hx-post="/console/actions/team{% if editing %}/{{ team.id }}{% endif %}"
+      hx-target="{% if editing %}#team-row-{{ team.id }}{% else %}#team-rows{% endif %}"
+      hx-swap="{% if editing %}outerHTML{% else %}afterbegin{% endif %}">
+  <h3>{{ editing ? 'Edit team' : 'New team' }}</h3>
+
+  <div class="field">
+    <label for="team-name">Name</label>
+    <input id="team-name" name="name" type="text" required autocomplete="off"
+           placeholder="e.g. Newsroom" value="{{ team.name | default('') }}">
+  </div>
+
+  <div class="field">
+    <div class="field">
+      <span class="material-symbols-outlined" aria-hidden="true">search</span>
+      <input id="team-member-search" type="search" name="q" autocomplete="off" data-member-search
+             list="member-options"
+             placeholder="Search users to add…"
+             aria-label="Search users to add"
+             hx-get="/console/fragments/member-options"
+             hx-target="#member-options"
+             hx-swap="innerHTML"
+             hx-trigger="input changed delay:200ms">
+      <datalist id="member-options"></datalist>
+    </div>
+    <div id="member-list" class="member-list">
+      {%- for member in members -%}{{ memberRow(member) }}{%- endfor -%}
+    </div>
+  </div>
+
+  <footer>
+    <button type="button" onclick="this.closest('dialog').close()">Cancel</button>
+    <button type="submit" class="btn btn-primary">Save team</button>
+  </footer>
+</form>

--- a/src/main/resources/templates/modules/teams/fragments/team-row.fragment.peb
+++ b/src/main/resources/templates/modules/teams/fragments/team-row.fragment.peb
@@ -1,0 +1,5 @@
+{% import "../team.macros.peb" %}
+{# @pebvariable name="team" type="ch.srgssr.pillarbox.backend.domain.model.Team" #}
+{# @pebvariable name="memberCount" type="java.lang.Long" #}
+{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
+{{ teamRow(team, memberCount, null, user.roles contains 'ADMIN') }}

--- a/src/main/resources/templates/modules/teams/fragments/team-table.fragment.peb
+++ b/src/main/resources/templates/modules/teams/fragments/team-table.fragment.peb
@@ -1,0 +1,26 @@
+{% import "../../../shared/macros/avatar.macros.peb" %}
+{# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Team>" #}
+{# @pebvariable name="memberCounts" type="java.util.Map<java.lang.String, java.lang.Long>" #}
+{# @pebvariable name="nextPage" type="java.lang.Integer" #}
+{# @pebvariable name="q" type="java.lang.String" #}
+
+{% set hasMore = (nextPage * result.limit) < result.totalCount %}
+{% set nextUrl = hasMore ? "/console/fragments/team-table?page=" + nextPage + "&pageSize=" + result.limit + "&q=" + (q | urlencode) : null %}
+
+{%- for team in result.items -%}
+<tr class="team-row"{% if loop.last and nextUrl is not empty %} hx-get="{{ nextUrl }}" hx-trigger="revealed" hx-swap="afterend" hx-select=".team-row"{% endif %}>
+  <td>
+    <span class="cell-identity">
+      {{ avatar(icon='group') }}
+      <span class="cell-name">{{ team.name }}</span>
+    </span>
+  </td>
+  <td>{{ memberCounts[team.id] | default(0) }}</td>
+  <td class="cell-muted">{{ team.createdAt | datetime }}</td>
+  <td class="cell-muted">{{ team.updatedAt | datetime }}</td>
+</tr>
+{%- endfor -%}
+
+{% if result.totalCount == 0 %}
+<tr><td class="table-empty" colspan="4">No teams found</td></tr>
+{% endif %}

--- a/src/main/resources/templates/modules/teams/fragments/team-table.fragment.peb
+++ b/src/main/resources/templates/modules/teams/fragments/team-table.fragment.peb
@@ -1,26 +1,18 @@
-{% import "../../../shared/macros/avatar.macros.peb" %}
+{% import "../team.macros.peb" %}
 {# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Team>" #}
 {# @pebvariable name="memberCounts" type="java.util.Map<java.lang.String, java.lang.Long>" #}
 {# @pebvariable name="nextPage" type="java.lang.Integer" #}
 {# @pebvariable name="q" type="java.lang.String" #}
+{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
 
+{% set canManage = user.roles contains 'ADMIN' %}
 {% set hasMore = (nextPage * result.limit) < result.totalCount %}
 {% set nextUrl = hasMore ? "/console/fragments/team-table?page=" + nextPage + "&pageSize=" + result.limit + "&q=" + (q | urlencode) : null %}
 
 {%- for team in result.items -%}
-<tr class="team-row"{% if loop.last and nextUrl is not empty %} hx-get="{{ nextUrl }}" hx-trigger="revealed" hx-swap="afterend" hx-select=".team-row"{% endif %}>
-  <td>
-    <span class="cell-identity">
-      {{ avatar(icon='group') }}
-      <span class="cell-name">{{ team.name }}</span>
-    </span>
-  </td>
-  <td>{{ memberCounts[team.id] | default(0) }}</td>
-  <td class="cell-muted">{{ team.createdAt | datetime }}</td>
-  <td class="cell-muted">{{ team.updatedAt | datetime }}</td>
-</tr>
+{{ teamRow(team, memberCounts[team.id] | default(0), loop.last ? nextUrl : null, canManage) }}
 {%- endfor -%}
 
 {% if result.totalCount == 0 %}
-<tr><td class="table-empty" colspan="4">No teams found</td></tr>
+<tr><td class="table-empty" colspan="{{ canManage ? 5 : 4 }}">No teams found</td></tr>
 {% endif %}

--- a/src/main/resources/templates/modules/teams/team.macros.peb
+++ b/src/main/resources/templates/modules/teams/team.macros.peb
@@ -1,0 +1,41 @@
+{% macro teamRow(team, memberCount, nextUrl, canManage) %}
+{# @pebvariable name="team" type="ch.srgssr.pillarbox.backend.domain.model.Team" #}
+{# @pebvariable name="memberCount" type="java.lang.Long" #}
+{# @pebvariable name="nextUrl" type="java.lang.String" #}
+{# @pebvariable name="canManage" type="java.lang.Boolean" #}
+<tr id="team-row-{{ team.id }}" class="team-row"{% if nextUrl is not empty %} hx-get="{{ nextUrl }}" hx-trigger="revealed" hx-swap="afterend" hx-select=".team-row"{% endif %}>
+  <td>
+    <span class="cell-identity">
+      <span class="avatar"><span class="material-symbols-outlined" aria-hidden="true">group</span></span>
+      <span class="cell-name">{{ team.name }}</span>
+    </span>
+  </td>
+  <td>{{ memberCount }}</td>
+  <td class="cell-muted">{{ team.createdAt | datetime }}</td>
+  <td class="cell-muted">{{ team.updatedAt | datetime }}</td>
+  {% if canManage %}
+  <td class="cell-action">
+    <button class="btn-icon" type="button" data-open-team
+            hx-get="/console/fragments/team-form?teamId={{ team.id }}"
+            hx-target="#team-dialog"
+            hx-swap="innerHTML"
+            title="Edit {{ team.name }}" aria-label="Edit {{ team.name }}">
+      <span class="material-symbols-outlined" aria-hidden="true">edit</span>
+    </button>
+  </td>
+  {% endif %}
+</tr>
+{% endmacro %}
+
+{% macro memberRow(member) %}
+{# @pebvariable name="member" type="ch.srgssr.pillarbox.backend.domain.model.User" #}
+<div class="member-row" data-member-id="{{ member.oidcSub }}">
+  <input type="hidden" name="memberId" value="{{ member.oidcSub }}">
+  <span class="avatar">{{ member.initials }}</span>
+  <span class="cell-name">{{ member.displayName }}</span>
+  <button type="button" class="btn-icon btn-remove" data-remove-member
+          title="Remove {{ member.displayName }}" aria-label="Remove {{ member.displayName }}">
+    <span class="material-symbols-outlined" aria-hidden="true">close</span>
+  </button>
+</div>
+{% endmacro %}

--- a/src/main/resources/templates/modules/teams/teams.page.peb
+++ b/src/main/resources/templates/modules/teams/teams.page.peb
@@ -9,10 +9,23 @@
 {% endblock %}
 
 {% block mainContent %}
+{% set canManage = user.roles contains 'ADMIN' %}
 <main role="main" id="main-container">
 
   <div class="main-header">
     <h2>Teams</h2>
+    {% if canManage %}
+    <div class="main-header-actions">
+      <button class="btn btn-primary" type="button"
+              data-open-team
+              hx-get="/console/fragments/team-form"
+              hx-target="#team-dialog"
+              hx-swap="innerHTML">
+        <span class="material-symbols-outlined">add</span>
+        New team
+      </button>
+    </div>
+    {% endif %}
   </div>
 
   <div class="field">
@@ -32,6 +45,7 @@
       <col class="col-members">
       <col class="col-date">
       <col class="col-date">
+      {% if canManage %}<col class="col-actions">{% endif %}
     </colgroup>
     <thead>
       <tr>
@@ -39,15 +53,20 @@
         <th>Members</th>
         <th>Created</th>
         <th>Updated</th>
+        {% if canManage %}<th></th>{% endif %}
       </tr>
     </thead>
     <tbody id="team-rows"
            hx-get="/console/fragments/team-table?page=0"
            hx-trigger="load"
            hx-swap="innerHTML">
-      <tr><td colspan="4" class="table-empty">Loading teams…</td></tr>
+      <tr><td colspan="{{ canManage ? 5 : 4 }}" class="table-empty">Loading teams…</td></tr>
     </tbody>
   </table>
+
+  {% if canManage %}
+  <dialog closedby="any" id="team-dialog" class="team-dialog"></dialog>
+  {% endif %}
 
 </main>
 {% endblock %}

--- a/src/main/resources/templates/modules/teams/teams.page.peb
+++ b/src/main/resources/templates/modules/teams/teams.page.peb
@@ -1,0 +1,53 @@
+{% extends "../../../layouts/dashboard.layout.peb" %}
+{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
+
+{% block title %}Teams · Pillarbox Console{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="/static/css/modules/teams/teams.page.css">
+<script src="/static/js/modules/teams/teams.page.js" type="module" defer></script>
+{% endblock %}
+
+{% block mainContent %}
+<main role="main" id="main-container">
+
+  <div class="main-header">
+    <h2>Teams</h2>
+  </div>
+
+  <div class="field">
+    <span class="material-symbols-outlined" aria-hidden="true">search</span>
+    <input type="search" name="q" autocomplete="off"
+           placeholder="Search teams by name…"
+           aria-label="Search teams by name"
+           hx-get="/console/fragments/team-table"
+           hx-target="#team-rows"
+           hx-swap="innerHTML"
+           hx-trigger="input changed delay:300ms, search">
+  </div>
+
+  <table>
+    <colgroup>
+      <col>
+      <col class="col-members">
+      <col class="col-date">
+      <col class="col-date">
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Members</th>
+        <th>Created</th>
+        <th>Updated</th>
+      </tr>
+    </thead>
+    <tbody id="team-rows"
+           hx-get="/console/fragments/team-table?page=0"
+           hx-trigger="load"
+           hx-swap="innerHTML">
+      <tr><td colspan="4" class="table-empty">Loading teams…</td></tr>
+    </tbody>
+  </table>
+
+</main>
+{% endblock %}

--- a/src/main/resources/templates/modules/users/fragments/user-table.fragment.peb
+++ b/src/main/resources/templates/modules/users/fragments/user-table.fragment.peb
@@ -9,9 +9,9 @@
 {%- for user in result.items -%}
 <tr class="user-row"{% if loop.last and nextUrl is not empty %} hx-get="{{ nextUrl }}" hx-trigger="revealed" hx-swap="afterend" hx-select=".user-row"{% endif %}>
   <td>
-    <span class="user-identity">
+    <span class="cell-identity">
       {{ avatar(initials=user.initials) }}
-      <span class="user-name">{{ user.displayName }}</span>
+      <span class="cell-name">{{ user.displayName }}</span>
     </span>
   </td>
   <td>
@@ -19,8 +19,8 @@
       {%- for role in user.roles -%}<span class="role-tag">{{ role }}</span>{%- endfor -%}
     </span>
   </td>
-  <td class="user-date">{{ user.createdAt | datetime }}</td>
-  <td class="user-date">{{ user.updatedAt | datetime }}</td>
+  <td class="cell-muted">{{ user.createdAt | datetime }}</td>
+  <td class="cell-muted">{{ user.updatedAt | datetime }}</td>
 </tr>
 {%- endfor -%}
 

--- a/src/main/resources/templates/modules/users/fragments/user-table.fragment.peb
+++ b/src/main/resources/templates/modules/users/fragments/user-table.fragment.peb
@@ -1,0 +1,29 @@
+{% import "../../../shared/macros/avatar.macros.peb" %}
+{# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.User>" #}
+{# @pebvariable name="nextPage" type="java.lang.Integer" #}
+{# @pebvariable name="q" type="java.lang.String" #}
+
+{% set hasMore = (nextPage * result.limit) < result.totalCount %}
+{% set nextUrl = hasMore ? "/console/fragments/user-table?page=" + nextPage + "&pageSize=" + result.limit + "&q=" + (q | urlencode) : null %}
+
+{%- for user in result.items -%}
+<tr class="user-row"{% if loop.last and nextUrl is not empty %} hx-get="{{ nextUrl }}" hx-trigger="revealed" hx-swap="afterend" hx-select=".user-row"{% endif %}>
+  <td>
+    <span class="user-identity">
+      {{ avatar(initials=user.initials) }}
+      <span class="user-name">{{ user.displayName }}</span>
+    </span>
+  </td>
+  <td>
+    <span class="role-tags">
+      {%- for role in user.roles -%}<span class="role-tag">{{ role }}</span>{%- endfor -%}
+    </span>
+  </td>
+  <td class="user-date">{{ user.createdAt | datetime }}</td>
+  <td class="user-date">{{ user.updatedAt | datetime }}</td>
+</tr>
+{%- endfor -%}
+
+{% if result.totalCount == 0 %}
+<tr><td class="table-empty" colspan="4">No users found</td></tr>
+{% endif %}

--- a/src/main/resources/templates/modules/users/users.page.peb
+++ b/src/main/resources/templates/modules/users/users.page.peb
@@ -1,0 +1,53 @@
+{% extends "../../../layouts/dashboard.layout.peb" %}
+{# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
+
+{% block title %}Users · Pillarbox Console{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="/static/css/modules/users/users.page.css">
+<script src="/static/js/modules/users/users.page.js" type="module" defer></script>
+{% endblock %}
+
+{% block mainContent %}
+<main role="main" id="main-container">
+
+  <div class="main-header">
+    <h2>Users</h2>
+  </div>
+
+  <div class="field">
+    <span class="material-symbols-outlined" aria-hidden="true">search</span>
+    <input type="search" name="q" autocomplete="off"
+           placeholder="Search users by name…"
+           aria-label="Search users by name"
+           hx-get="/console/fragments/user-table"
+           hx-target="#user-rows"
+           hx-swap="innerHTML"
+           hx-trigger="input changed delay:300ms, search">
+  </div>
+
+  <table>
+    <colgroup>
+      <col>
+      <col class="col-roles">
+      <col class="col-date">
+      <col class="col-date">
+    </colgroup>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Roles</th>
+        <th>Created</th>
+        <th>Updated</th>
+      </tr>
+    </thead>
+    <tbody id="user-rows"
+           hx-get="/console/fragments/user-table?page=0"
+           hx-trigger="load"
+           hx-swap="innerHTML">
+      <tr><td colspan="4" class="table-empty">Loading users…</td></tr>
+    </tbody>
+  </table>
+
+</main>
+{% endblock %}

--- a/src/main/resources/templates/shared/components/sidebar.component.peb
+++ b/src/main/resources/templates/shared/components/sidebar.component.peb
@@ -1,5 +1,6 @@
 {# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
 {# @pebvariable name="folder" type="ch.srgssr.pillarbox.backend.domain.model.Folder" #}
+{# @pebvariable name="section" type="java.lang.String" #}
 
 <aside class="sidebar" id="sidebar" popover>
   <header>
@@ -8,17 +9,13 @@
   </header>
 
   <nav>
-    <a href="/console" class="{{ folder is empty and not deleted ? 'is-active' : '' }}">
+    <a href="/console" class="{{ section == 'library' ? 'is-active' : '' }}">
       <span class="material-symbols-outlined">folder_open</span> Media Library
     </a>
+    {% if user.roles contains 'WRITE' %}
+    <a href="/console/users" class="{{ section == 'users' ? 'is-active' : '' }}">
+      <span class="material-symbols-outlined">group</span> Users
+    </a>
+    {% endif %}
   </nav>
-
-  <!--
-  <div class="sidebar-section-label">Folders</div>
-  <div class="folder-tree"
-       hx-get="/console/folders/tree?active={{ folder.id | default('') }}"
-       hx-trigger="load"
-       hx-swap="innerHTML">
-  </div> -->
-
 </aside>

--- a/src/main/resources/templates/shared/components/sidebar.component.peb
+++ b/src/main/resources/templates/shared/components/sidebar.component.peb
@@ -16,6 +16,9 @@
     <a href="/console/users" class="{{ section == 'users' ? 'is-active' : '' }}">
       <span class="material-symbols-outlined">group</span> Users
     </a>
+    <a href="/console/teams" class="{{ section == 'teams' ? 'is-active' : '' }}">
+      <span class="material-symbols-outlined">groups</span> Teams
+    </a>
     {% endif %}
   </nav>
 </aside>

--- a/src/main/resources/templates/shared/components/user-menu.component.peb
+++ b/src/main/resources/templates/shared/components/user-menu.component.peb
@@ -1,5 +1,5 @@
 {# @pebvariable name="user" type="ch.srgssr.pillarbox.backend.entrypoint.web.console.UserView" #}
-<button type="button" class="user-avatar" popovertarget="user-menu" aria-expanded="false" title="{{ user.name | default('User') }}">
+<button type="button" class="avatar" popovertarget="user-menu" aria-expanded="false" title="{{ user.name | default('User') }}">
   {{ user.initials | default('?') }}
 </button>
 <div class="dropdown user-dropdown" popover id="user-menu">

--- a/src/main/resources/templates/shared/macros/avatar.macros.peb
+++ b/src/main/resources/templates/shared/macros/avatar.macros.peb
@@ -1,4 +1,4 @@
 {# A round avatar showing either a material icon or the subject's initials. #}
 {% macro avatar(initials = null, icon = null) %}
-<span class="avatar">{% if icon is not null %}<span class="material-symbols-outlined" aria-hidden="true">{{ icon }}</span>{% else %}{{ initials | default('?') }}{% endif %}</span>
+<span class="avatar" aria-hidden="true">{% if icon is not null %}<span class="material-symbols-outlined">{{ icon }}</span>{% else %}{{ initials | default('?') }}{% endif %}</span>
 {% endmacro %}

--- a/src/main/resources/templates/shared/macros/avatar.macros.peb
+++ b/src/main/resources/templates/shared/macros/avatar.macros.peb
@@ -1,0 +1,4 @@
+{# A round avatar showing either a material icon or the subject's initials. #}
+{% macro avatar(initials = null, icon = null) %}
+<span class="avatar">{% if icon is not null %}<span class="material-symbols-outlined" aria-hidden="true">{{ icon }}</span>{% else %}{{ initials | default('?') }}{% endif %}</span>
+{% endmacro %}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleTeamsTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleTeamsTest.kt
@@ -1,0 +1,122 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
+import ch.srgssr.pillarbox.backend.test.count
+import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.parseRows
+import ch.srgssr.pillarbox.backend.test.seedTeam
+import ch.srgssr.pillarbox.backend.test.seedUser
+import ch.srgssr.pillarbox.backend.test.teamFixture
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.testDb
+import ch.srgssr.pillarbox.backend.test.userFixture
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import org.jsoup.Jsoup
+import org.jsoup.select.Elements
+
+class ConsoleTeamsTest :
+  ShouldSpec({
+    should("render the teams page shell that lazy-loads the table") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+
+        val doc = Jsoup.parse(client.get("${Navigation.CONSOLE}/teams").bodyAsText())
+
+        doc.count("input[type=search][name=q]") shouldBe 1
+        doc.count("#team-rows[hx-get*=team-table]") shouldBe 1
+      }
+    }
+
+    should("list teams ordered by most recently updated") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedTeam(teamFixture(id = "t-early", name = "Archive"))
+        seedTeam(teamFixture(id = "t-late", name = "Newsroom"))
+
+        val names =
+          parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/team-table").bodyAsText())
+            .select(".cell-name")
+            .eachText()
+
+        (names.indexOf("Newsroom") < names.indexOf("Archive")).shouldBeTrue()
+      }
+    }
+
+    should("filter the table by name") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedTeam(teamFixture(id = "t-news", name = "Newsroom"))
+        seedTeam(teamFixture(id = "t-sport", name = "Sport"))
+
+        val names =
+          parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/team-table?q=news").bodyAsText())
+            .select(".cell-name")
+            .eachText()
+
+        names shouldContain "Newsroom"
+        names shouldNotContain "Sport"
+      }
+    }
+
+    should("show the member count for each team") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedUser(userFixture(oidcSub = "u1", displayName = "One"))
+        seedUser(userFixture(oidcSub = "u2", displayName = "Two"))
+        seedTeam(teamFixture(id = "t-crowded", name = "Crowded"))
+        seedTeam(teamFixture(id = "t-empty", name = "Empty"))
+        with(TeamRepository(testDb)) {
+          addMember("t-crowded", "u1")
+          addMember("t-crowded", "u2")
+        }
+
+        val rows =
+          parseRows(
+            client.hxGet("${Navigation.CONSOLE}/fragments/team-table").bodyAsText(),
+          ).select(".team-row")
+
+        rows.memberCountOf("Crowded") shouldBe "2"
+        rows.memberCountOf("Empty") shouldBe "0"
+      }
+    }
+
+    should("page through the table with a cursor that carries the search query") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        repeat(3) { seedTeam(teamFixture(id = "match-$it", name = "Match $it")) }
+
+        val doc =
+          parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/team-table?q=match&pageSize=2").bodyAsText())
+
+        doc.count(".team-row") shouldBe 2
+        val nextUrl = doc.select(".team-row[hx-get]").attr("hx-get")
+        nextUrl shouldContain "page=1"
+        nextUrl shouldContain "q=match"
+      }
+    }
+
+    should("forbid users without write access from the page and the fragment") {
+      testApplicationContext {
+        login(roles = emptySet())
+
+        client.get("${Navigation.CONSOLE}/teams") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxGet("${Navigation.CONSOLE}/fragments/team-table") shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+  })
+
+/** The text of the member-count cell (second column) of the row whose name matches [name]. */
+private fun Elements.memberCountOf(name: String): String =
+  first { it.selectFirst(".cell-name")?.text() == name }.select("td")[1].text()

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleTeamsTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleTeamsTest.kt
@@ -5,6 +5,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
 import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
 import ch.srgssr.pillarbox.backend.test.count
 import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.hxPost
 import ch.srgssr.pillarbox.backend.test.login
 import ch.srgssr.pillarbox.backend.test.parseRows
 import ch.srgssr.pillarbox.backend.test.seedTeam
@@ -21,8 +22,12 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.get
+import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.formUrlEncode
 import org.jsoup.Jsoup
 import org.jsoup.select.Elements
 
@@ -113,6 +118,147 @@ class ConsoleTeamsTest :
 
         client.get("${Navigation.CONSOLE}/teams") shouldHaveStatus HttpStatusCode.Forbidden
         client.hxGet("${Navigation.CONSOLE}/fragments/team-table") shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("show the new-team button only to administrators") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        Jsoup.parse(client.get("${Navigation.CONSOLE}/teams").bodyAsText()).count("[data-open-team]") shouldBe 1
+      }
+    }
+
+    should("hide the new-team button from non-administrators") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        Jsoup.parse(client.get("${Navigation.CONSOLE}/teams").bodyAsText()).count("[data-open-team]") shouldBe 0
+      }
+    }
+
+    should("offer matching users as member options and render a member row") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "grace", displayName = "Grace Hopper"))
+
+        val options = Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/member-options?q=grace").bodyAsText())
+        options.select("option").attr("value") shouldBe "Grace Hopper"
+        options.select("option").attr("data-id") shouldBe "grace"
+
+        val row = Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/member-row?oidcSub=grace").bodyAsText())
+        row.count(".member-row[data-member-id=grace]") shouldBe 1
+        row.select("input[name=memberId]").attr("value") shouldBe "grace"
+      }
+    }
+
+    should("create a team with its members in a single request") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "m1", displayName = "Mia One"))
+        seedUser(userFixture(oidcSub = "m2", displayName = "Max Two"))
+
+        val added =
+          client.hxPost("${Navigation.CONSOLE}/actions/team") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("name" to "Newsroom", "memberId" to "m1", "memberId" to "m2").formUrlEncode())
+          }
+        added shouldHaveStatus HttpStatusCode.OK
+        parseRows(added.bodyAsText()).select(".team-row").memberCountOf("Newsroom") shouldBe "2"
+
+        val table = parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/team-table").bodyAsText())
+        table.select(".cell-name").eachText() shouldContain "Newsroom"
+      }
+    }
+
+    should("reject a team without a name") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+
+        client.hxPost("${Navigation.CONSOLE}/actions/team") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("name" to "  ").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.UnprocessableEntity
+      }
+    }
+
+    should("forbid non-administrators from creating teams") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+
+        client.hxGet("${Navigation.CONSOLE}/fragments/team-form") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxPost("${Navigation.CONSOLE}/actions/team") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("name" to "Nope").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+
+    should("show an edit action on team rows only to administrators") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedTeam(teamFixture(id = "t1", name = "Newsroom"))
+        val rows = parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/team-table").bodyAsText())
+        rows.count(".team-row [hx-get*=team-form]") shouldBe 1
+      }
+    }
+
+    should("hide the edit action from non-administrators") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedTeam(teamFixture(id = "t1", name = "Newsroom"))
+        val rows = parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/team-table").bodyAsText())
+        rows.count(".team-row [hx-get*=team-form]") shouldBe 0
+      }
+    }
+
+    should("populate the edit form with the team and its members") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "m1", displayName = "Mia One"))
+        seedTeam(teamFixture(id = "t1", name = "Newsroom"))
+        with(TeamRepository(testDb)) { addMember("t1", "m1") }
+
+        val doc = Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/team-form?teamId=t1").bodyAsText())
+
+        doc.select("input[name=name]").attr("value") shouldBe "Newsroom"
+        doc.count(".member-row[data-member-id=m1]") shouldBe 1
+        doc.select("form").attr("hx-post") shouldContain "/actions/team/t1"
+      }
+    }
+
+    should("update a team's name and members in a single request") {
+      testApplicationContext {
+        login(roles = setOf(Role.ADMIN))
+        seedUser(userFixture(oidcSub = "m1", displayName = "Mia One"))
+        seedUser(userFixture(oidcSub = "m2", displayName = "Max Two"))
+        seedTeam(teamFixture(id = "t1", name = "Newsroom"))
+        with(TeamRepository(testDb)) { addMember("t1", "m1") }
+
+        val updated =
+          client.hxPost("${Navigation.CONSOLE}/actions/team/t1") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(listOf("name" to "Sports Desk", "memberId" to "m2").formUrlEncode())
+          }
+        updated shouldHaveStatus HttpStatusCode.OK
+        parseRows(updated.bodyAsText()).select(".team-row").memberCountOf("Sports Desk") shouldBe "1"
+
+        val table =
+          parseRows(
+            client.hxGet("${Navigation.CONSOLE}/fragments/team-table").bodyAsText(),
+          ).select(".cell-name").eachText()
+        table shouldContain "Sports Desk"
+        table shouldNotContain "Newsroom"
+      }
+    }
+
+    should("forbid non-administrators from updating a team") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedTeam(teamFixture(id = "t1", name = "Newsroom"))
+
+        client.hxPost("${Navigation.CONSOLE}/actions/team/t1") {
+          contentType(ContentType.Application.FormUrlEncoded)
+          setBody(listOf("name" to "Nope").formUrlEncode())
+        } shouldHaveStatus HttpStatusCode.Forbidden
       }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleUsersTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleUsersTest.kt
@@ -1,0 +1,94 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.test.count
+import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.seedUser
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.userFixture
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
+class ConsoleUsersTest :
+  ShouldSpec({
+    should("render the users page shell that lazy-loads the table") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+
+        val doc = Jsoup.parse(client.get("${Navigation.CONSOLE}/users").bodyAsText())
+
+        doc.count("input[type=search][name=q]") shouldBe 1
+        doc.count("#user-rows[hx-get*=user-table]") shouldBe 1
+      }
+    }
+
+    should("list users ordered by most recently updated, without exposing the oidc subject") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedUser(userFixture(oidcSub = "secret-sub-aaa", displayName = "Aaron Early"))
+        seedUser(userFixture(oidcSub = "secret-sub-bbb", displayName = "Bianca Late", roles = setOf(Role.WRITE)))
+
+        val body = client.hxGet("${Navigation.CONSOLE}/fragments/user-table?page=0").bodyAsText()
+        val names = parseRows(body).select(".user-name").eachText()
+
+        (names.indexOf("Bianca Late") < names.indexOf("Aaron Early")).shouldBeTrue()
+        body shouldNotContain "secret-sub"
+        body shouldContain "WRITE"
+      }
+    }
+
+    should("filter the table by display name") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        seedUser(userFixture(oidcSub = "u-grace", displayName = "Grace Hopper"))
+        seedUser(userFixture(oidcSub = "u-alan", displayName = "Alan Turing"))
+
+        val names =
+          parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/user-table?q=grace").bodyAsText())
+            .select(".user-name")
+            .eachText()
+
+        names shouldContain "Grace Hopper"
+        names shouldNotContain "Alan Turing"
+      }
+    }
+
+    should("page through the table with a cursor that carries the search query") {
+      testApplicationContext {
+        login(roles = setOf(Role.WRITE))
+        repeat(3) { seedUser(userFixture(oidcSub = "match-$it", displayName = "Match $it")) }
+
+        val doc = parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/user-table?q=match&pageSize=2").bodyAsText())
+
+        doc.count(".user-row") shouldBe 2
+        val nextUrl = doc.select(".user-row[hx-get]").attr("hx-get")
+        nextUrl shouldContain "page=1"
+        nextUrl shouldContain "q=match"
+      }
+    }
+
+    should("forbid users without write access from the page and the fragment") {
+      testApplicationContext {
+        login(roles = emptySet())
+
+        client.get("${Navigation.CONSOLE}/users") shouldHaveStatus HttpStatusCode.Forbidden
+        client.hxGet("${Navigation.CONSOLE}/fragments/user-table") shouldHaveStatus HttpStatusCode.Forbidden
+      }
+    }
+  })
+
+/** Wraps a bare `<tr>` fragment in a table so Jsoup's HTML parser keeps the rows. */
+private fun parseRows(fragment: String): Document = Jsoup.parse("<table>$fragment</table>")

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleUsersTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleUsersTest.kt
@@ -5,6 +5,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
 import ch.srgssr.pillarbox.backend.test.count
 import ch.srgssr.pillarbox.backend.test.hxGet
 import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.parseRows
 import ch.srgssr.pillarbox.backend.test.seedUser
 import ch.srgssr.pillarbox.backend.test.testApplicationContext
 import ch.srgssr.pillarbox.backend.test.userFixture
@@ -20,7 +21,6 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
 
 class ConsoleUsersTest :
   ShouldSpec({
@@ -42,7 +42,7 @@ class ConsoleUsersTest :
         seedUser(userFixture(oidcSub = "secret-sub-bbb", displayName = "Bianca Late", roles = setOf(Role.WRITE)))
 
         val body = client.hxGet("${Navigation.CONSOLE}/fragments/user-table?page=0").bodyAsText()
-        val names = parseRows(body).select(".user-name").eachText()
+        val names = parseRows(body).select(".cell-name").eachText()
 
         (names.indexOf("Bianca Late") < names.indexOf("Aaron Early")).shouldBeTrue()
         body shouldNotContain "secret-sub"
@@ -58,7 +58,7 @@ class ConsoleUsersTest :
 
         val names =
           parseRows(client.hxGet("${Navigation.CONSOLE}/fragments/user-table?q=grace").bodyAsText())
-            .select(".user-name")
+            .select(".cell-name")
             .eachText()
 
         names shouldContain "Grace Hopper"
@@ -89,6 +89,3 @@ class ConsoleUsersTest :
       }
     }
   })
-
-/** Wraps a bare `<tr>` fragment in a table so Jsoup's HTML parser keeps the rows. */
-private fun parseRows(fragment: String): Document = Jsoup.parse("<table>$fragment</table>")

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/JsoupExtensions.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/JsoupExtensions.kt
@@ -1,5 +1,6 @@
 package ch.srgssr.pillarbox.backend.test
 
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
@@ -9,3 +10,6 @@ operator fun Document.get(selector: String): Elements = this.select(selector)
 fun Document.count(selector: String): Int = this[selector].size
 
 operator fun Element.get(selector: String): Elements = this.select(selector)
+
+/** Wraps a bare `<tr>` fragment in a table so Jsoup's HTML parser keeps the rows. */
+fun parseRows(fragment: String): Document = Jsoup.parse("<table>$fragment</table>")


### PR DESCRIPTION
## Description

Lets administrators manage teams and users within the console.

## Changes Made

### User Page

Gives editors a place to see who can use the console. A new Users page, reachable from the sidebar by anyone with write access, lists every user in an infinite-scrolling table with a name search, newest activity first.

- Show each user's display name, roles, and creation and update times,  ordered by last update, with a search box that filters on the display name.
- Highlight the active sidebar entry using a explicit `section` variable.
- Extract the page shell (`#main-container`, `.main-header`) into the dashboard layout so every page shares its padding, spacing, and title size.
- Add a generic round `avatar` component (with a clickable `button.avatar` variant) and adopt it in the header user menu, the users table, and the folder-permission rows.
- Add generic `table` styling in `_table.css` base partial.
- Add a generic search field (leading icon, keyed off `input[type="search"]`) to the form styles.

### Team Page

A new Teams page, reachable from the sidebar by anyone with write access, lists every team in an infinite-scrolling table with a name search, newest activity first, and a column showing how many members each team has.

- Show each team's name, member count, and creation and update times, ordered by last update, with a name search.
- Count the members of a page of teams in a single grouped query (`countMembersOf`); teams with no members report zero.
- Move the identity cell (an avatar beside a truncating label) and the muted-cell helper into the generic `_table.css` as `.cell-identity`, `.cell-name`, and `.cell-muted`.
- Reuse the round avatar with a group icon for teams.
- Add a dialog to create and update a team and its members.
- Submit the name and the chosen members in one request.
- Edition of teams is gated to admin role only.
- Generify the row cross into a `.btn-remove`.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
