### PR TITLE
feat(console): import media from the integration layer by urn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,11 @@ AUTH_CLIENT_SECRET=
 # Comma-separated OIDC scopes.
 AUTH_SCOPES=openid,profile,email
 
+# --- Integration Layer Configuration ---
+
+# The base URL of the SRG SSR Integration Layer, used to import media by URN.
+INTEGRATION_LAYER_BASE_URL=https://il.srgssr.ch
+
 # --- Session Configuration ---
 
 # The secret key used to sign the session cookie.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,6 +23,7 @@ by folder write access (see [Folder permissions](#folder-permissions)).
 | **GET**    | `/console/bin`                                 | Page     | Renders the bin (recently deleted media).                                                 |
 | **GET**    | `/console/editor/{id?}`                        | Page     | Opens the media editor (empty for new, populated for an existing id). Accepts `folderId`. |
 | **GET**    | `/console/editor/{id}/duplicate`               | Page     | Opens the editor pre-filled from an existing id (id cleared) for duplication.             |
+| **GET**    | `/console/editor/import`                       | Page     | Opens the editor pre-filled with data imported from the Integration Layer. Requires `urn`, accepts `folderId`; answers `502` when the URN cannot be resolved. |
 | **GET**    | `/console/fragments/media-grid`                | Fragment | Paginated media grid. Accepts `page`, `pageSize`, `folderId`, and `deleted`.              |
 | **GET**    | `/console/fragments/folder-grid`               | Fragment | Grid of subfolders. Accepts `id` (parent folder, omitted for root).                       |
 | **GET**    | `/console/fragments/folder-picker`             | Fragment | Folder picker dialog for moving a media item. Accepts `mediaId` and `folderId`.           |

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -13,6 +13,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.api.team
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.user
 import ch.srgssr.pillarbox.backend.entrypoint.web.console.console
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.PillarboxPebbleExtension
+import ch.srgssr.pillarbox.backend.integrationlayer.integrationLayerModule
 import ch.srgssr.pillarbox.backend.io.httpClientModule
 import ch.srgssr.pillarbox.backend.io.jsonModule
 import ch.srgssr.pillarbox.backend.ktor.plugins.configureDevelopmentDefaults
@@ -71,6 +72,7 @@ fun Application.module() {
       persistenceModule(),
       jsonModule(),
       httpClientModule(),
+      integrationLayerModule(),
       authenticationModule(),
       authzModule(),
     )
@@ -98,7 +100,7 @@ fun Application.module() {
     folder(get(), get(), get(), get(), get())
     user(get(), get())
     team(get(), get())
-    console(get(), get(), get(), get(), get())
+    console(get(), get(), get(), get(), get(), get())
     playerMedia(get(), get())
   }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/WriteAccess.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/authz/WriteAccess.kt
@@ -15,6 +15,40 @@ val ApplicationCall.permissionChecker: PermissionChecker
   get() = application.get()
 
 /**
+ * Whether the authenticated user may write the media identified by [mediaId],
+ * otherwise responds [HttpStatusCode.Forbidden] and returns false.
+ *
+ * A `null` id means there is no existing media to protect (e.g. creating a new item).
+ *
+ * @param mediaId The media to protect, or `null` when there is nothing to check.
+ * @return true if the user has write permission to the given media, false otherwise.
+ */
+suspend fun RoutingContext.requireMediaWrite(mediaId: String?): Boolean =
+  if (mediaId == null || call.permissionChecker.canWriteMedia(call.user, mediaId)) {
+    true
+  } else {
+    call.respond(HttpStatusCode.Forbidden)
+    false
+  }
+
+/**
+ * Whether authenticated user may write every one of the given [folderIds],
+ * otherwise responds [HttpStatusCode.Forbidden] and returns false.
+ *
+ * A `null` id denotes the unrestricted root scope.
+ *
+ * @param folderIds The folders that must be writable; pass several to require write access to all.
+ * @return true if the user has write permission to all the given folders, false otherwise.
+ */
+suspend fun RoutingContext.requireFolderWrite(vararg folderIds: String?): Boolean =
+  if (folderIds.all { call.permissionChecker.canWriteFolder(call.user, it) }) {
+    true
+  } else {
+    call.respond(HttpStatusCode.Forbidden)
+    false
+  }
+
+/**
  * Runs [block] only if the authenticated user may write every one of the given [folderIds],
  * otherwise responds [HttpStatusCode.Forbidden] and skips it.
  *
@@ -23,15 +57,11 @@ val ApplicationCall.permissionChecker: PermissionChecker
  * @param folderIds The folders that must be writable; pass several to require write access to all.
  * @param block The work to perform when access is granted.
  */
