### PR TITLE
fix(il): force CH location on Integration Layer requests

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClient.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClient.kt
@@ -27,6 +27,7 @@ class IntegrationLayerClient(
     val response =
       httpClient.get(config.baseUrl) {
         url.appendPathSegments(listOf("integrationlayer", "2.0", "mediaComposition", "byUrn", urn), encodeSlash = true)
+        url.parameters.append("forceLocation", "CH")
       }
 
     return if (response.status.isSuccess()) response.body() else null

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClientTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerClientTest.kt
@@ -29,7 +29,7 @@ class IntegrationLayerClientTest :
       val engine =
         MockEngine { request ->
           request.url.toString() shouldBe
-            "https://il.example.ch/integrationlayer/2.0/mediaComposition/byUrn/urn:rsi:video:3845234"
+            "https://il.example.ch/integrationlayer/2.0/mediaComposition/byUrn/urn:rsi:video:3845234?forceLocation=CH"
           respond(
             content = IntegrationLayerFixtures.vodComposition,
             status = HttpStatusCode.OK,
@@ -62,7 +62,7 @@ class IntegrationLayerClientTest :
       val engine =
         MockEngine { request ->
           request.url.toString() shouldBe
-            "https://il.example.ch/integrationlayer/2.0/mediaComposition/byUrn/urn%3F%23%2F%25:video:1"
+            "https://il.example.ch/integrationlayer/2.0/mediaComposition/byUrn/urn%3F%23%2F%25:video:1?forceLocation=CH"
           respond(
             content = IntegrationLayerFixtures.vodComposition,
             status = HttpStatusCode.OK,


### PR DESCRIPTION
## Description

Servers hosted outside Switzerland were failing to resolve resources because the Integration Layer applies geoblocking based on the caller's IP. Appending forceLocation=CH makes the IL respond as if the request originated in Switzerland, so metadata can still be without a blockReason/empty resourceList.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
