### PR TITLE
feat(player): add platform presets for stream and DRM negotiation

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -198,6 +198,7 @@ If neither is supplied, the API returns a media item without a source.
 |---------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `stream-type` | `application/dash+xml`             | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
 | `drm`         | `com.widevine.alpha;HW_SECURE_ALL` | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
+| `platform`    | `android`                          | Target platform whose ready-made preferences are used as defaults. One of `android`, `apple`, `web`.                                |
 
 Example:
 
@@ -212,6 +213,7 @@ curl --request GET \
 |------------------------|------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `X-Accept-Stream-Type` | `application/dash+xml`             | Preferred MIME type (e.g., DASH, HLS). Comma-separated for multiple values.                                                         |
 | `X-Accept-DRM`         | `com.widevine.alpha;HW_SECURE_ALL` | Preferred DRM key system, optionally followed by `;` and the highest supported security level. Comma-separated for multiple values. |
+| `X-Target-Platform`    | `android`                          | Target platform whose ready-made preferences are used as defaults. One of `android`, `apple`, `web`.                                |
 
 Example:
 
@@ -220,6 +222,21 @@ curl --request GET \
   --url http://localhost:8080/v1/player/media/urn:pillarbox:video:12345 \
   --header 'X-Accept-Stream-Type: application/dash+xml' \
   --header 'X-Accept-DRM: com.widevine.alpha;HW_SECURE_ALL'
