### PR TITLE
feat(media): full-text search across the library and APIs

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/PermissionChecker.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/PermissionChecker.kt
@@ -107,6 +107,45 @@ class PermissionChecker(
     mediaId: String,
   ): Boolean = canWriteFolder(user, folderRepository.findFolderOf(mediaId)?.id)
 
+  /**
+   * Whether [user] may modify each of the given media items, based on the folders they are
+   * assigned to.
+   *
+   * @param user The authenticated user.
+   * @param mediaIds The target media items.
+   * @return A map from media id to whether [user] may write it.
+   */
+  suspend fun canWriteMedia(
+    user: User,
+    mediaIds: List<String>,
+  ): Map<String, Boolean> = canWriteMedia(user, mediaIds, folderRepository.findFoldersOf(mediaIds))
+
+  /**
+   * Whether [user] may modify each of the given media items, reusing an already-resolved
+   * [foldersByMedia] map so the caller and this check share a single folder lookup.
+   *
+   * @param user The authenticated user.
+   * @param mediaIds The target media items.
+   * @param foldersByMedia The folder each media item is assigned to; ids absent from the map are
+   *   treated as unassigned.
+   * @return A map from media id to whether [user] may write it.
+   */
+  suspend fun canWriteMedia(
+    user: User,
+    mediaIds: List<String>,
+    foldersByMedia: Map<String, Folder>,
+  ): Map<String, Boolean> {
+    val writableByFolder = canWriteFolders(user, foldersByMedia.values.distinctBy { it.id })
+    val canWriteUnassigned = canWriteFolder(user, null)
+
+    return mediaIds.associateWith { mediaId ->
+      when (val folder = foldersByMedia[mediaId]) {
+        null -> canWriteUnassigned
+        else -> writableByFolder[folder.id] == true
+      }
+    }
+  }
+
   private fun isGranted(
     user: User,
     grants: List<FolderPermission>,

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/FullTextSearch.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/FullTextSearch.kt
@@ -1,0 +1,107 @@
+package ch.srgssr.pillarbox.backend.db
+
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.FloatColumnType
+import org.jetbrains.exposed.v1.core.Function
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.QueryBuilder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.TextColumnType
+import org.jetbrains.exposed.v1.core.stringLiteral
+
+/**
+ * Full-text search against a `tsvector` column that PostgreSQL generates and indexes.
+ *
+ * The column is not part of the Exposed [Table] definition; this helper renders the `WHERE` and
+ * `ORDER BY` fragments that reference it by name.
+ *
+ * @param table The table carrying the vector column.
+ * @param column The database name of the `tsvector` column.
+ * @property config The text-search configuration queries are parsed with; must match the one the
+ *   vector is generated with. The `simple` default skips stemming, keeping identifiers intact.
+ */
+class FullTextSearch(
+  table: Table,
+  column: String,
+  private val config: String = "simple",
+) {
+  private val vector = "\"${table.tableName}\".\"$column\""
+
+  /**
+   * Builds a `WHERE` predicate matching rows against [query].
+   *
+   * @param query Free-text search input; every term must match as a prefix ("glac" finds "glacier").
+   * @return An [Op] that is `true` for rows whose vector matches [query].
+   */
+  infix fun matches(query: String): Op<Boolean> = MatchOp(query)
+
+  /**
+   * Builds a relevance score for [query], for use in `ORDER BY`.
+   *
+   * @param query Free-text search input, tokenised like [matches].
+   * @return A float [Expression] of the row's `ts_rank` against [query].
+   */
+  fun rank(query: String): Expression<Float> = RankFunction(query)
+
+  /**
+   * Whether [query] carries at least one term that can be searched.
+   *
+   * @param query Free-text search input.
+   * @return `true` if [query] holds a letter-or-digit run; `false` for blank or punctuation-only
+   *   input, which would tokenise to an empty `tsquery`.
+   */
+  fun hasTerms(query: String): Boolean = TERM_PATTERN.containsMatchIn(query)
+
+  /** Appends a `to_tsquery(config, …)` call with the prefix query bound as a parameter. */
+  private fun QueryBuilder.appendTsQuery(query: String) {
+    append("to_tsquery(")
+    append(stringLiteral(config))
+    append(", ")
+    registerArgument(TextColumnType(), toPrefixTsQuery(query))
+    append(")")
+  }
+
+  private inner class MatchOp(
+    private val query: String,
+  ) : Op<Boolean>() {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+      queryBuilder {
+        append(vector)
+        append(" @@ ")
+        appendTsQuery(query)
+      }
+    }
+  }
+
+  private inner class RankFunction(
+    private val query: String,
+  ) : Function<Float>(FloatColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) {
+      queryBuilder {
+        append("ts_rank(")
+        append(vector)
+        append(", ")
+        appendTsQuery(query)
+        append(")")
+      }
+    }
+  }
+
+  companion object {
+    /** Matches maximal runs of letters or digits, used to tokenise a free-text query. */
+    private val TERM_PATTERN = Regex("[\\p{L}\\p{N}]+")
+
+    /**
+     * Turns free text into a prefix `tsquery` string such as `glac:* & alp:*`.
+     *
+     * Only letters and digits survive tokenisation, so the result is always a well-formed,
+     * injection-safe `tsquery` (an all-punctuation input yields an empty string).
+     *
+     * @return The `to_tsquery` text for [query]; terms are AND-ed and matched as prefixes.
+     */
+    private fun toPrefixTsQuery(query: String): String =
+      TERM_PATTERN
+        .findAll(query)
+        .joinToString(" & ") { "${it.value}:*" }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/db/SearchableRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/db/SearchableRepository.kt
@@ -1,0 +1,53 @@
+package ch.srgssr.pillarbox.backend.db
+
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * An [ExposedRepository] over a table carrying a full-text search vector.
+ *
+ * @param textSearch The [FullTextSearch] bound to the table's `tsvector` column.
+ */
+abstract class SearchableRepository<T, ID>(
+  db: Database,
+  table: Table,
+  idColumn: Column<ID>,
+  private val textSearch: FullTextSearch,
+) : ExposedRepository<T, ID>(db = db, table = table, idColumn = idColumn) {
+  /**
+   * Retrieves a page of entities matching the full-text [query], most relevant first.
+   *
+   * @param query Free-text search input; each term matches as a prefix. Blank or term-less input
+   *   (e.g. punctuation only) yields an empty result without hitting the database.
+   * @param limit The maximum number of items to return.
+   * @param offset The number of items to skip before returning results.
+   * @param filter An optional additional WHERE predicate.
+   * @param sort Optional tie-breaking order applied after relevance.
+   * @return A [PaginatedResult] of the matching entities.
+   */
+  suspend fun search(
+    query: String,
+    limit: Int = 100,
+    offset: Long = 0,
+    filter: (() -> Op<Boolean>)? = null,
+    sort: List<Pair<Expression<*>, SortOrder>> = emptyList(),
+  ): PaginatedResult<T> {
+    val term = query.trim()
+    if (!textSearch.hasTerms(term)) {
+      return PaginatedResult(items = emptyList(), totalCount = 0, limit = limit, offset = offset)
+    }
+
+    val match = textSearch matches term
+    return getAllPaginated(
+      limit = limit,
+      offset = offset,
+      filter = { filter?.let { match and it() } ?: match },
+      sort = listOf(textSearch.rank(term) to SortOrder.DESC) + sort + (idColumn to SortOrder.ASC),
+    )
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
@@ -21,8 +21,6 @@ import io.ktor.server.routing.patch
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.util.getOrFail
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 
@@ -42,14 +40,11 @@ fun Route.media(mediaRepository: MediaRepository) {
 
       get {
         with(call.request.queryParameters.toQuerySlice()) {
+          val query = call.request.queryParameters["q"]
           call.respond(
             mediaRepository
-              .getAll(
-                limit,
-                offset,
-                filter = { MediaTable.deleted eq false },
-              ).map { it.toMediaResponseV1() }
-              .toList(),
+              .findActiveMedia(query, limit, offset)
+              .map { it.toMediaResponseV1() },
           )
         }
       }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
@@ -16,8 +16,6 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.server.routing.route
 import io.ktor.server.util.getOrFail
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 
@@ -39,14 +37,11 @@ fun Route.playerMedia(
       get {
         with(call.request.queryParameters.toQuerySlice()) {
           val mediaSourceSelector = call.request.toMediaSourceSelector()
+          val query = call.request.queryParameters["q"]
           call.respond(
             mediaRepository
-              .getAll(
-                limit,
-                offset,
-                filter = { MediaTable.deleted eq false },
-              ).map { it.toPlayerResponse(mediaSourceSelector) }
-              .toList(),
+              .findActiveMedia(query, limit, offset)
+              .map { it.toPlayerResponse(mediaSourceSelector) },
           )
         }
       }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/HomeRoute.kt
@@ -80,6 +80,7 @@ fun Route.homePage(
 
   folderFragments(folderRepository)
   mediaGridFragments(mediaRepository)
+  mediaSearchFragments(mediaRepository, folderRepository)
 
   withRole(Role.WRITE) {
     folderActions(mediaRepository, folderRepository)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRoute.kt
@@ -3,6 +3,8 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.console
 import ch.srgssr.pillarbox.backend.auth.user
 import ch.srgssr.pillarbox.backend.authz.permissionChecker
 import ch.srgssr.pillarbox.backend.authz.withMediaWrite
+import ch.srgssr.pillarbox.backend.db.PaginatedResult
+import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.Role
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
 import ch.srgssr.pillarbox.backend.log.debug
@@ -36,20 +38,25 @@ fun Route.mediaGridFragments(mediaRepository: MediaRepository) {
     with(call.queryParameters.toPageRequest()) {
       val deleted = call.parameters["deleted"] == "true"
       val folderId = call.parameters["folderId"]?.takeIf { it.isNotBlank() }
+      val query = call.parameters["q"]?.takeIf { it.isNotBlank() }
 
-      logger.debug { "Fetching media grid: pageRequest=$this, folderId=$folderId, deleted=$deleted" }
+      logger.debug { "Fetching media grid: pageRequest=$this, folderId=$folderId, deleted=$deleted, query=$query" }
 
       val result =
         when {
+          query != null -> mediaRepository.search(query, limit, offset, filter = { MediaTable.deleted eq deleted })
           deleted -> mediaRepository.getAllPaginated(limit, offset, filter = { MediaTable.deleted eq true })
           folderId != null -> mediaRepository.findMediaInFolder(folderId, limit, offset)
           else -> mediaRepository.findMediaWithoutFolder(limit, offset)
         }
 
-      val canWrite =
+      // The bin is admin-only and a folder grid shares one ACL, so a single verdict fits both; a
+      // cross-folder search spans folders and must resolve write access per media item.
+      val writableByMedia =
         when {
-          deleted -> call.user.hasAnyRole(setOf(Role.ADMIN))
-          else -> call.permissionChecker.canWriteFolder(call.user, folderId)
+          deleted -> result.writeAccess(call.user.hasAnyRole(setOf(Role.ADMIN)))
+          query != null -> call.permissionChecker.canWriteMedia(call.user, result.items.map { it.id })
+          else -> result.writeAccess(call.permissionChecker.canWriteFolder(call.user, folderId))
         }
 
       call.respondWithContext(
@@ -58,13 +65,23 @@ fun Route.mediaGridFragments(mediaRepository: MediaRepository) {
           put("result", result)
           put("nextPage", nextPage)
           put("deleted", deleted)
-          put("canWrite", canWrite)
-          folderId?.let { put("folderId", folderId) }
+          put("writableByMedia", writableByMedia)
+          query?.let { put("query", it) }
+          folderId?.let { put("folderId", it) }
         },
       )
     }
   }
 }
+
+/**
+ * Maps every media item on the page to the same write [verdict].
+ *
+ * @param verdict Whether the current user may write all items on the page.
+ * @return A map from media id to [verdict].
+ */
+private fun PaginatedResult<Media>.writeAccess(verdict: Boolean): Map<String, Boolean> =
+  items.associate { it.id to verdict }
 
 /**
  * Registers HTMX action endpoints for the paginated media-grid fragment.

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaSearchRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaSearchRoute.kt
@@ -1,0 +1,64 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.auth.user
+import ch.srgssr.pillarbox.backend.authz.permissionChecker
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toPageRequest
+import ch.srgssr.pillarbox.backend.log.debug
+import ch.srgssr.pillarbox.backend.log.logger
+import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
+import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
+import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import io.ktor.server.htmx.hx
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.utils.io.ExperimentalKtorApi
+import org.jetbrains.exposed.v1.core.eq
+
+private object MediaSearchRoute
+
+private val logger = MediaSearchRoute.logger()
+
+/**
+ * Registers the HTMX fragment endpoint for the library search screen.
+ *
+ * A query swaps the library for cross-folder results ranked by relevance, each labelled with the
+ * folder it belongs to; a blank query renders the regular library sections back.
+ *
+ * @param mediaRepository Repository used to run the full-text search.
+ * @param folderRepository Repository used to resolve the folder of each result.
+ */
+@OptIn(ExperimentalKtorApi::class)
+fun Route.mediaSearchFragments(
+  mediaRepository: MediaRepository,
+  folderRepository: FolderRepository,
+) {
+  hx.get("fragments/media-search") {
+    with(call.queryParameters.toPageRequest()) {
+      val folderId = call.parameters["folderId"]?.takeIf { it.isNotBlank() }
+
+      logger.debug { "Fetching media search: pageRequest=$this, folderId=$folderId, query=${call.parameters["q"]}" }
+
+      val query =
+        call.parameters["q"]?.takeIf { it.isNotBlank() }
+          ?: return@get call.respondWithContext(
+            "modules/home/fragments/library-sections.fragment.peb",
+            buildMap { folderId?.let { put("folderId", it) } },
+          )
+
+      val result = mediaRepository.search(query, limit, offset, filter = { MediaTable.deleted eq false })
+      val mediaIds = result.items.map { it.id }
+      val foldersByMedia = folderRepository.findFoldersOf(mediaIds)
+
+      call.respondWithContext(
+        "modules/home/fragments/media-search-results.fragment.peb",
+        mapOf(
+          "result" to result,
+          "nextPage" to nextPage,
+          "query" to query,
+          "writableByMedia" to call.permissionChecker.canWriteMedia(call.user, mediaIds, foldersByMedia),
+          "foldersByMedia" to foldersByMedia,
+        ),
+      )
+    }
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
@@ -110,6 +110,26 @@ class FolderRepository(
     }
 
   /**
+   * Finds the folder each of the given media items is assigned to, in a single query.
+   *
+   * Media items that are not assigned to any folder are absent from the result.
+   *
+   * @param mediaIds The media IDs to look up.
+   * @return A map from media ID to its assigned [Folder].
+   */
+  suspend fun findFoldersOf(mediaIds: Collection<String>): Map<String, Folder> =
+    query(readOnly = true) {
+      if (mediaIds.isEmpty()) {
+        emptyMap()
+      } else {
+        (FolderTable innerJoin FolderMediaTable)
+          .selectAll()
+          .where { FolderMediaTable.mediaId inList mediaIds.distinct() }
+          .associate { it[FolderMediaTable.mediaId] to it.decode() }
+      }
+    }
+
+  /**
    * Returns `true` if the given media item is already assigned to the given folder.
    *
    * @param folderId The folder ID to check.

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
@@ -1,13 +1,15 @@
 package ch.srgssr.pillarbox.backend.persistence.media
 
-import ch.srgssr.pillarbox.backend.db.ExposedRepository
+import ch.srgssr.pillarbox.backend.db.FullTextSearch
 import ch.srgssr.pillarbox.backend.db.PaginatedResult
+import ch.srgssr.pillarbox.backend.db.SearchableRepository
 import ch.srgssr.pillarbox.backend.db.map
 import ch.srgssr.pillarbox.backend.db.paginated
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderMediaTable
 import ch.srgssr.pillarbox.backend.time.toKotlinInstant
 import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import kotlinx.coroutines.flow.toList
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
@@ -37,7 +39,12 @@ import kotlin.time.Clock
  */
 class MediaRepository(
   db: Database,
-) : ExposedRepository<Media, String>(db = db, table = MediaTable, idColumn = MediaTable.id) {
+) : SearchableRepository<Media, String>(
+    db = db,
+    table = MediaTable,
+    idColumn = MediaTable.id,
+    textSearch = FullTextSearch(MediaTable, column = "search_vector"),
+  ) {
   /**
    * Decodes a [ResultRow] from the [MediaTable] into a [Media] domain object.
    */
@@ -166,6 +173,24 @@ class MediaRepository(
         .apply { sort?.let { orderBy(*it.toTypedArray()) } }
         .paginated(limit, offset)
         .map { it.decode() }
+    }
+
+  /**
+   * Retrieves a page of active (non-deleted) media, narrowed by an optional full-text [query].
+   *
+   * @param query Optional search text; blank or `null` lists the page unfiltered.
+   * @param limit The maximum number of items to return.
+   * @param offset The number of items to skip before returning results.
+   * @return The matching [Media] items, most relevant first when searching.
+   */
+  suspend fun findActiveMedia(
+    query: String?,
+    limit: Int = 100,
+    offset: Long = 0,
+  ): List<Media> =
+    when {
+      query.isNullOrBlank() -> getAll(limit, offset, filter = { MediaTable.deleted eq false }).toList()
+      else -> search(query, limit, offset, filter = { MediaTable.deleted eq false }).items
     }
 
   /**

--- a/src/main/resources/db/migration/V8__Add_Media_Search_Index.sql
+++ b/src/main/resources/db/migration/V8__Add_Media_Search_Index.sql
@@ -1,0 +1,16 @@
+CREATE FUNCTION pb_immutable_array_to_string(arr text[]) RETURNS text
+  LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+$$
+SELECT array_to_string(arr, ' ') $$;
+
+ALTER TABLE pb_media
+  ADD COLUMN search_vector tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('simple', coalesce(metadata ->> 'title', '')), 'A') ||
+      setweight(to_tsvector('simple', coalesce(id, '')), 'A') ||
+      setweight(to_tsvector('simple', pb_immutable_array_to_string(tags)), 'B') ||
+      setweight(to_tsvector('simple', coalesce(metadata ->> 'subtitle', '')), 'C') ||
+      setweight(to_tsvector('simple', coalesce(metadata ->> 'description', '')), 'D')
+      ) STORED;
+
+CREATE INDEX idx_pb_media_search ON pb_media USING GIN (search_vector);

--- a/src/main/resources/static/css/modules/home/home.page.css
+++ b/src/main/resources/static/css/modules/home/home.page.css
@@ -1,9 +1,15 @@
 @import url("../../layouts/dashboard.layout.css");
 @import url("../../shared/fragments/media-grid.fragment.css");
 @import url("../../shared/components/snackbar.component.css");
+@import url("../../shared/components/media-search.component.css");
 @import url("./folder-grid.fragment.css");
 @import url("./folder-picker.fragment.css");
 @import url("./folder-permissions.fragment.css");
+
+/* ── Search results — library actions do not apply while they are shown ── */
+main:has(.search-results) .main-header-actions > :not(.media-search) {
+  display: none;
+}
 
 /* ── Section labels ── */
 .section-label {

--- a/src/main/resources/static/css/shared/components/media-search.component.css
+++ b/src/main/resources/static/css/shared/components/media-search.component.css
@@ -1,0 +1,16 @@
+/* ── Media search ── */
+.media-search {
+  inline-size: 24ch;
+  transition: inline-size 0.25s var(--ease-out-3);
+}
+
+.media-search:focus-within {
+  inline-size: 36ch;
+}
+
+@media (width <= 768px) {
+  .media-search {
+    flex: 1;
+    inline-size: auto;
+  }
+}

--- a/src/main/resources/static/css/shared/fragments/media-grid.fragment.css
+++ b/src/main/resources/static/css/shared/fragments/media-grid.fragment.css
@@ -25,6 +25,10 @@
   font-weight: var(--font-weight-6);
 }
 
+.media-list[data-empty-label]:empty::after {
+  content: attr(data-empty-label);
+}
+
 /* ── Media card ── */
 .media-card {
   display: grid;
@@ -102,6 +106,10 @@
   color: var(--text-3);
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.media-card-folder .material-symbols-outlined {
+  font-size: var(--font-size-1);
 }
 
 /* Inset the outline so it is not clipped by the id row's overflow. */

--- a/src/main/resources/templates/modules/bin/bin.page.peb
+++ b/src/main/resources/templates/modules/bin/bin.page.peb
@@ -11,6 +11,9 @@
 
   <div class="main-header">
     <h2>Recently Deleted</h2>
+    <div class="main-header-actions">
+      {% include "../../shared/components/media-search.component.peb" with {"deleted": true} %}
+    </div>
   </div>
 
   <div id="media-section"

--- a/src/main/resources/templates/modules/home/fragments/library-sections.fragment.peb
+++ b/src/main/resources/templates/modules/home/fragments/library-sections.fragment.peb
@@ -1,0 +1,14 @@
+{# @pebvariable name="folderId" type="java.lang.String" #}
+<div class="section-label">Folders</div>
+<div id="folder-section"
+     hx-get="/console/fragments/folder-grid{% if folderId is not empty %}?id={{ folderId }}{% endif %}"
+     hx-trigger="load">
+  <div class="loader">Loading folders...</div>
+</div>
+
+<div class="section-label">Media</div>
+<div id="media-section"
+     hx-get="/console/fragments/media-grid{% if folderId is not empty %}?folderId={{ folderId }}{% endif %}"
+     hx-trigger="load">
+  <div class="loader">Loading media...</div>
+</div>

--- a/src/main/resources/templates/modules/home/fragments/media-search-results.fragment.peb
+++ b/src/main/resources/templates/modules/home/fragments/media-search-results.fragment.peb
@@ -1,0 +1,19 @@
+{% import "../../../shared/macros/media-card.macros.peb" %}
+
+{# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Media>" #}
+{# @pebvariable name="nextPage" type="java.lang.Integer" #}
+{# @pebvariable name="query" type="java.lang.String" #}
+{# @pebvariable name="writableByMedia" type="java.util.Map<java.lang.String, java.lang.Boolean>" #}
+{# @pebvariable name="foldersByMedia" type="java.util.Map<java.lang.String, ch.srgssr.pillarbox.backend.domain.model.Folder>" #}
+
+{% set hasMore = (nextPage * result.limit) < result.totalCount %}
+{% set nextUrl = hasMore ? "/console/fragments/media-search?page=" + nextPage + "&pageSize=" + result.limit + "&q=" + (query | urlencode) : null %}
+
+<div class="search-results">
+  <div class="section-label">Results for &ldquo;{{ query }}&rdquo; ({{ result.totalCount }})</div>
+  <section class="media-list" data-empty-label="No media found for &quot;{{ query }}&quot;">
+  {%- for item in result.items -%}
+    {{ mediaCard(item, loop.last ? nextUrl : null, not writableByMedia[item.id], foldersByMedia[item.id].id, foldersByMedia[item.id].name) }}
+  {%- endfor -%}
+  </section>
+</div>

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -15,6 +15,11 @@
   <div class="main-header">
     <h2>{{ folder.name | default("Media Library") }}</h2>
     <div class="main-header-actions">
+      {% include "../../shared/components/media-search.component.peb" with {
+        "url": "/console/fragments/media-search",
+        "target": "#library-content",
+        "folderId": folder.id
+      } %}
       <a class="btn" href="/console/bin">
         <span class="material-symbols-outlined">delete</span>
         Recently Deleted
@@ -72,18 +77,8 @@
     </div>
   </div>
 
-  <div class="section-label">Folders</div>
-  <div id="folder-section"
-       hx-get="/console/fragments/folder-grid?{% if folder is not empty %}&id={{ folder.id }}{% endif %}"
-       hx-trigger="load">
-    <div class="loader">Loading folders...</div>
-  </div>
-
-  <div class="section-label">Media</div>
-  <div id="media-section"
-       hx-get="/console/fragments/media-grid?{% if folder is not empty %}&folderId={{ folder.id }}{% endif %}"
-       hx-trigger="load">
-    <div class="loader">Loading media...</div>
+  <div id="library-content">
+    {% include "./fragments/library-sections.fragment.peb" with {"folderId": folder.id} %}
   </div>
 </main>
 {% endblock %}

--- a/src/main/resources/templates/shared/components/media-search.component.peb
+++ b/src/main/resources/templates/shared/components/media-search.component.peb
@@ -1,0 +1,16 @@
+{# @pebvariable name="url" type="java.lang.String" #}
+{# @pebvariable name="target" type="java.lang.String" #}
+{# @pebvariable name="folderId" type="java.lang.String" #}
+{# @pebvariable name="deleted" type="java.lang.Boolean" #}
+<search class="field media-search">
+  <span class="material-symbols-outlined" aria-hidden="true">search</span>
+  <input type="search" name="q" placeholder="Search media…" autocomplete="off"
+         aria-label="Search media"
+         hx-get="{{ url | default('/console/fragments/media-grid') }}"
+         hx-include="closest .media-search"
+         hx-trigger="input changed delay:300ms, search"
+         hx-target="{{ target | default('#media-section') }}"
+         hx-swap="innerHTML">
+  {% if folderId is not empty %}<input type="hidden" name="folderId" value="{{ folderId }}">{% endif %}
+  {% if deleted %}<input type="hidden" name="deleted" value="true">{% endif %}
+</search>

--- a/src/main/resources/templates/shared/fragments/media-grid.fragment.peb
+++ b/src/main/resources/templates/shared/fragments/media-grid.fragment.peb
@@ -4,10 +4,12 @@
 {# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Media>" #}
 {# @pebvariable name="nextPage" type="java.lang.Integer" #}
 {# @pebvariable name="folderId" type="java.lang.String" #}
-{# @pebvariable name="canWrite" type="java.lang.Boolean" #}
+{# @pebvariable name="query" type="java.lang.String" #}
+{# @pebvariable name="writableByMedia" type="java.util.Map<java.lang.String, java.lang.Boolean>" #}
 
 {% set hasMore = (nextPage * result.limit) < result.totalCount %}
-{% set folderParam = folderId is not empty ? "&folderId=" + folderId : "" %}
-{% set nextUrl = hasMore ? "/console/fragments/media-grid?page=" + nextPage + "&pageSize=" + result.limit + "&deleted=" + deleted + folderParam : null %}
+{% set scopeParam = query is not empty ? "&q=" + (query | urlencode) : (folderId is not empty ? "&folderId=" + (folderId | urlencode) : "") %}
+{% set nextUrl = hasMore ? "/console/fragments/media-grid?page=" + nextPage + "&pageSize=" + result.limit + "&deleted=" + deleted + scopeParam : null %}
+{% set emptyLabel = query is not empty ? 'No media found for "' + query + '"' : null %}
 
-{{ mediaList(result, nextUrl, not canWrite, folderId) }}
+{{ mediaList(result, nextUrl, writableByMedia, folderId, emptyLabel) }}

--- a/src/main/resources/templates/shared/macros/media-card.macros.peb
+++ b/src/main/resources/templates/shared/macros/media-card.macros.peb
@@ -1,8 +1,9 @@
-{% macro mediaCard(media, nextUrl = null, readOnly = false, folderId = null) %}
+{% macro mediaCard(media, nextUrl = null, readOnly = false, folderId = null, folderName = null) %}
 {# @pebvariable name="nextUrl" type="java.lang.String" #}
 {# @pebvariable name="media" type="ch.srgssr.pillarbox.backend.domain.model.Media" #}
 {# @pebvariable name="readOnly" type="java.lang.Boolean" #}
 {# @pebvariable name="folderId" type="java.lang.String" #}
+{# @pebvariable name="folderName" type="java.lang.String" #}
 <article class="media-card" id="media-card-{{ media.id }}"
     {% if not readOnly %}draggable="true" data-media-id="{{ media.id }}"{% endif %}
     {% if nextUrl is not empty %}
@@ -19,6 +20,12 @@
   </figure>
 
   <header>
+    {% if folderName is not empty %}
+    <p class="media-card-folder">
+      <span class="material-symbols-outlined" aria-hidden="true">folder</span>
+      {{ folderName }}
+    </p>
+    {% endif %}
     <h3>{{ media.metadata.title | default('Untitled Asset') }}</h3>
     <p>
       {% if not media.deleted %}
@@ -92,13 +99,14 @@
 </article>
 {% endmacro %}
 
-{% macro mediaList(result, nextUrl = null, readOnly = false, folderId = null) %}
+{% macro mediaList(result, nextUrl = null, writableByMedia = null, folderId = null, emptyLabel = null) %}
 {# @pebvariable name="result" type="ch.srgssr.pillarbox.backend.db.PaginatedResult<ch.srgssr.pillarbox.backend.domain.model.Media>" #}
-{# @pebvariable name="readOnly" type="java.lang.Boolean" #}
+{# @pebvariable name="writableByMedia" type="java.util.Map<java.lang.String, java.lang.Boolean>" #}
 {# @pebvariable name="folderId" type="java.lang.String" #}
-<section class="media-list">
+{# @pebvariable name="emptyLabel" type="java.lang.String" #}
+<section class="media-list"{% if emptyLabel is not empty %} data-empty-label="{{ emptyLabel }}"{% endif %}>
 {%- for item in result.items -%}
-  {{ mediaCard(item, loop.last ? nextUrl : null, readOnly, folderId) }}
+  {{ mediaCard(item, loop.last ? nextUrl : null, not writableByMedia[item.id], folderId) }}
 {%- endfor -%}
 </section>
 {% endmacro %}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaApiSearchTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaApiSearchTest.kt
@@ -1,0 +1,81 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.api
+
+import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.PlayerMediaResponseV1
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.toMediaRequestV1
+import ch.srgssr.pillarbox.backend.test.token
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.testing.ApplicationTestBuilder
+
+class MediaApiSearchTest :
+  ShouldSpec({
+
+    fun media(title: String) = mediaFixture { metadata = MediaMetadata(title = title) }
+
+    suspend fun ApplicationTestBuilder.create(media: Media) =
+      client.post("/v1/media") {
+        bearerAuth(token)
+        contentType(ContentType.Application.Json)
+        setBody(media.toMediaRequestV1())
+      } shouldHaveStatus HttpStatusCode.Created
+
+    should("filter the management media list by the q parameter") {
+      testApplicationContext {
+        val alps = media("Sunrise over the Alps")
+        create(alps)
+        create(media("City nightlife"))
+
+        val results =
+          client
+            .get("/v1/media?q=alps") { bearerAuth(token) }
+            .body<List<MediaResponseV1>>()
+
+        results.map { it.id } shouldBe listOf(alps.id)
+      }
+    }
+
+    should("filter the public player media list by the q parameter") {
+      testApplicationContext {
+        val alps = media("Sunrise over the Alps")
+        create(alps)
+        create(media("City nightlife"))
+
+        val results =
+          client
+            .get("/v1/player/media?q=alps")
+            .body<List<PlayerMediaResponseV1>>()
+
+        results.map { it.identifier } shouldBe listOf(alps.id)
+      }
+    }
+
+    should("exclude soft-deleted media from public player search") {
+      testApplicationContext {
+        val gone = media("Glacier descent")
+        create(gone)
+        client.delete("/v1/media/${gone.id}") { bearerAuth(token) } shouldHaveStatus HttpStatusCode.NoContent
+
+        val results =
+          client
+            .get("/v1/player/media?q=glacier")
+            .body<List<PlayerMediaResponseV1>>()
+
+        results.map { it.identifier } shouldBe emptyList()
+      }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaSearchConsoleTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaSearchConsoleTest.kt
@@ -1,0 +1,191 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderPermissionRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
+import ch.srgssr.pillarbox.backend.test.count
+import ch.srgssr.pillarbox.backend.test.hxDelete
+import ch.srgssr.pillarbox.backend.test.hxGet
+import ch.srgssr.pillarbox.backend.test.hxPost
+import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.mediaFixture
+import ch.srgssr.pillarbox.backend.test.seedUser
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.tokenWithRoles
+import ch.srgssr.pillarbox.backend.test.userFixture
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import org.jsoup.Jsoup
+
+class MediaSearchConsoleTest :
+  ShouldSpec({
+
+    fun media(
+      title: String,
+      tags: List<String> = emptyList(),
+    ) = mediaFixture {
+      metadata = MediaMetadata(title = title)
+    }.copy(tags = tags)
+
+    suspend fun HttpClient.createMedia(media: Media) =
+      hxPost("${Navigation.CONSOLE}/actions/media") {
+        contentType(ContentType.Application.Json)
+        setBody(media)
+      }
+
+    should("return only the media matching the query") {
+      testApplicationContext {
+        login()
+
+        val alps = media("Sunrise over the Alps")
+        val city = media("City nightlife")
+        client.createMedia(alps)
+        client.createMedia(city)
+
+        val doc =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=alps").bodyAsText())
+
+        doc.count(".media-card") shouldBe 1
+        doc.select("#media-card-${alps.id}").size shouldBe 1
+        doc.select("#media-card-${city.id}").size shouldBe 0
+      }
+    }
+
+    should("render write actions for media the user may write") {
+      testApplicationContext {
+        login()
+
+        val glacier = media("Glacier hike")
+        client.createMedia(glacier)
+
+        val doc =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=glacier").bodyAsText())
+
+        doc.select("#media-card-${glacier.id} footer.actions").size shouldBe 1
+      }
+    }
+
+    should("hide write actions for matching media the user cannot write") {
+      testApplicationContext {
+        login()
+
+        val glacier = media("Glacier descent")
+        client.createMedia(glacier)
+
+        val folder =
+          client
+            .post("/v1/folder") {
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Locked"))
+            }.body<FolderResponseV1>()
+        client.post("/v1/folder/${folder.id}/media") {
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = glacier.id))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        seedUser(userFixture(oidcSub = "someone-else"))
+        client.post("/v1/folder/${folder.id}/permission") {
+          bearerAuth(tokenWithRoles(setOf(Role.ADMIN)))
+          contentType(ContentType.Application.Json)
+          setBody(FolderPermissionRequestV1(oidcSub = "someone-else"))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val doc =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=glacier").bodyAsText())
+
+        doc.count(".media-card") shouldBe 1
+        doc.select("#media-card-${glacier.id} footer.actions").size shouldBe 0
+      }
+    }
+
+    should("label each result with its folder and point its actions at it") {
+      testApplicationContext {
+        login()
+
+        val glacier = media("Glacier hike")
+        client.createMedia(glacier)
+
+        val folder =
+          client
+            .post("/v1/folder") {
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Documentaries"))
+            }.body<FolderResponseV1>()
+        client.post("/v1/folder/${folder.id}/media") {
+          contentType(ContentType.Application.Json)
+          setBody(AssignMediaRequestV1(mediaId = glacier.id))
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val doc =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=glacier").bodyAsText())
+
+        val card = doc.select("#media-card-${glacier.id}")
+        card.select(".media-card-folder").text() shouldBe "folder Documentaries"
+        card
+          .select("a[href^='/console/editor/${glacier.id}?folderId=']")
+          .attr("href") shouldBe "/console/editor/${glacier.id}?folderId=${folder.id}"
+      }
+    }
+
+    should("restore the library sections when the query is cleared") {
+      testApplicationContext {
+        login()
+
+        val doc =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=").bodyAsText())
+
+        doc.select("#folder-section").size shouldBe 1
+        doc.select("#media-section").size shouldBe 1
+        doc.count(".search-results") shouldBe 0
+      }
+    }
+
+    should("show a search-specific empty state when nothing matches") {
+      testApplicationContext {
+        login()
+
+        client.createMedia(media("Sunrise over the Alps"))
+
+        val doc =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=nonexistent").bodyAsText())
+
+        doc.count(".media-card") shouldBe 0
+        doc.select(".media-list[data-empty-label]").size shouldBe 1
+      }
+    }
+
+    should("find soft-deleted media when searching the bin") {
+      testApplicationContext {
+        login()
+
+        val glacier = media("Glacier hike")
+        client.createMedia(glacier)
+        client.hxDelete("${Navigation.CONSOLE}/actions/media/${glacier.id}") shouldHaveStatus HttpStatusCode.OK
+
+        val active =
+          Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-search?q=glacier").bodyAsText())
+        active.select("#media-card-${glacier.id}").size shouldBe 0
+
+        val bin =
+          Jsoup.parse(
+            client.hxGet("${Navigation.CONSOLE}/fragments/media-grid?q=glacier&deleted=true").bodyAsText(),
+          )
+        bin.select("#media-card-${glacier.id}").size shouldBe 1
+      }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepositoryTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepositoryTest.kt
@@ -1,0 +1,145 @@
+package ch.srgssr.pillarbox.backend.persistence.media
+
+import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.test.MediaLibrary
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import ch.srgssr.pillarbox.backend.test.testDb
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.jetbrains.exposed.v1.core.eq
+
+private fun media(
+  id: String,
+  title: String? = null,
+  subtitle: String? = null,
+  description: String? = null,
+  tags: List<String> = emptyList(),
+  deleted: Boolean = false,
+) = Media(
+  id = id,
+  tags = tags,
+  sources = listOf(MediaLibrary.Dash),
+  metadata = MediaMetadata(title = title, subtitle = subtitle, description = description),
+  deleted = deleted,
+)
+
+class MediaRepositoryTest :
+  ShouldSpec({
+    val repository = MediaRepository(testDb)
+
+    should("match media by title") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "alps", title = "Sunrise over the Alps"))
+        repository.save(media(id = "city", title = "City nightlife"))
+
+        repository.search("alps").items.map { it.id } shouldContainExactly listOf("alps")
+      }
+    }
+
+    should("match media by tag, subtitle, and description") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "tagged", title = "Untitled", tags = listOf("documentary", "nature")))
+        repository.save(media(id = "subtitled", title = "Untitled", subtitle = "A wildlife journey"))
+        repository.save(media(id = "described", title = "Untitled", description = "Filmed across the savannah"))
+
+        repository.search("documentary").items.map { it.id } shouldContainExactly listOf("tagged")
+        repository.search("wildlife").items.map { it.id } shouldContainExactly listOf("subtitled")
+        repository.search("savannah").items.map { it.id } shouldContainExactly listOf("described")
+      }
+    }
+
+    should("match partial words as a prefix for search-as-you-type") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "glacier", title = "Glacier hike"))
+        repository.save(media(id = "city", title = "City nightlife"))
+
+        repository.search("glac").items.map { it.id } shouldContainExactly listOf("glacier")
+        repository.search("glacier hi").items.map { it.id } shouldContainExactly listOf("glacier")
+      }
+    }
+
+    should("match media by identifier") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "special-promo", title = "Untitled"))
+        repository.save(media(id = "regular", title = "Untitled"))
+
+        repository.search("promo").items.map { it.id } shouldContainExactly listOf("special-promo")
+      }
+    }
+
+    should("rank a title match above a description-only match") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "in-description", title = "Something else", description = "A story about whales"))
+        repository.save(media(id = "in-title", title = "Whales of the deep"))
+
+        repository.search("whales").items.map { it.id } shouldContainExactly listOf("in-title", "in-description")
+      }
+    }
+
+    should("require all terms of a multi-word query to match, across fields") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "both", title = "Mountain trails", description = "alpine routes"))
+        repository.save(media(id = "one", title = "Mountain bikes"))
+
+        // Terms are AND-ed: only the item carrying both matches.
+        repository.search("mountain alpine").items.map { it.id } shouldContainExactly listOf("both")
+        repository.search("mountain").items.map { it.id } shouldContainExactlyInAnyOrder listOf("both", "one")
+      }
+    }
+
+    should("scope search with an additional filter") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "live", title = "Glacier hike"))
+        repository.save(media(id = "binned", title = "Glacier descent", deleted = true))
+
+        repository.search("glacier").items.map { it.id } shouldContainExactlyInAnyOrder listOf("live", "binned")
+        repository
+          .search("glacier", filter = { MediaTable.deleted eq false })
+          .items
+          .map { it.id } shouldContainExactly listOf("live")
+      }
+    }
+
+    should("report the total count independently of the page size") {
+      testApplicationContext {
+        startApplication()
+        repeat(3) { repository.save(media(id = "doc-$it", title = "Documentary $it")) }
+
+        val page = repository.search("documentary", limit = 2)
+        page.items shouldHaveSize 2
+        page.totalCount shouldBe 3
+      }
+    }
+
+    should("return an empty result for a blank query") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "any", title = "Anything"))
+
+        val result = repository.search("   ")
+        result.items.shouldBeEmpty()
+        result.totalCount shouldBe 0
+      }
+    }
+
+    should("return an empty result when nothing matches") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "any", title = "Anything"))
+
+        repository.search("nonexistentterm").items.shouldBeEmpty()
+      }
+    }
+  })


### PR DESCRIPTION
## Description

Resolves #28 by letting users find media by title, id, tags and description in addition of browsing folders. In the console a search box in the library header swaps the folder and media sections for cross-folder results ranked by relevance, clearing the query restores the library.

The management and player APIs gain the same search through an optional `q` parameter.

## Changes Made

- Add a Postgres `tsvector` column, generated and indexed over a weighted mix of title, id, tags, subtitle and description, and query it with prefix terms so results narrow as the user types.
- Introduce a reusable `SearchableRepository`/`FullTextSearch` pair that render the `to_tsquery`/`ts_rank` fragments and tokenise input into an injection-safe prefix query.
- Order results by relevance with an id tie-breaker.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