-suspend fun RoutingContext.withFolderWrite(
+suspend inline fun RoutingContext.withFolderWrite(
   vararg folderIds: String?,
   block: suspend () -> Unit,
 ) {
-  if (folderIds.all { call.permissionChecker.canWriteFolder(call.user, it) }) {
-    block()
-  } else {
-    call.respond(HttpStatusCode.Forbidden)
-  }
+  if (requireFolderWrite(*folderIds)) block()
 }
 
 /**
@@ -44,13 +74,9 @@ suspend fun RoutingContext.withFolderWrite(
  * @param mediaId The media to protect, or `null` when there is nothing to check.
  * @param block The work to perform when access is granted.
  */
-suspend fun RoutingContext.withMediaWrite(
+suspend inline fun RoutingContext.withMediaWrite(
   mediaId: String?,
   block: suspend () -> Unit,
 ) {
-  if (mediaId == null || call.permissionChecker.canWriteMedia(call.user, mediaId)) {
-    block()
-  } else {
-    call.respond(HttpStatusCode.Forbidden)
-  }
+  if (requireMediaWrite(mediaId)) block()
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/ConsoleRoute.kt
@@ -2,6 +2,7 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.console
 
 import ch.srgssr.pillarbox.backend.auth.AuthenticatedUserPlugin
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.integrationlayer.IntegrationLayerClient
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
@@ -20,6 +21,7 @@ import io.ktor.server.routing.route
  * @param folderPermissionRepository Repository used to read and manage folder grants.
  * @param userRepository Repository used to resolve and search users for grants.
  * @param teamRepository Repository used to resolve and search teams for grants.
+ * @param integrationLayerClient Client used to import media metadata by URN.
  */
 fun Route.console(
   mediaRepository: MediaRepository,
@@ -27,6 +29,7 @@ fun Route.console(
   folderPermissionRepository: FolderPermissionRepository,
   userRepository: UserRepository,
   teamRepository: TeamRepository,
+  integrationLayerClient: IntegrationLayerClient,
 ) {
   authenticate("pillarbox-session") {
     install(AuthenticatedUserPlugin)
@@ -35,7 +38,7 @@ fun Route.console(
 
     route(Navigation.CONSOLE) {
       homePage(mediaRepository, folderRepository, folderPermissionRepository, userRepository, teamRepository)
-      editorPage(mediaRepository, folderRepository)
+      editorPage(mediaRepository, folderRepository, integrationLayerClient)
       usersPage(userRepository)
       teamsPage(teamRepository, userRepository)
     }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/EditorRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/EditorRoute.kt
@@ -3,8 +3,11 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.console
 import ch.srgssr.pillarbox.backend.auth.withRole
 import ch.srgssr.pillarbox.backend.authz.withFolderWrite
 import ch.srgssr.pillarbox.backend.authz.withMediaWrite
+import ch.srgssr.pillarbox.backend.domain.model.Folder
 import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.Role
+import ch.srgssr.pillarbox.backend.integrationlayer.IntegrationLayerClient
+import ch.srgssr.pillarbox.backend.integrationlayer.toMedia
 import ch.srgssr.pillarbox.backend.log.debug
 import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
@@ -16,6 +19,7 @@ import io.ktor.server.htmx.hx
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.util.getOrFail
@@ -30,31 +34,23 @@ private val logger = ConsoleEditorRoute.logger()
  *
  * @param mediaRepository Repository used to look up and persist media items.
  * @param folderRepository Repository used to look up folders and assign media to them.
+ * @param integrationLayerClient Client used to import media metadata by URN.
  */
 @OptIn(ExperimentalKtorApi::class)
 @SuppressWarnings("LongMethod", "CyclomaticComplexMethod")
 fun Route.editorPage(
   mediaRepository: MediaRepository,
   folderRepository: FolderRepository,
+  integrationLayerClient: IntegrationLayerClient,
 ) {
   withRole(Role.WRITE) {
     get("editor/{id?}") {
       val mediaId = call.parameters["id"]
-      val folder = call.queryParameters["folderId"]?.takeIf { it.isNotBlank() }?.let { folderRepository.find(it) }
+      val folder = folderParam(folderRepository)
 
       val renderEditor: suspend () -> Unit = {
         val media = mediaId?.let { mediaRepository.find(it) }?.also { logger.debug { "Opening editor for media: $it" } }
-        call.respondWithContext(
-          "modules/editor/editor.page.peb",
-          buildMap {
-            media?.let { put("item", media) }
-            folder?.let {
-              put("folderId", it.id)
-              put("folder", it)
-              put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
-            }
-          },
-        )
+        respondEditor(folderRepository, media, exists = media != null, folder = folder)
       }
 
       // Editing targets the media's folder; creating new media targets the destination folder.
@@ -72,21 +68,32 @@ fun Route.editorPage(
           .find(id)
           ?.also { logger.debug { "Opening editor with duplicate data from original ID: $id" } }
           ?: return@get call.respond(HttpStatusCode.NotFound)
-      val folder = call.queryParameters["folderId"]?.takeIf { it.isNotBlank() }?.let { folderRepository.find(it) }
+      val folder = folderParam(folderRepository)
 
       // Duplicating creates a new media in the destination folder.
       withFolderWrite(folder?.id) {
-        call.respondWithContext(
-          "modules/editor/editor.page.peb",
-          buildMap {
-            put("item", media.copy(id = ""))
-            folder?.let {
-              put("folderId", it.id)
-              put("folder", it)
-              put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
-            }
-          },
-        )
+        respondEditor(folderRepository, media.copy(id = ""), exists = false, folder = folder)
+      }
+    }
+
+    get("editor/import") {
+      val urn =
+        call.queryParameters["urn"]?.takeIf { it.isNotBlank() } ?: return@get call.respond(HttpStatusCode.BadRequest)
+
+      // Overwriting an existing media is governed by its folder; the destination folder gates the import.
+      val mediaFolder = folderRepository.findFolderOf(urn)
+      val folder = folderParam(folderRepository) ?: mediaFolder
+
+      withFolderWrite(*setOf(mediaFolder?.id, folder?.id).toTypedArray()) {
+        val media =
+          runCatching { integrationLayerClient.findMediaComposition(urn) }
+            .onFailure { logger.info { "Failed to fetch media composition for URN $urn: ${it.message}" } }
+            .getOrNull()
+            ?.toMedia() ?: return@get call.respond(HttpStatusCode.BadGateway)
+
+        logger.debug { "Opening editor with imported data for URN: $urn" }
+
+        respondEditor(folderRepository, media, exists = mediaRepository.exists(media.id), folder = folder)
       }
     }
 
@@ -124,6 +131,43 @@ fun Route.editorPage(
       }
     }
   }
+}
+
+/**
+ * Resolves the folder referenced by the `folderId` query parameter.
+ *
+ * @param folderRepository Repository used to look up the folder.
+ * @return The folder, or null when the parameter is absent, blank, or unknown.
+ */
+private suspend fun RoutingContext.folderParam(folderRepository: FolderRepository): Folder? =
+  call.queryParameters["folderId"]?.takeIf { it.isNotBlank() }?.let { folderRepository.find(it) }
+
+/**
+ * Renders the media editor page for the given item and folder context.
+ *
+ * @param folderRepository Repository used to resolve the folder's ancestors.
+ * @param media The media item to edit, or null for a blank editor.
+ * @param exists Whether the item is already persisted, switching the editor to edit mode.
+ * @param folder The folder the editor operates in, or null for the root scope.
+ */
+private suspend fun RoutingContext.respondEditor(
+  folderRepository: FolderRepository,
+  media: Media?,
+  exists: Boolean,
+  folder: Folder?,
+) {
+  call.respondWithContext(
+    "modules/editor/editor.page.peb",
+    buildMap {
+      media?.let { put("item", it) }
+      put("exists", exists)
+      folder?.let {
+        put("folderId", it.id)
+        put("folder", it)
+        put("ancestors", folderRepository.findAncestors(it.id).dropLast(1))
+      }
+    },
+  )
 }
 
 /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClient.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClient.kt
@@ -1,0 +1,34 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.appendPathSegments
+import io.ktor.http.isSuccess
+
+/**
+ * Client for the SRG SSR Integration Layer public API.
+ *
+ * @property httpClient The shared HTTP client used to perform requests.
+ * @property config Connection parameters for the Integration Layer.
+ */
+class IntegrationLayerClient(
+  private val httpClient: HttpClient,
+  private val config: IntegrationLayerConfig,
+) {
+  /**
+   * Fetches the media composition identified by the given URN.
+   *
+   * @param urn The URN of the media (e.g., `urn:rts:video:3608506`).
+   *
+   * @return The decoded composition, or null when the URN is not found.
+   */
+  suspend fun findMediaComposition(urn: String): MediaComposition? {
+    val response =
+      httpClient.get(config.baseUrl) {
+        url.appendPathSegments(listOf("integrationlayer", "2.0", "mediaComposition", "byUrn", urn), encodeSlash = true)
+      }
+
+    return if (response.status.isSuccess()) response.body() else null
+  }
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerConfig.kt
@@ -1,0 +1,22 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import io.ktor.server.config.ApplicationConfig
+
+/**
+ * Configuration parameters for the SRG SSR Integration Layer client.
+ *
+ * @property baseUrl The base URL of the Integration Layer service.
+ */
+data class IntegrationLayerConfig(
+  val baseUrl: String,
+)
+
+/**
+ * Extracts [IntegrationLayerConfig] from the application's configuration file.
+ *
+ * @return A populated [IntegrationLayerConfig] instance.
+ */
+fun ApplicationConfig.toIntegrationLayerConfig(): IntegrationLayerConfig =
+  IntegrationLayerConfig(
+    baseUrl = property("integrationLayer.baseUrl").getString(),
+  )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerModels.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerModels.kt
@@ -1,0 +1,150 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import kotlinx.serialization.Serializable
+
+/**
+ * The Integration Layer media composition returned for a URN lookup.
+ *
+ * Only the fields consumed by the import mapping are declared; the lenient
+ * JSON configuration ignores the rest of the payload.
+ *
+ * @property chapterUrn The URN of the requested (main) chapter.
+ * @property episode The episode the media belongs to, if any.
+ * @property show The show the media belongs to, if any.
+ * @property chapterList The physical chapters carrying the playable resources.
+ */
+@Serializable
+data class MediaComposition(
+  val chapterUrn: String,
+  val episode: Episode? = null,
+  val show: Show? = null,
+  val chapterList: List<CompositionChapter> = emptyList(),
+) {
+  /**
+   * The chapter matching [chapterUrn], falling back to the first chapter.
+   *
+   * @return The main chapter, or null when the composition has no chapters.
+   */
+  val mainChapter: CompositionChapter?
+    get() = chapterList.firstOrNull { it.urn == chapterUrn } ?: chapterList.firstOrNull()
+}
+
+/**
+ * A physical media chapter with its descriptive fields and stream resources.
+ *
+ * @property urn The unique URN of the chapter.
+ * @property title The display title of the chapter.
+ * @property lead A short teaser text.
+ * @property description A detailed description of the content.
+ * @property imageUrl URL to an image representing the chapter.
+ * @property mediaType The kind of media, either `VIDEO` or `AUDIO`.
+ * @property subtitleList The external subtitle tracks available for the chapter.
+ * @property resourceList The playable stream resources, best variants first.
+ * @property segmentList The logical segments contained in the chapter.
+ */
+@Serializable
+data class CompositionChapter(
+  val urn: String,
+  val title: String,
+  val lead: String? = null,
+  val description: String? = null,
+  val imageUrl: String? = null,
+  val mediaType: String? = null,
+  val subtitleList: List<Subtitle> = emptyList(),
+  val resourceList: List<Resource> = emptyList(),
+  val segmentList: List<Segment> = emptyList(),
+)
+
+/**
+ * A logical segment within a chapter, delimited by mark-in/mark-out positions.
+ *
+ * @property urn The unique URN of the segment.
+ * @property title The display title of the segment.
+ * @property imageUrl URL to an image representing the segment.
+ * @property markIn The start position in milliseconds.
+ * @property markOut The end position in milliseconds.
+ */
+@Serializable
+data class Segment(
+  val urn: String,
+  val title: String,
+  val imageUrl: String? = null,
+  val markIn: Long? = null,
+  val markOut: Long? = null,
+)
+
+/**
+ * A playable stream resource of a chapter.
+ *
+ * @property url The URL of the media stream.
+ * @property streaming The streaming method (e.g., `HLS`, `DASH`, `PROGRESSIVE`).
+ * @property mimeType The MIME type of the content.
+ * @property quality The stream quality (e.g., `SD`, `HD`).
+ * @property dvr Whether the stream supports DVR (time-shift).
+ * @property live Whether the stream is a live broadcast.
+ * @property drmList The DRM systems protecting the stream, empty when clear.
+ */
+@Serializable
+data class Resource(
+  val url: String,
+  val streaming: String? = null,
+  val mimeType: String? = null,
+  val quality: String? = null,
+  val dvr: Boolean = false,
+  val live: Boolean = false,
+  val drmList: List<Drm> = emptyList(),
+)
+
+/**
+ * A DRM system entry protecting a stream resource.
+ *
+ * @property type The DRM system (`FAIRPLAY`, `WIDEVINE`, or `PLAYREADY`).
+ * @property licenseUrl The URL of the license server.
+ * @property certificateUrl The URL of the certificate, used by FairPlay.
+ */
+@Serializable
+data class Drm(
+  val type: String,
+  val licenseUrl: String,
+  val certificateUrl: String? = null,
+)
+
+/**
+ * An external subtitle track of a chapter.
+ *
+ * @property url The URL of the subtitle file.
+ * @property format The file format (e.g., `VTT`, `TTML`).
+ * @property locale The BCP 47 language code of the track.
+ * @property language The human-readable language name.
+ * @property type The track purpose (e.g., `SDH` for hard-of-hearing captions).
+ */
+@Serializable
+data class Subtitle(
+  val url: String,
+  val format: String? = null,
+  val locale: String? = null,
+  val language: String? = null,
+  val type: String? = null,
+)
+
+/**
+ * The episode a media belongs to.
+ *
+ * @property seasonNumber The season index if part of a series.
+ * @property number The episode index within the season.
+ */
+@Serializable
+data class Episode(
+  val seasonNumber: Int? = null,
+  val number: Int? = null,
+)
+
+/**
+ * The show a media belongs to.
+ *
+ * @property title The display title of the show.
+ */
+@Serializable
+data class Show(
+  val title: String? = null,
+)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerModule.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerModule.kt
@@ -1,0 +1,18 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import io.ktor.server.config.ApplicationConfig
+import org.koin.dsl.module
+
+/**
+ * Defines the Koin module for the Integration Layer integration.
+ *
+ * Provides the [IntegrationLayerConfig] extracted from the application
+ * configuration and an [IntegrationLayerClient] backed by the shared HTTP client.
+ *
+ * @return A Koin module containing the Integration Layer definitions.
+ */
+fun integrationLayerModule() =
+  module {
+    single { get<ApplicationConfig>().toIntegrationLayerConfig() }
+    single { IntegrationLayerClient(httpClient = get(), config = get()) }
+  }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapper.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapper.kt
@@ -1,0 +1,110 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import ch.srgssr.pillarbox.backend.domain.model.Chapter
+import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
+import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.domain.model.MediaSource
+import ch.srgssr.pillarbox.backend.domain.model.SubtitleTrack
+
+private val supportedStreamings = listOf("HLS", "DASH", "PROGRESSIVE")
+
+private val drmKeySystems =
+  mapOf(
+    "FAIRPLAY" to "com.apple.fps",
+    "WIDEVINE" to "com.widevine.alpha",
+    "PLAYREADY" to "com.microsoft.playready",
+  )
+
+/**
+ * Converts an Integration Layer media composition into a [Media] item.
+ *
+ * Maps the main chapter's metadata, one source per supported streaming
+ * method (preferring DVR and HD variants), DRM configurations, segments
+ * as chapters, and VTT subtitle tracks.
+ *
+ * @return The mapped media, or null when the composition has no chapter.
+ */
+fun MediaComposition.toMedia(): Media? {
+  val chapter = mainChapter ?: return null
+
+  return Media(
+    id = chapter.urn,
+    sources = chapter.toSources(),
+    metadata =
+      MediaMetadata(
+        title = chapter.title,
+        subtitle = show?.title,
+        description = chapter.description?.takeIf { it.isNotBlank() } ?: chapter.lead,
+        posterUrl = chapter.imageUrl,
+        seasonNumber = episode?.seasonNumber,
+        episodeNumber = episode?.number,
+        subtitles = chapter.toSubtitleTracks().ifEmpty { null },
+        chapters = chapter.toChapters().ifEmpty { null },
+      ),
+  )
+}
+
+private fun CompositionChapter.toSources(): List<MediaSource> =
+  supportedStreamings.mapNotNull { streaming ->
+    resourceList
+      .filter { it.streaming == streaming }
+      .maxWithOrNull(compareBy({ it.dvr }, { it.quality == "HD" }))
+      ?.toMediaSource(mediaType)
+  }
+
+private fun Resource.toMediaSource(mediaType: String?): MediaSource =
+  MediaSource(
+    url = url,
+    type =
+      when {
+        live && dvr -> "DVR"
+        live -> "LIVE"
+        else -> "ON-DEMAND"
+      },
+    mimeType = mimeType ?: defaultMimeType(mediaType),
+    drmConfigs = drmList.mapNotNull { it.toDrmConfig() },
+  )
+
+private fun Resource.defaultMimeType(mediaType: String?): String? =
+  when (streaming) {
+    "HLS" -> "application/x-mpegURL"
+    "DASH" -> "application/dash+xml"
+    "PROGRESSIVE" -> if (mediaType == "AUDIO") "audio/mp4" else "video/mp4"
+    else -> null
+  }
+
+private fun Drm.toDrmConfig(): DrmConfig? =
+  drmKeySystems[type]?.let { keySystem ->
+    DrmConfig(
+      keySystem = keySystem,
+      licenseUrl = licenseUrl,
+      certificateUrl = certificateUrl,
+    )
+  }
+
+private fun CompositionChapter.toChapters(): List<Chapter> =
+  segmentList
+    .filter { it.urn != urn }
+    .mapNotNull { segment ->
+      Chapter(
+        identifier = segment.urn,
+        title = segment.title,
+        posterUrl = segment.imageUrl,
+        startTime = segment.markIn ?: return@mapNotNull null,
+        endTime = segment.markOut ?: return@mapNotNull null,
+      )
+    }
+
+private fun CompositionChapter.toSubtitleTracks(): List<SubtitleTrack> =
+  subtitleList
+    .filter { it.format == "VTT" }
+    .mapNotNull { subtitle ->
+      val locale = subtitle.locale ?: return@mapNotNull null
+      SubtitleTrack(
+        label = subtitle.language ?: locale,
+        kind = if (subtitle.type == "SDH") "captions" else "subtitles",
+        language = locale,
+        url = subtitle.url,
+      )
+    }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -42,6 +42,11 @@ oidc {
   scopes = ${?AUTH_SCOPES}
 }
 
+integrationLayer {
+  baseUrl = "https://il.srgssr.ch"
+  baseUrl = ${?INTEGRATION_LAYER_BASE_URL}
+}
+
 session {
   cookieSecret = ${?SESSION_COOKIE_SECRET}
   timeoutSeconds = 28800

--- a/src/main/resources/static/css/layouts/_dialog.css
+++ b/src/main/resources/static/css/layouts/_dialog.css
@@ -36,6 +36,18 @@ dialog[open] {
   }
 }
 
+/* Default content layout: stacked body with right-aligned actions. */
+dialog form {
+  display: grid;
+  gap: var(--size-4);
+}
+
+dialog footer {
+  display: flex;
+  gap: var(--size-2);
+  justify-content: flex-end;
+}
+
 dialog h3 {
   margin: 0;
   font-size: var(--font-size-3);

--- a/src/main/resources/static/css/modules/home/folder-picker.fragment.css
+++ b/src/main/resources/static/css/modules/home/folder-picker.fragment.css
@@ -12,12 +12,6 @@
   height: 100%;
 }
 
-.move-folder-dialog footer {
-  display: flex;
-  gap: var(--size-2);
-  justify-content: flex-end;
-}
-
 /* ── Folder picker list ── */
 .folder-picker-list {
   scrollbar-gutter: stable;

--- a/src/main/resources/static/css/modules/home/home.page.css
+++ b/src/main/resources/static/css/modules/home/home.page.css
@@ -21,18 +21,3 @@ main:has(.search-results) .main-header-actions > :not(.media-search) {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-
-/* ── New-folder / rename dialog ── */
-.new-folder-dialog form,
-.rename-folder-dialog form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-4);
-}
-
-.new-folder-dialog footer,
-.rename-folder-dialog footer {
-  display: flex;
-  gap: var(--size-2);
-  justify-content: flex-end;
-}

--- a/src/main/resources/static/css/modules/teams/teams.page.css
+++ b/src/main/resources/static/css/modules/teams/teams.page.css
@@ -18,18 +18,6 @@
   inline-size: min(92vw, 32rem);
 }
 
-.team-form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--size-4);
-}
-
-.team-form footer {
-  display: flex;
-  gap: var(--size-2);
-  justify-content: flex-end;
-}
-
 /* ── Member list ── */
 .member-list {
   display: flex;

--- a/src/main/resources/static/css/shared/components/confirm-dialog.component.css
+++ b/src/main/resources/static/css/shared/components/confirm-dialog.component.css
@@ -4,7 +4,6 @@
 }
 
 .confirm-dialog form {
-  display: grid;
   gap: var(--size-5);
 }
 
@@ -45,10 +44,8 @@
 }
 
 .confirm-dialog footer {
-  display: flex;
   flex-wrap: wrap;
   gap: var(--size-3);
-  justify-content: end;
 }
 
 @media (width <= 400px) {

--- a/src/main/resources/templates/modules/editor/editor.page.peb
+++ b/src/main/resources/templates/modules/editor/editor.page.peb
@@ -3,7 +3,8 @@
 {%  import "./media-form.macros.peb" %}
 {# @pebvariable name="item" type="ch.srgssr.pillarbox.backend.domain.model.Media" #}
 {# @pebvariable name="folderId" type="java.lang.String" #}
-{% set breadcrumb_current = item.id is empty ? "New Media" : "Edit Media" %}
+{# @pebvariable name="exists" type="java.lang.Boolean" #}
+{% set breadcrumb_current = exists ? "Edit Media" : "New Media" %}
 
 {% block head %}
 <link rel="stylesheet" href="/static/css/modules/media/editor.page.css">
@@ -18,9 +19,9 @@
 
     <header class="editor-toolbar">
       <span class="editor-title">
-        {% if item.id is empty %}New Media{% else %}{{ item.metadata.title | default(item.id) }}{% endif %}
+        {% if exists %}{{ item.metadata.title | default(item.id) }}{% else %}New Media{% endif %}
       </span>
-      <button type="submit" class="btn-primary">{{ item.id is empty ? "Publish" : "Save Changes" }}</button>
+      <button type="submit" class="btn-primary">{{ exists ? "Save Changes" : "Publish" }}</button>
     </header>
 
     <nav class="editor-tabs" role="tablist">

--- a/src/main/resources/templates/modules/home/home.page.peb
+++ b/src/main/resources/templates/modules/home/home.page.peb
@@ -72,6 +72,11 @@
           <span class="material-symbols-outlined">create_new_folder</span>
           New Folder
         </button>
+        <button class="btn dropdown-item" type="button"
+                onclick="this.closest('[popover]').hidePopover(); document.getElementById('urn-import-dialog').showModal()">
+          <span class="material-symbols-outlined">cloud_download</span>
+          Import from URN
+        </button>
       </div>
       {% endif %}
     </div>
@@ -104,6 +109,22 @@
     <input type="hidden" name="parentId" value="{{ folder.id | default('') }}">
     <footer>
       <button type="submit" class="btn btn-primary">Create Folder</button>
+    </footer>
+  </form>
+</dialog>
+<dialog closedby="any" id="urn-import-dialog" class="urn-import-dialog">
+  <form method="get" action="/console/editor/import">
+    <button type="button" class="btn-icon dialog-close" aria-label="Close" onclick="this.closest('dialog').close()">
+      <span class="material-symbols-outlined" aria-hidden="true">close</span>
+    </button>
+    <h3>Import from URN</h3>
+    <div class="field">
+      <label for="urn-import-urn">URN</label>
+      <input id="urn-import-urn" name="urn" type="text" required pattern="urn:.+" placeholder="e.g. urn:rts:video:3608506" autocomplete="off" autofocus>
+    </div>
+    <input type="hidden" name="folderId" value="{{ folder.id | default('') }}">
+    <footer>
+      <button type="submit" class="btn btn-primary">Import</button>
     </footer>
   </form>
 </dialog>

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/UrnImportRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/UrnImportRouteTest.kt
@@ -1,0 +1,181 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.console
+
+import ch.srgssr.pillarbox.backend.domain.model.Media
+import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
+import ch.srgssr.pillarbox.backend.entrypoint.web.api.Navigation
+import ch.srgssr.pillarbox.backend.test.IntegrationLayerFixtures
+import ch.srgssr.pillarbox.backend.test.get
+import ch.srgssr.pillarbox.backend.test.hxPost
+import ch.srgssr.pillarbox.backend.test.login
+import ch.srgssr.pillarbox.backend.test.testApplicationContext
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.get
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import kotlinx.coroutines.runBlocking
+import org.jsoup.Jsoup
+
+/**
+ * Runs a test application against a local stub of the Integration Layer that
+ * answers every URN lookup with the given status and body.
+ */
+private fun withStubbedIntegrationLayer(
+  status: HttpStatusCode = HttpStatusCode.OK,
+  contentType: ContentType = ContentType.Application.Json,
+  body: String = IntegrationLayerFixtures.vodComposition,
+  block: suspend ApplicationTestBuilder.() -> Unit,
+) {
+  val stub =
+    embeddedServer(Netty, port = 0) {
+      routing {
+        get("/integrationlayer/2.0/mediaComposition/byUrn/{urn}") {
+          call.respondText(body, contentType, status)
+        }
+      }
+    }.start()
+
+  try {
+    val port =
+      runBlocking {
+        stub.engine
+          .resolvedConnectors()
+          .first()
+          .port
+      }
+    testApplicationContext(configOverrides = mapOf("integrationLayer.baseUrl" to "http://localhost:$port")) {
+      block()
+    }
+  } finally {
+    stub.stop()
+  }
+}
+
+class UrnImportRouteTest :
+  ShouldSpec({
+
+    should("prefill the editor with data imported from the Integration Layer") {
+      withStubbedIntegrationLayer {
+        login()
+
+        val response = client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rsi:video:3845234")
+        response shouldHaveStatus HttpStatusCode.OK
+
+        val doc = Jsoup.parse(response.bodyAsText())
+
+        doc["input[name='id']"].first()?.attributes()["value"] shouldBe "urn:rsi:video:3845234"
+        doc["input[name='metadata.title']"].first()?.attributes()["value"] shouldBe "Telegiornale flash"
+        doc["input[name='metadata.subtitle']"].first()?.attributes()["value"] shouldBe "Telegiornale"
+        doc["input[name='sources[0].url']"].first()?.attributes()["value"] shouldBe
+          "https://rsivod.akamaized.net/out/v1/telegiornale/index.m3u8"
+        doc["input[name='metadata.chapters[0].title']"].shouldNotBeEmpty()
+        doc["input[name='metadata.subtitles[0].url']"].shouldNotBeEmpty()
+      }
+    }
+
+    should("prefill DRM configurations for protected streams") {
+      withStubbedIntegrationLayer(body = IntegrationLayerFixtures.liveDrmComposition) {
+        login()
+
+        val response = client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rts:video:3608506")
+        response shouldHaveStatus HttpStatusCode.OK
+
+        val doc = Jsoup.parse(response.bodyAsText())
+
+        doc["input[name='sources[0].type']"].first()?.attributes()["value"] shouldBe "DVR"
+        doc["input[name='sources[0].drmConfigs[0].keySystem']"].first()?.attributes()["value"] shouldBe "com.apple.fps"
+        doc["input[name='sources[1].drmConfigs[0].keySystem']"].first()?.attributes()["value"] shouldBe
+          "com.widevine.alpha"
+      }
+    }
+
+    should("return BAD_GATEWAY when the URN is not found") {
+      withStubbedIntegrationLayer(
+        status = HttpStatusCode.NotFound,
+        contentType = ContentType.parse("application/problem+json"),
+        body = """{"status":404,"title":"Not found"}""",
+      ) {
+        login()
+
+        client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rts:video:unknown") shouldHaveStatus
+          HttpStatusCode.BadGateway
+      }
+    }
+
+    should("return BAD_REQUEST when the URN parameter is missing") {
+      testApplicationContext {
+        login()
+
+        client.get("${Navigation.CONSOLE}/editor/import") shouldHaveStatus HttpStatusCode.BadRequest
+        client.get("${Navigation.CONSOLE}/editor/import?urn=") shouldHaveStatus HttpStatusCode.BadRequest
+      }
+    }
+
+    should("return 403 when authenticated with no roles") {
+      testApplicationContext {
+        login(roles = emptySet())
+
+        client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rts:video:1") shouldHaveStatus
+          HttpStatusCode.Forbidden
+      }
+    }
+
+    should("label the submit button Publish until the imported media exists in the database") {
+      withStubbedIntegrationLayer {
+        login()
+
+        val importResponse = client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rsi:video:3845234")
+        Jsoup
+          .parse(importResponse.bodyAsText())[".editor-toolbar .btn-primary"]
+          .first()
+          ?.text() shouldBe "Publish"
+
+        client.hxPost("${Navigation.CONSOLE}/actions/media") {
+          contentType(ContentType.Application.Json)
+          setBody(Media(id = "urn:rsi:video:3845234", metadata = MediaMetadata(title = "Telegiornale flash")))
+        } shouldHaveStatus HttpStatusCode.OK
+
+        val reimportResponse = client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rsi:video:3845234")
+        Jsoup
+          .parse(reimportResponse.bodyAsText())[".editor-toolbar .btn-primary"]
+          .first()
+          ?.text() shouldBe "Save Changes"
+      }
+    }
+
+    should("save an imported media through the regular editor flow") {
+      withStubbedIntegrationLayer {
+        login()
+
+        val importResponse = client.get("${Navigation.CONSOLE}/editor/import?urn=urn:rsi:video:3845234")
+        val doc = Jsoup.parse(importResponse.bodyAsText())
+        val id = doc["input[name='id']"].first()?.attributes()["value"] ?: ""
+        val title = doc["input[name='metadata.title']"].first()?.attributes()["value"]
+
+        val saveResponse =
+          client.hxPost("${Navigation.CONSOLE}/actions/media") {
+            contentType(ContentType.Application.Json)
+            setBody(Media(id = id, metadata = MediaMetadata(title = title)))
+          }
+        saveResponse shouldHaveStatus HttpStatusCode.OK
+
+        val editorResponse = client.get("${Navigation.CONSOLE}/editor/$id")
+        editorResponse shouldHaveStatus HttpStatusCode.OK
+        Jsoup
+          .parse(editorResponse.bodyAsText())["input[name='metadata.title']"]
+          .first()
+          ?.attributes()["value"] shouldBe "Telegiornale flash"
+      }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClientTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClientTest.kt
@@ -1,0 +1,77 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import ch.srgssr.pillarbox.backend.test.IntegrationLayerFixtures
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+private fun httpClient(engine: MockEngine) =
+  HttpClient(engine) {
+    install(ContentNegotiation) {
+      json(Json { ignoreUnknownKeys = true })
+    }
+  }
+
+class IntegrationLayerClientTest :
+  ShouldSpec({
+
+    should("fetch and decode the media composition for a URN") {
+      val engine =
+        MockEngine { request ->
+          request.url.toString() shouldBe
+            "https://il.example.ch/integrationlayer/2.0/mediaComposition/byUrn/urn:rsi:video:3845234"
+          respond(
+            content = IntegrationLayerFixtures.vodComposition,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+          )
+        }
+      val client = IntegrationLayerClient(httpClient(engine), IntegrationLayerConfig(baseUrl = "https://il.example.ch"))
+
+      val composition = client.findMediaComposition("urn:rsi:video:3845234")
+
+      composition.shouldNotBeNull().chapterUrn shouldBe "urn:rsi:video:3845234"
+      composition.chapterList shouldBe composition.chapterList.filter { it.urn == "urn:rsi:video:3845234" }
+    }
+
+    should("return null when the URN is not found") {
+      val engine =
+        MockEngine {
+          respond(
+            content = """{"status":404,"title":"Not found"}""",
+            status = HttpStatusCode.NotFound,
+            headers = headersOf(HttpHeaders.ContentType, "application/problem+json"),
+          )
+        }
+      val client = IntegrationLayerClient(httpClient(engine), IntegrationLayerConfig(baseUrl = "https://il.example.ch"))
+
+      client.findMediaComposition("urn:rts:video:unknown").shouldBeNull()
+    }
+
+    should("encode reserved characters in the URN and tolerate a trailing slash in the base url") {
+      val engine =
+        MockEngine { request ->
+          request.url.toString() shouldBe
+            "https://il.example.ch/integrationlayer/2.0/mediaComposition/byUrn/urn%3F%23%2F%25:video:1"
+          respond(
+            content = IntegrationLayerFixtures.vodComposition,
+            status = HttpStatusCode.OK,
+            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+          )
+        }
+      val client =
+        IntegrationLayerClient(httpClient(engine), IntegrationLayerConfig(baseUrl = "https://il.example.ch/"))
+
+      client.findMediaComposition("urn?#/%:video:1").shouldNotBeNull()
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapperTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapperTest.kt
@@ -1,0 +1,151 @@
+package ch.srgssr.pillarbox.backend.integrationlayer
+
+import ch.srgssr.pillarbox.backend.test.IntegrationLayerFixtures
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+private val json = Json { ignoreUnknownKeys = true }
+
+private fun decode(fixture: String): MediaComposition = json.decodeFromString(fixture)
+
+class MediaCompositionMapperTest :
+  ShouldSpec({
+
+    context("VOD composition") {
+      val media = decode(IntegrationLayerFixtures.vodComposition).toMedia().shouldNotBeNull()
+
+      should("map the main chapter metadata") {
+        media.id shouldBe "urn:rsi:video:3845234"
+        media.metadata.title shouldBe "Telegiornale flash"
+        media.metadata.subtitle shouldBe "Telegiornale"
+        media.metadata.posterUrl shouldBe "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/3878974"
+        media.metadata.seasonNumber shouldBe 2
+        media.metadata.episodeNumber shouldBe 7
+        media.tags shouldBe emptyList()
+      }
+
+      should("fall back to the lead when the description is blank") {
+        media.metadata.description shouldBe "Le notizie di mezza giornata"
+      }
+
+      should("emit one source per streaming method, preferring HD variants") {
+        media.sources shouldHaveSize 2
+        media.sources.map { it.url } shouldContainExactly
+          listOf(
+            "https://rsivod.akamaized.net/out/v1/telegiornale/index.m3u8",
+            "https://rsivod.akamaized.net/telegiornale/video.mp4",
+          )
+        media.sources.map { it.type }.toSet() shouldBe setOf("ON-DEMAND")
+      }
+
+      should("derive the mime type when the resource does not provide one") {
+        media.sources.first().mimeType shouldBe "application/x-mpegURL"
+        media.sources.last().mimeType shouldBe "video/mp4"
+      }
+
+      should("map segments to chapters, skipping the requested media itself") {
+        val chapters = media.metadata.chapters.shouldNotBeNull()
+        chapters shouldHaveSize 2
+        chapters.first().identifier shouldBe "urn:rsi:video:3878648"
+        chapters.first().title shouldBe "Nuovi attacchi USA contro l'Iran"
+        chapters.first().startTime shouldBe 46600
+        chapters.first().endTime shouldBe 156256
+        chapters.first().posterUrl shouldBe "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/3878975"
+      }
+
+      should("keep only VTT subtitle tracks") {
+        val subtitles = media.metadata.subtitles.shouldNotBeNull()
+        subtitles shouldHaveSize 1
+        subtitles.first().label shouldBe "Italiano"
+        subtitles.first().kind shouldBe "captions"
+        subtitles.first().language shouldBe "it"
+        subtitles.first().url shouldBe
+          "https://rsi-subtitles.s3.eu-central-1.amazonaws.com/subt_web/rsi/production/2026/telegiornale.vtt"
+      }
+    }
+
+    context("live composition with DRM") {
+      val media = decode(IntegrationLayerFixtures.liveDrmComposition).toMedia().shouldNotBeNull()
+
+      should("prefer the DVR variant of each streaming method") {
+        media.sources shouldHaveSize 2
+        media.sources.map { it.type }.toSet() shouldBe setOf("DVR")
+        media.sources.map { it.url } shouldContainExactly
+          listOf(
+            "https://lsvs-rts1-d.akamaized.net/out/v1/82ab0e39500a47a3b7ac54626d5399b5/index.m3u8?dw=7201",
+            "https://lsvs-rts1-d.akamaized.net/out/v1/9bd2958c2c564691b8dd08fc652d4d6e/index.mpd?dw=7201",
+          )
+      }
+
+      should("map DRM systems to their key system identifiers") {
+        val hls = media.sources.first()
+        hls.drmConfigs shouldHaveSize 1
+        hls.drmConfigs.first().keySystem shouldBe "com.apple.fps"
+        hls.drmConfigs.first().certificateUrl shouldBe
+          "https://srg.live.ott.irdeto.com/licenseServer/streaming/v1/SRG/getcertificate?applicationId=live"
+
+        val dash = media.sources.last()
+        dash.drmConfigs.map { it.keySystem } shouldContainExactly
+          listOf("com.widevine.alpha", "com.microsoft.playready")
+      }
+
+      should("use the show title as subtitle and leave series fields empty") {
+        media.metadata.subtitle shouldBe "RTS 1"
+        media.metadata.seasonNumber.shouldBeNull()
+        media.metadata.episodeNumber.shouldBeNull()
+        media.metadata.chapters.shouldBeNull()
+        media.metadata.subtitles.shouldBeNull()
+      }
+    }
+
+    context("degenerate compositions") {
+      should("return null when the composition has no chapter") {
+        MediaComposition(chapterUrn = "urn:rts:video:1").toMedia().shouldBeNull()
+      }
+
+      should("fall back to the first chapter when none matches the requested URN") {
+        val composition =
+          MediaComposition(
+            chapterUrn = "urn:rts:video:missing",
+            chapterList = listOf(CompositionChapter(urn = "urn:rts:video:1", title = "Fallback")),
+          )
+
+        val media = composition.toMedia().shouldNotBeNull()
+        media.id shouldBe "urn:rts:video:1"
+        media.metadata.title shouldBe "Fallback"
+      }
+
+      should("skip unsupported streaming methods and unknown DRM types") {
+        val composition =
+          MediaComposition(
+            chapterUrn = "urn:rts:video:1",
+            chapterList =
+              listOf(
+                CompositionChapter(
+                  urn = "urn:rts:video:1",
+                  title = "Streams",
+                  resourceList =
+                    listOf(
+                      Resource(url = "https://stream.com/legacy.rtmp", streaming = "UNKNOWN"),
+                      Resource(
+                        url = "https://stream.com/index.m3u8",
+                        streaming = "HLS",
+                        drmList = listOf(Drm(type = "CUSTOM", licenseUrl = "https://license.com")),
+                      ),
+                    ),
+                ),
+              ),
+          )
+
+        val media = composition.toMedia().shouldNotBeNull()
+        media.sources shouldHaveSize 1
+        media.sources.first().url shouldBe "https://stream.com/index.m3u8"
+        media.sources.first().drmConfigs shouldBe emptyList()
+      }
+    }
+  })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/IntegrationLayerFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/IntegrationLayerFixtures.kt
@@ -1,0 +1,17 @@
+package ch.srgssr.pillarbox.backend.test
+
+/**
+ * Trimmed real Integration Layer `mediaComposition` responses used as test fixtures.
+ */
+object IntegrationLayerFixtures {
+  /** A VOD composition with segments, VTT/TTML subtitles, and HD/SD stream variants. */
+  val vodComposition: String get() = read("media-composition-vod.json")
+
+  /** A live composition with DVR/non-DVR duplicates protected by FairPlay, Widevine, and PlayReady. */
+  val liveDrmComposition: String get() = read("media-composition-live-drm.json")
+
+  private fun read(name: String): String =
+    checkNotNull(IntegrationLayerFixtures::class.java.getResource("/integrationlayer/$name")) {
+      "Missing fixture: $name"
+    }.readText()
+}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/TestUtils.kt
@@ -30,11 +30,13 @@ val writeRoles: Set<Role> = setOf(Role.WRITE)
  *    4. Ensuring database isolation between tests by truncating all tables after each
  *       test execution.
  *
+ * @param configOverrides Additional configuration properties applied on top of the defaults.
  * @param block The test logic to execute, provides access to the [ApplicationTestBuilder]
  *              and a pre-configured `client` with JSON support.
  */
 fun testApplicationContext(
   enableProxyHeaders: Boolean = false,
+  configOverrides: Map<String, String> = emptyMap(),
   block: suspend ApplicationTestBuilder.() -> Unit,
 ) {
   val oAuthServer = mockOAuth2Server().also { it.start() }
@@ -50,6 +52,7 @@ fun testApplicationContext(
       this["oidc.discovery_path"] = ".well-known/openid-configuration"
       this["oidc.client_id"] = "pillarbox-test-client"
       this["oidc.realm"] = "pillarbox-realm"
+      configOverrides.forEach { (key, value) -> this[key] = value }
     }
 
     client =

--- a/src/test/resources/integrationlayer/media-composition-live-drm.json
+++ b/src/test/resources/integrationlayer/media-composition-live-drm.json
@@ -1,0 +1,127 @@
+{
+  "chapterUrn": "urn:rts:video:3608506",
+  "show": {
+    "id": "93abfc12-b547-31ce-9c0a-68ff11ff0e52",
+    "vendor": "RTS",
+    "transmission": "TV",
+    "urn": "urn:rts:show:tv:93abfc12-b547-31ce-9c0a-68ff11ff0e52",
+    "title": "RTS 1",
+    "imageUrl": "https://img.rts.ch/articles/2023/image/ra3xg-26166607.image/16x9"
+  },
+  "chapterList": [
+    {
+      "id": "3608506",
+      "mediaType": "VIDEO",
+      "vendor": "RTS",
+      "urn": "urn:rts:video:3608506",
+      "title": "RTS 1",
+      "imageUrl": "https://img.rts.ch/articles/2023/image/ra3xg-26166607.image",
+      "imageTitle": "RTS 1",
+      "type": "LIVESTREAM",
+      "date": "2026-07-08T00:00:00+02:00",
+      "duration": 0,
+      "playableAbroad": false,
+      "displayable": true,
+      "position": 0,
+      "noEmbed": false,
+      "resourceList": [
+        {
+          "url": "https://lsvs-rts1-d.akamaized.net/out/v1/82ab0e39500a47a3b7ac54626d5399b5/index.m3u8?dw=7201",
+          "quality": "HD",
+          "protocol": "HLS-DVR",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "presentation": "DEFAULT",
+          "streaming": "HLS",
+          "dvr": true,
+          "live": true,
+          "mediaContainer": "NONE",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE",
+          "drmList": [
+            {
+              "type": "FAIRPLAY",
+              "licenseUrl": "https://srg.live.ott.irdeto.com/licenseServer/streaming/v1/SRG/getckc?contentId=RTS1DRM&keyId=a4de6060-e533-46ca-9cc1-0f043b903416",
+              "certificateUrl": "https://srg.live.ott.irdeto.com/licenseServer/streaming/v1/SRG/getcertificate?applicationId=live"
+            }
+          ]
+        },
+        {
+          "url": "https://lsvs-rts1-d.akamaized.net/out/v1/82ab0e39500a47a3b7ac54626d5399b5/index.m3u8",
+          "quality": "HD",
+          "protocol": "HLS",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "presentation": "DEFAULT",
+          "streaming": "HLS",
+          "dvr": false,
+          "live": true,
+          "mediaContainer": "NONE",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE",
+          "drmList": [
+            {
+              "type": "FAIRPLAY",
+              "licenseUrl": "https://srg.live.ott.irdeto.com/licenseServer/streaming/v1/SRG/getckc?contentId=RTS1DRM&keyId=a4de6060-e533-46ca-9cc1-0f043b903416",
+              "certificateUrl": "https://srg.live.ott.irdeto.com/licenseServer/streaming/v1/SRG/getcertificate?applicationId=live"
+            }
+          ]
+        },
+        {
+          "url": "https://lsvs-rts1-d.akamaized.net/out/v1/9bd2958c2c564691b8dd08fc652d4d6e/index.mpd?dw=7201",
+          "quality": "HD",
+          "protocol": "DASH-DVR",
+          "encoding": "H264",
+          "mimeType": "application/dash+xml",
+          "presentation": "DEFAULT",
+          "streaming": "DASH",
+          "dvr": true,
+          "live": true,
+          "mediaContainer": "NONE",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE",
+          "drmList": [
+            {
+              "type": "WIDEVINE",
+              "licenseUrl": "https://srg.live.ott.irdeto.com/licenseServer/widevine/v1/SRG/license?contentId=RTS1DRM",
+              "widevineSecurityLevel": "L3"
+            },
+            {
+              "type": "PLAYREADY",
+              "licenseUrl": "https://srg.live.ott.irdeto.com/licenseServer/playready/v1/SRG/license?contentId=RTS1DRM"
+            }
+          ]
+        },
+        {
+          "url": "https://lsvs-rts1-d.akamaized.net/out/v1/9bd2958c2c564691b8dd08fc652d4d6e/index.mpd",
+          "quality": "HD",
+          "protocol": "DASH",
+          "encoding": "H264",
+          "mimeType": "application/dash+xml",
+          "presentation": "DEFAULT",
+          "streaming": "DASH",
+          "dvr": false,
+          "live": true,
+          "mediaContainer": "NONE",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE",
+          "drmList": [
+            {
+              "type": "WIDEVINE",
+              "licenseUrl": "https://srg.live.ott.irdeto.com/licenseServer/widevine/v1/SRG/license?contentId=RTS1DRM",
+              "widevineSecurityLevel": "L3"
+            },
+            {
+              "type": "PLAYREADY",
+              "licenseUrl": "https://srg.live.ott.irdeto.com/licenseServer/playready/v1/SRG/license?contentId=RTS1DRM"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/integrationlayer/media-composition-vod.json
+++ b/src/test/resources/integrationlayer/media-composition-vod.json
@@ -1,0 +1,153 @@
+{
+  "chapterUrn": "urn:rsi:video:3845234",
+  "episode": {
+    "id": "3845234",
+    "title": "Telegiornale flash",
+    "seasonNumber": 2,
+    "number": 7
+  },
+  "show": {
+    "id": "6413e0d9-cbb6-4b1c-89b4-19fe0bd54fc1",
+    "vendor": "RSI",
+    "transmission": "TV",
+    "urn": "urn:rsi:show:tv:6413e0d9-cbb6-4b1c-89b4-19fe0bd54fc1",
+    "title": "Telegiornale",
+    "imageUrl": "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/1837577"
+  },
+  "chapterList": [
+    {
+      "id": "3845234",
+      "mediaType": "VIDEO",
+      "vendor": "RSI",
+      "urn": "urn:rsi:video:3845234",
+      "title": "Telegiornale flash",
+      "lead": "Le notizie di mezza giornata",
+      "description": "",
+      "imageUrl": "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/3878974",
+      "type": "EPISODE",
+      "date": "2026-07-08T12:30:00+02:00",
+      "duration": 372000,
+      "playableAbroad": true,
+      "displayable": true,
+      "position": 0,
+      "noEmbed": false,
+      "subtitleList": [
+        {
+          "locale": "it",
+          "language": "Italiano",
+          "source": "EXTERNAL",
+          "type": "SDH",
+          "url": "https://rsi-subtitles.s3.eu-central-1.amazonaws.com/subt_web/rsi/production/2026/telegiornale.vtt",
+          "format": "VTT"
+        },
+        {
+          "locale": "it",
+          "language": "Italiano",
+          "source": "EXTERNAL",
+          "type": "SDH",
+          "url": "https://rsi-subtitles.s3.eu-central-1.amazonaws.com/subt_web/rsi/production/2026/telegiornale.xml",
+          "format": "TTML"
+        }
+      ],
+      "resourceList": [
+        {
+          "url": "https://rsivod.akamaized.net/out/v1/telegiornale/index.m3u8",
+          "quality": "HD",
+          "protocol": "HLS",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "presentation": "DEFAULT",
+          "streaming": "HLS",
+          "dvr": false,
+          "live": false,
+          "mediaContainer": "NONE",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE"
+        },
+        {
+          "url": "https://rsivod.akamaized.net/out/v1/telegiornale/index-sd.m3u8",
+          "quality": "SD",
+          "protocol": "HLS",
+          "encoding": "H264",
+          "mimeType": "application/x-mpegURL",
+          "presentation": "DEFAULT",
+          "streaming": "HLS",
+          "dvr": false,
+          "live": false,
+          "mediaContainer": "NONE",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE"
+        },
+        {
+          "url": "https://rsivod.akamaized.net/telegiornale/video.mp4",
+          "quality": "HD",
+          "protocol": "HTTPS",
+          "encoding": "H264",
+          "presentation": "DEFAULT",
+          "streaming": "PROGRESSIVE",
+          "dvr": false,
+          "live": false,
+          "mediaContainer": "MP4",
+          "audioCodec": "AAC",
+          "videoCodec": "H264",
+          "tokenType": "NONE"
+        }
+      ],
+      "segmentList": [
+        {
+          "id": "3845234",
+          "mediaType": "VIDEO",
+          "vendor": "RSI",
+          "urn": "urn:rsi:video:3845234",
+          "title": "Telegiornale flash",
+          "markIn": 0,
+          "markOut": 372000,
+          "imageUrl": "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/3878974",
+          "type": "EPISODE",
+          "date": "2026-07-08T12:30:00+02:00",
+          "duration": 372000,
+          "playableAbroad": true,
+          "displayable": true,
+          "position": 0,
+          "noEmbed": false
+        },
+        {
+          "id": "3878648",
+          "mediaType": "VIDEO",
+          "vendor": "RSI",
+          "urn": "urn:rsi:video:3878648",
+          "title": "Nuovi attacchi USA contro l'Iran",
+          "markIn": 46600,
+          "markOut": 156256,
+          "imageUrl": "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/3878975",
+          "type": "CLIP",
+          "date": "2026-07-08T12:30:00+02:00",
+          "duration": 109656,
+          "playableAbroad": true,
+          "displayable": true,
+          "position": 1,
+          "noEmbed": false
+        },
+        {
+          "id": "3878666",
+          "mediaType": "VIDEO",
+          "vendor": "RSI",
+          "urn": "urn:rsi:video:3878666",
+          "title": "La salma di Khamenei a Mashad per la sepoltura",
+          "markIn": 155600,
+          "markOut": 187600,
+          "imageUrl": "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/3878981",
+          "type": "CLIP",
+          "date": "2026-07-08T12:30:00+02:00",
+          "duration": 32000,
+          "playableAbroad": true,
+          "displayable": true,
+          "position": 2,
+          "noEmbed": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Resolves #30 by letting editors prefill the media editor with data fetched from the Integration Layer instead of typing it by hand.

## Changes Made

- Adds an "Import from URN" dialog in the library header opens the editor pre-populated.
- Added an `exists` template flag so the editor switches between Publish and Save Changes based on persistence instead of the id field.
- Extract boolean `requireFolderWrite`/`requireMediaWrite` guards.
- Hoist the generic dialog form/footer layout into `_dialog.css`, replacing the per-dialog copies in the home, teams and confirm styles.
- Make the base IL URL configurable via `INTEGRATION_LAYER_BASE_URL` env variable.
- Stubbed Integration Layer server for tests.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