+```
+
+**Platform Presets**
+
+The `platform` parameter and `X-Target-Platform` header select a ready-made preference list for
+the target platform: stream types and DRM systems a typical `android`, `apple`, or `web` client
+supports, in a sensible priority order. Explicit `stream-type` and `drm` values take precedence:
+each one replaces the corresponding part of the preset, while the preset fills whatever is
+omitted.
+
+Only one platform can be targeted at a time, unknown platforms are rejected with `400 Bad Request`.
+
+```bash
+curl --request GET \
+  --url 'http://localhost:8080/v1/player/media/urn:pillarbox:video:12345?platform=android'
 ```
 
 **Security Levels**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
@@ -1,8 +1,10 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.api
 
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toPlayerResponse
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaPreferences
 import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaSourceSelector
 import ch.srgssr.pillarbox.backend.entrypoint.web.service.toDrmPreferences
+import ch.srgssr.pillarbox.backend.entrypoint.web.service.toPlatformPreferences
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toQuerySlice
 import ch.srgssr.pillarbox.backend.io.parseHeaderList
 import ch.srgssr.pillarbox.backend.io.parseParamList
@@ -35,6 +37,8 @@ fun Route.playerMedia(
   route("v1/player/") {
     route("media") {
       get {
+        if (!call.request.hasKnownPlatform()) return@get call.respond(HttpStatusCode.BadRequest, "Unknown platform")
+
         with(call.request.queryParameters.toQuerySlice()) {
           val mediaSourceSelector = call.request.toMediaSourceSelector()
           val query = call.request.queryParameters["q"]
@@ -47,6 +51,8 @@ fun Route.playerMedia(
       }
 
       get("/{id}") {
+        if (!call.request.hasKnownPlatform()) return@get call.respond(HttpStatusCode.BadRequest, "Unknown platform")
+
         val id = call.parameters.getOrFail("id")
 
         val media =
@@ -60,6 +66,8 @@ fun Route.playerMedia(
 
     route("folder") {
       get("/{id}/media") {
+        if (!call.request.hasKnownPlatform()) return@get call.respond(HttpStatusCode.BadRequest, "Unknown platform")
+
         val id = call.parameters.getOrFail("id")
         if (!folderRepository.exists(id)) return@get call.respond(HttpStatusCode.NotFound)
 
@@ -87,10 +95,12 @@ fun Route.playerMedia(
  * @return A [MediaSourceSelector] configured with the client's preferences.
  */
 private fun ApplicationRequest.toMediaSourceSelector() =
-  MediaSourceSelector(
-    toMimeTypePreferences(),
-    toDrmPreferences(),
-  )
+  this.toMediaPreferences().let {
+    MediaSourceSelector(
+      it.mimeTypePreferences,
+      it.drmPreferences,
+    )
+  }
 
 /**
  * Extracts the client's preferred MIME types from the `stream-type` query parameter,
@@ -115,3 +125,43 @@ private fun ApplicationRequest.toDrmPreferences() =
     .parseParamList("drm")
     .ifEmpty { call.request.headers.parseHeaderList("X-Accept-DRM") }
     .toDrmPreferences()
+
+/**
+ * Extracts the client's target platform from the `platform` query parameter,
+ * falling back to the `X-Target-Platform` header if the parameter is absent or blank.
+ *
+ * @return The raw platform identifier, or `null` if the client targets no platform.
+ */
+private fun ApplicationRequest.toPlatform() =
+  queryParameters["platform"]?.trim()?.takeIf { it.isNotEmpty() }
+    ?: call.request.headers["X-Target-Platform"]
+      ?.trim()
+      ?.takeIf { it.isNotEmpty() }
+
+/**
+ * Checks that the targeted platform has a ready-made preset, so that a client typo
+ * is reported instead of silently yielding an empty set of preferences.
+ *
+ * @return `true` if the client targets no platform or a known one.
+ */
+private fun ApplicationRequest.hasKnownPlatform() =
+  toPlatform()?.lowercase()?.let { it in MediaPreferences.knownPlatforms } ?: true
+
+/**
+ * Combines the request's explicit stream-type and DRM preferences with the platform preset
+ * from the `platform` query parameter (or `X-Target-Platform` header).
+ *
+ * Explicit preferences take precedence; the preset fills whichever list the client omitted.
+ *
+ * @return The effective [MediaPreferences] for this request.
+ */
+private fun ApplicationRequest.toMediaPreferences(): MediaPreferences {
+  val platformPreferences = toPlatform()?.toPlatformPreferences() ?: MediaPreferences()
+
+  return MediaPreferences(
+    mimeTypePreferences =
+      this.toMimeTypePreferences().takeIf { it.isNotEmpty() }
+        ?: platformPreferences.mimeTypePreferences,
+    drmPreferences = this.toDrmPreferences().takeIf { it.isNotEmpty() } ?: platformPreferences.drmPreferences,
+  )
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/DrmPreference.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/DrmPreference.kt
@@ -1,5 +1,7 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.service
 
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.DrmSystems
+
 /**
  * A client's preference for a specific DRM key system, optionally
  * constrained to a maximum security level.
@@ -20,8 +22,8 @@ data class DrmPreference(
  */
 private val minSecurityLevels: Map<String, String> =
   mapOf(
-    "com.widevine.alpha" to "L3",
-    "com.microsoft.playready" to "SL2000",
+    DrmSystems.WIDEVINE to "L3",
+    DrmSystems.PLAYREADY to "SL2000",
   )
 
 /**
@@ -29,16 +31,16 @@ private val minSecurityLevels: Map<String, String> =
  */
 private val robustnessToLevel: Map<Pair<String, String>, String> =
   mapOf(
-    ("com.widevine.alpha" to "SW_SECURE_CRYPTO") to "L3",
-    ("com.widevine.alpha" to "SW_SECURE_DECODE") to "L3",
-    ("com.widevine.alpha" to "HW_SECURE_CRYPTO") to "L2",
-    ("com.widevine.alpha" to "HW_SECURE_DECODE") to "L2",
-    ("com.widevine.alpha" to "HW_SECURE_ALL") to "L1",
-    ("com.microsoft.playready" to "SW_SECURE_CRYPTO") to "SL2000",
-    ("com.microsoft.playready" to "SW_SECURE_DECODE") to "SL2000",
-    ("com.microsoft.playready" to "HW_SECURE_CRYPTO") to "SL2000",
-    ("com.microsoft.playready" to "HW_SECURE_DECODE") to "SL2000",
-    ("com.microsoft.playready" to "HW_SECURE_ALL") to "SL3000",
+    (DrmSystems.WIDEVINE to "SW_SECURE_CRYPTO") to "L3",
+    (DrmSystems.WIDEVINE to "SW_SECURE_DECODE") to "L3",
+    (DrmSystems.WIDEVINE to "HW_SECURE_CRYPTO") to "L2",
+    (DrmSystems.WIDEVINE to "HW_SECURE_DECODE") to "L2",
+    (DrmSystems.WIDEVINE to "HW_SECURE_ALL") to "L1",
+    (DrmSystems.PLAYREADY to "SW_SECURE_CRYPTO") to "SL2000",
+    (DrmSystems.PLAYREADY to "SW_SECURE_DECODE") to "SL2000",
+    (DrmSystems.PLAYREADY to "HW_SECURE_CRYPTO") to "SL2000",
+    (DrmSystems.PLAYREADY to "HW_SECURE_DECODE") to "SL2000",
+    (DrmSystems.PLAYREADY to "HW_SECURE_ALL") to "SL3000",
   )
 
 /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/MediaPreferences.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/MediaPreferences.kt
@@ -1,0 +1,115 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.service
+
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.DrmSystems
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.MimeTypes
+
+/**
+ * A client's combined media capabilities, pairing prioritised MIME types
+ * with prioritised DRM preferences.
+ *
+ * Ready-made presets for common platforms are available in the companion object.
+ *
+ * @property mimeTypePreferences Prioritised list of accepted MIME types.
+ * @property drmPreferences Prioritised list of accepted DRM preferences.
+ */
+data class MediaPreferences(
+  val mimeTypePreferences: List<String> = listOf(),
+  val drmPreferences: List<DrmPreference> = listOf(),
+) {
+  companion object {
+    /** Preset for Android clients: DASH-first with Widevine, MP3 priority for aod. */
+    val android =
+      MediaPreferences(
+        mimeTypePreferences =
+          listOf(
+            MimeTypes.MP3,
+            MimeTypes.DASH,
+            MimeTypes.HLS,
+            MimeTypes.HLS_LEGACY,
+            MimeTypes.SMOOTH_STREAMING,
+            MimeTypes.AAC,
+            MimeTypes.M4A,
+            MimeTypes.MP4,
+            MimeTypes.WEBM,
+            MimeTypes.WEBM_AUDIO,
+            MimeTypes.MKV,
+            MimeTypes.FLAC,
+            MimeTypes.OGG,
+            MimeTypes.OPUS,
+            MimeTypes.WAV,
+            MimeTypes.TS,
+            MimeTypes.THREE_GPP,
+          ),
+        drmPreferences =
+          listOf(
+            DrmPreference(DrmSystems.WIDEVINE),
+          ),
+      )
+
+    /** Preset for Apple clients: HLS-first with FairPlay, MP3 priority for aod. */
+    val apple =
+      MediaPreferences(
+        mimeTypePreferences =
+          listOf(
+            MimeTypes.MP3,
+            MimeTypes.HLS,
+            MimeTypes.HLS_LEGACY,
+            MimeTypes.AAC,
+            MimeTypes.M4A,
+            MimeTypes.MP4,
+            MimeTypes.MOV,
+            MimeTypes.FLAC,
+            MimeTypes.WAV,
+            MimeTypes.THREE_GPP,
+          ),
+        drmPreferences =
+          listOf(
+            DrmPreference(DrmSystems.FAIRPLAY),
+          ),
+      )
+
+    /** Preset for web browser clients: HLS/DASH-first, no DRM assumption, MP3 first for aod. */
+    val web =
+      MediaPreferences(
+        mimeTypePreferences =
+          listOf(
+            MimeTypes.MP3,
+            MimeTypes.HLS,
+            MimeTypes.HLS_LEGACY,
+            MimeTypes.DASH,
+            MimeTypes.SMOOTH_STREAMING,
+            MimeTypes.AAC,
+            MimeTypes.M4A,
+            MimeTypes.MP4,
+            MimeTypes.WEBM,
+            MimeTypes.WEBM_AUDIO,
+            MimeTypes.OGG,
+            MimeTypes.OPUS,
+            MimeTypes.FLAC,
+            MimeTypes.WAV,
+          ),
+        drmPreferences = emptyList(),
+      )
+
+    /** The ready-made preset of each platform, keyed by its lowercase identifier. */
+    val platformPresets: Map<String, MediaPreferences> =
+      mapOf(
+        "android" to android,
+        "apple" to apple,
+        "web" to web,
+      )
+
+    /** The platform identifiers a client may ask for, in lowercase. */
+    val knownPlatforms: Set<String> = platformPresets.keys
+  }
+}
+
+/**
+ * Resolves a raw platform identifier to its ready-made [MediaPreferences] preset.
+ *
+ * Recognised identifiers (case-insensitive): `android`, `apple`, `web`.
+ *
+ * @receiver the raw platform identifier.
+ * @return the preset of that platform, or `null` if the identifier is unrecognised.
+ */
+fun String.toPlatformPreferences(): MediaPreferences? = MediaPreferences.platformPresets[lowercase()]

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/MediaSourceSelector.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/service/MediaSourceSelector.kt
@@ -2,6 +2,7 @@ package ch.srgssr.pillarbox.backend.entrypoint.web.service
 
 import ch.srgssr.pillarbox.backend.domain.model.DrmConfig
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.DrmSystems
 
 /**
  * Selects the best [MediaSource] from a list given a client's stream and DRM capabilities.
@@ -142,12 +143,12 @@ private object SecurityLevels {
   /** Maps `(keySystem, level)` pairs to their numeric rank. */
   private val rankings: Map<Pair<String, String>, Int> =
     mapOf(
-      ("com.widevine.alpha" to "L1") to 1,
-      ("com.widevine.alpha" to "L2") to 2,
-      ("com.widevine.alpha" to "L3") to 3,
-      ("com.microsoft.playready" to "SL3000") to 1,
-      ("com.microsoft.playready" to "SL2000") to 2,
-      ("com.microsoft.playready" to "SL150") to 3,
+      (DrmSystems.WIDEVINE to "L1") to 1,
+      (DrmSystems.WIDEVINE to "L2") to 2,
+      (DrmSystems.WIDEVINE to "L3") to 3,
+      (DrmSystems.PLAYREADY to "SL3000") to 1,
+      (DrmSystems.PLAYREADY to "SL2000") to 2,
+      (DrmSystems.PLAYREADY to "SL150") to 3,
     )
 
   /**

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/MediaTypes.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/MediaTypes.kt
@@ -1,0 +1,39 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.utils
+
+/**
+ * Well-known MIME types. The API accepts arbitrary strings; these are just the
+ * values we reference ourselves.
+ * See https://www.iana.org/assignments/media-types/media-types.xhtml
+ */
+object MimeTypes {
+  // Audio
+  const val MP3 = "audio/mpeg"
+  const val AAC = "audio/aac"
+  const val M4A = "audio/mp4"
+  const val FLAC = "audio/flac"
+  const val WAV = "audio/wav"
+  const val OGG = "audio/ogg"
+  const val OPUS = "audio/opus"
+  const val WEBM_AUDIO = "audio/webm"
+
+  // Video
+  const val MP4 = "video/mp4"
+  const val WEBM = "video/webm"
+  const val MKV = "video/x-matroska"
+  const val MOV = "video/quicktime"
+  const val TS = "video/mp2t"
+  const val THREE_GPP = "video/3gpp"
+
+  // Adaptive streaming manifests
+  const val HLS = "application/vnd.apple.mpegurl"
+  const val HLS_LEGACY = "application/x-mpegURL"
+  const val DASH = "application/dash+xml"
+  const val SMOOTH_STREAMING = "application/vnd.ms-sstr+xml"
+}
+
+/** EME key system identifiers. See https://www.w3.org/TR/encrypted-media/ */
+object DrmSystems {
+  const val WIDEVINE = "com.widevine.alpha"
+  const val FAIRPLAY = "com.apple.fps"
+  const val PLAYREADY = "com.microsoft.playready"
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapper.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapper.kt
@@ -6,14 +6,16 @@ import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
 import ch.srgssr.pillarbox.backend.domain.model.SubtitleTrack
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.DrmSystems
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.MimeTypes
 
 private val supportedStreamings = listOf("HLS", "DASH", "PROGRESSIVE")
 
 private val drmKeySystems =
   mapOf(
-    "FAIRPLAY" to "com.apple.fps",
-    "WIDEVINE" to "com.widevine.alpha",
-    "PLAYREADY" to "com.microsoft.playready",
+    "FAIRPLAY" to DrmSystems.FAIRPLAY,
+    "WIDEVINE" to DrmSystems.WIDEVINE,
+    "PLAYREADY" to DrmSystems.PLAYREADY,
   )
 
 /**
@@ -68,9 +70,9 @@ private fun Resource.toMediaSource(mediaType: String?): MediaSource =
 
 private fun Resource.defaultMimeType(mediaType: String?): String? =
   when (streaming) {
-    "HLS" -> "application/x-mpegURL"
-    "DASH" -> "application/dash+xml"
-    "PROGRESSIVE" -> if (mediaType == "AUDIO") "audio/mp4" else "video/mp4"
+    "HLS" -> MimeTypes.HLS_LEGACY
+    "DASH" -> MimeTypes.DASH
+    "PROGRESSIVE" -> if (mediaType == "AUDIO") MimeTypes.M4A else MimeTypes.MP4
     else -> null
   }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRouteTest.kt
@@ -202,6 +202,133 @@ class PlayerMediaRouteTest :
         response.drm shouldBe MediaLibrary.WidevineL1
       }
     }
+
+    should("select an unprotected source by preset priority for the web platform") {
+      testApplicationContext {
+        val media =
+          mediaFixture {
+            withMp4()
+            withDash()
+            withHls()
+          }
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val response =
+          client
+            .get("/v1/player/media/${media.id}") {
+              url { parameters.append("platform", "web") }
+            }.body<PlayerMediaResponseV1>()
+
+        response.source shouldBe MediaLibrary.Hls.toPlayerMediaSourceV1()
+        response.drm shouldBe null
+      }
+    }
+
+    should("override the android preset DRM with the drm query parameter") {
+      testApplicationContext {
+        val media =
+          mediaFixture {
+            withDash(MediaLibrary.FairPlay)
+            withHls()
+          }
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val response =
+          client
+            .get("/v1/player/media/${media.id}") {
+              url {
+                parameters.append("platform", "android")
+                parameters.append("drm", "com.apple.fps")
+              }
+            }.body<PlayerMediaResponseV1>()
+
+        response.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
+        response.drm shouldBe MediaLibrary.FairPlay
+      }
+    }
+
+    should("override the apple preset stream types with the stream-type query parameter") {
+      testApplicationContext {
+        val media =
+          mediaFixture {
+            withDash(MediaLibrary.FairPlay)
+            withHls()
+          }
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val response =
+          client
+            .get("/v1/player/media/${media.id}") {
+              url {
+                parameters.append("platform", "apple")
+                parameters.append("stream-type", "application/dash+xml")
+              }
+            }.body<PlayerMediaResponseV1>()
+
+        response.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
+        response.drm shouldBe MediaLibrary.FairPlay
+      }
+    }
+
+    should("fall back to the X-Target-Platform header when the platform parameter is absent") {
+      testApplicationContext {
+        val media =
+          mediaFixture {
+            withMp4()
+            withDash()
+            withHls()
+          }
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        val response =
+          client
+            .get("/v1/player/media/${media.id}") {
+              header("X-Target-Platform", "android")
+            }.body<PlayerMediaResponseV1>()
+
+        response.source shouldBe MediaLibrary.Dash.toPlayerMediaSourceV1()
+        response.drm shouldBe null
+      }
+    }
+
+    should("return BAD_REQUEST when the target platform is unknown") {
+      testApplicationContext {
+        val media = mediaFixture { withHls() }
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client.get("/v1/player/media/${media.id}") {
+          url { parameters.append("platform", "playstation") }
+        } shouldHaveStatus HttpStatusCode.BadRequest
+
+        client.get("/v1/player/media/${media.id}") {
+          url { parameters.append("platform", "web,android") }
+        } shouldHaveStatus HttpStatusCode.BadRequest
+
+        client.get("/v1/player/media") {
+          header("X-Target-Platform", "playstation")
+        } shouldHaveStatus HttpStatusCode.BadRequest
+      }
+    }
   })
 
 /**


### PR DESCRIPTION
## Description

Resolves #23 by introducing a `platform` query parameter (and a `X-Target-Platform` header fallback) that selects a ready-made MediaPreferences preset, i.e. Prioritised stream types and DRM systems for android, apple, and web clients.

Explicit stream-type and drm values take precedence.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
