### PR TITLE
feat(console): add JSON view and editor to the media editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,11 @@
     "": {
       "name": "pillarbox-console-frontend",
       "dependencies": {
+        "codejar": "^4.3.0",
         "dot-object": "^2.1.5",
         "htmx.org": "^2.0.10",
-        "open-props": "^1.7.23"
+        "open-props": "^1.7.23",
+        "prismjs": "^1.30.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.6",
@@ -2112,6 +2114,12 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/codejar": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/codejar/-/codejar-4.3.0.tgz",
+      "integrity": "sha512-A7BlrtD2oHR4xsABs/lLvDNxiPxkx71SuyHhcilBHbPMASpQs4d1AG2XjDSAm7y40RmfXbSGbMBhllGy//CDOA==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -6875,6 +6883,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "stylelint-order": "^8.1.1"
   },
   "dependencies": {
+    "codejar": "^4.3.0",
     "dot-object": "^2.1.5",
     "htmx.org": "^2.0.10",
-    "open-props": "^1.7.23"
+    "open-props": "^1.7.23",
+    "prismjs": "^1.30.0"
   }
 }

--- a/src/main/resources/static/css/modules/media/editor.page.css
+++ b/src/main/resources/static/css/modules/media/editor.page.css
@@ -1,4 +1,5 @@
 @import url("../../layouts/dashboard.layout.css");
+@import url("../../shared/components/json-editor.component.css");
 
 /* ── Editor host ── */
 
@@ -43,6 +44,7 @@ form.media-form {
 
 .editor-title {
   overflow: hidden;
+  flex: 1;
 
   font-size: var(--font-size-2);
   font-weight: var(--font-weight-6);
@@ -130,6 +132,40 @@ form.media-form {
   padding: var(--size-5);
 }
 
+/* ── JSON view — visibility controlled via JS hidden attribute ── */
+
+.editor-tabs[hidden],
+.json-view[hidden] {
+  display: none;
+}
+
+.json-view {
+  display: grid;
+  grid-area: panel;
+  grid-template-rows: auto 1fr;
+  gap: var(--size-2);
+
+  min-width: 0;
+  min-height: 0;
+  margin: var(--size-5);
+}
+
+.json-view > p {
+  max-inline-size: none;
+  margin: 0;
+  font-size: var(--font-size-0);
+  color: var(--text-2);
+}
+
+.json-discard-dialog {
+  max-inline-size: min(var(--size-15), calc(100vw - var(--size-7)));
+}
+
+.json-discard-dialog p {
+  margin: 0;
+  color: var(--text-2);
+}
+
 /* ── Active tab ── */
 
 .editor-tab[aria-selected="true"] {
@@ -176,7 +212,8 @@ form.media-form {
     background: transparent;
   }
 
-  .tab-panel {
+  .tab-panel,
+  .json-view {
     flex: 1;
   }
 }
@@ -191,12 +228,6 @@ form.media-form {
   border-radius: var(--radius-2);
 
   background: var(--surface-1);
-}
-
-/* JSON textarea uses monospace */
-textarea[data-type="json"] {
-  font-family: var(--font-mono);
-  font-size: var(--font-size-0);
 }
 
 /* ── Content tab panels (chapters, time-ranges, subtitles, sources) ── */

--- a/src/main/resources/static/css/shared/components/json-editor.component.css
+++ b/src/main/resources/static/css/shared/components/json-editor.component.css
@@ -1,0 +1,91 @@
+/* ── JSON editor ── */
+
+.json-editor {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: var(--size-1);
+
+  min-width: 0;
+  min-height: 0;
+}
+
+.json-editor[hidden] {
+  display: none;
+}
+
+/* ── Code surface — mirrors .field input styling ── */
+
+.json-editor-code {
+  max-inline-size: none;
+  min-block-size: var(--size-12);
+  margin: 0;
+  padding: var(--size-2) var(--size-3);
+  border: var(--border-size-1) solid transparent;
+  border-radius: var(--radius-2);
+
+  font-family: var(--font-mono);
+  font-size: var(--font-size-0);
+  line-height: var(--font-lineheight-3);
+  color: var(--text-1);
+  tab-size: 2;
+
+  background-color: var(--surface-2);
+
+  transition:
+    border-color 0.2s var(--ease-out-3),
+    background-color 0.15s var(--ease-out-3),
+    box-shadow 0.2s var(--ease-out-3);
+}
+
+.json-editor-code:focus {
+  border-color: var(--accent);
+  background-color: var(--surface-1);
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-softer);
+}
+
+/* ── Error state — mirrors .field :user-invalid styling ── */
+
+.json-editor-code[aria-invalid="true"] {
+  background-color: color-mix(in srgb, var(--red-6) 8%, var(--surface-2));
+}
+
+.json-editor-code[aria-invalid="true"]:focus {
+  border-color: var(--red-5);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--red-5) 20%, transparent);
+}
+
+.field:has(.json-editor-code[aria-invalid="true"]) label {
+  color: var(--red-5);
+}
+
+.json-editor-error {
+  margin: 0;
+  font-size: var(--font-size-0);
+  color: var(--red-5);
+  max-inline-size: none;
+}
+
+/* ── Syntax tokens ── */
+
+.json-editor-code .token.property {
+  color: var(--accent-text);
+}
+
+.json-editor-code .token.string {
+  color: light-dark(var(--green-8), var(--green-4));
+}
+
+.json-editor-code .token.number {
+  color: light-dark(var(--blue-8), var(--blue-4));
+}
+
+.json-editor-code .token.boolean,
+.json-editor-code .token.null {
+  color: light-dark(var(--purple-8), var(--purple-4));
+}
+
+.json-editor-code .token.punctuation,
+.json-editor-code .token.operator {
+  color: var(--text-3);
+}

--- a/src/main/resources/static/js/modules/editor/editor.page.js
+++ b/src/main/resources/static/js/modules/editor/editor.page.js
@@ -1,6 +1,8 @@
 import "../../layouts/dashboard.layout.js";
 import htmx from "htmx.org";
 import dot from 'dot-object';
+import { initJsonView } from "./json-view.js";
+import { createJsonEditor } from "../../shared/components/json-editor.component.js";
 
 /**
  * Maps input[type] values to their corresponding coercion functions.
@@ -97,10 +99,13 @@ htmx.defineExtension('dot-json', {
    * @param {XMLHttpRequest} xhr - The XMLHttpRequest instance.
    * @param {Object} parameters - The default htmx parameters (unused, replaced by DOM collection).
    * @param {HTMLElement} elt - The element that triggered the request.
-   * @returns {string} A JSON string of the coerced and dot-expanded parameters.
+   * @returns {string} A JSON string of the coerced and dot-expanded parameters,
+   *   or the JSON editor text verbatim while the JSON view is active.
    */
   encodeParameters(xhr, parameters, elt) {
     xhr.setRequestHeader('Content-Type', 'application/json');
+
+    if (jsonView?.active()) return jsonView.text();
 
     return JSON.stringify(dot.object(collectParams(elt)), stripNullsFromArrays);
   }
@@ -243,6 +248,26 @@ tabButtons.forEach((btn, i) => {
 document.addEventListener('htmx:afterSettle', updateTabCounts);
 
 const form = document.querySelector('.media-form');
+
+const customData = document.querySelector('#panel-customdata .json-editor');
+const customDataEditor =
+  customData ? createJsonEditor(customData, 'metadata.customData') : null;
+
+/**
+ * The JSON view over this form, sharing the serialization used by the
+ * dot-json extension on submit. Custom data is attached from its editor,
+ * mirroring the json coercion applied to it on submit.
+ */
+const jsonView = initJsonView(() => {
+  const payload = dot.object(collectParams(form));
+  const custom = customDataEditor?.read();
+
+  if (custom?.valid && custom.value !== undefined) {
+    payload.metadata = {...payload.metadata, customData: custom.value};
+  }
+
+  return JSON.stringify(payload, stripNullsFromArrays, 2);
+});
 
 /**
  * Toggles the `tab-in-error` class on a tab button based on whether its

--- a/src/main/resources/static/js/modules/editor/json-view.js
+++ b/src/main/resources/static/js/modules/editor/json-view.js
@@ -1,0 +1,117 @@
+import { createJsonEditor } from "../../shared/components/json-editor.component.js";
+
+const view = document.querySelector('.json-view');
+const toggle = document.getElementById('view-toggle');
+const form = document.querySelector('.media-form');
+const dialog = document.getElementById('json-discard-dialog');
+const editor = view ? createJsonEditor(view.querySelector('.json-editor')) : null;
+
+/**
+ * Returns whether the JSON view is currently shown, derived from the
+ * toggle button's pressed state.
+ * @returns {boolean} True while the JSON view is active.
+ */
+function jsonViewActive() {
+  return toggle.getAttribute('aria-pressed') === 'true';
+}
+
+/**
+ * Returns whether a tab panel belongs to the currently selected tab.
+ * @param {HTMLElement} panel - The tab panel element.
+ * @returns {boolean} True when the panel's tab is selected.
+ */
+function isSelectedPanel(panel) {
+  const tab = document.getElementById(panel.getAttribute('aria-labelledby'));
+
+  return tab?.getAttribute('aria-selected') === 'true';
+}
+
+/**
+ * Reflects the toggle state into the page: shows the JSON view or the
+ * form view with its selected tab panel, and relabels the toggle button.
+ */
+function syncView() {
+  const active = jsonViewActive();
+  const icon = toggle.querySelector('.material-symbols-outlined');
+  const label = toggle.querySelector('.view-toggle-label');
+
+  document.querySelector('.editor-tabs').hidden = active;
+  view.hidden = !active;
+  document.querySelectorAll('.tab-panel').forEach(panel => {
+    panel.hidden = active || !isSelectedPanel(panel);
+  });
+  icon.textContent = active ? 'edit_note' : 'data_object';
+  label.textContent = active ? 'Form' : 'JSON';
+  form.noValidate = active;
+}
+
+/**
+ * Asks whether to discard unsaved JSON edits.
+ * @returns {Promise<boolean>} Resolves true when discarding is confirmed.
+ */
+function confirmDiscard() {
+  dialog.returnValue = '';
+
+  return new Promise(resolve => {
+    dialog.addEventListener('close', () => {
+      resolve(dialog.returnValue === 'discard');
+    }, {once: true});
+    dialog.showModal();
+  });
+}
+
+/**
+ * Opens the JSON view over the serialized form state.
+ * @param {function(): string} serialize - Serializes the form to JSON text.
+ */
+function enterJsonView(serialize) {
+  editor.setText(serialize());
+  toggle.setAttribute('aria-pressed', 'true');
+  syncView();
+}
+
+/**
+ * Returns to the form view. Since JSON edits are never applied to the
+ * form, asks for confirmation first when the JSON text was changed.
+ * @param {function(): string} serialize - Serializes the form to JSON text.
+ */
+async function leaveJsonView(serialize) {
+  if (editor.getText() !== serialize() && !(await confirmDiscard())) return;
+
+  toggle.setAttribute('aria-pressed', 'false');
+  syncView();
+}
+
+/**
+ * Wires the JSON view: the toggle switches views, and while the JSON view
+ * is active the editor text is the payload submitted by the form.
+ * @param {function(): string} serialize - Serializes the form to JSON text.
+ * @returns {{active: function(): boolean, text: function(): string}|null}
+ *   Accessors for the submit path, or null when the page has no JSON view.
+ */
+export function initJsonView(serialize) {
+  if (!editor || !toggle) return null;
+
+  /**
+   * @listens HTMLButtonElement#click
+   */
+  toggle.addEventListener('click', () => {
+    if (jsonViewActive()) {
+      leaveJsonView(serialize);
+    } else {
+      enterJsonView(serialize);
+    }
+  });
+
+  /**
+   * Blocks saving from the JSON view while the text is not valid JSON.
+   * @listens document#htmx:beforeRequest
+   */
+  document.addEventListener('htmx:beforeRequest', (evt) => {
+    if (jsonViewActive() && evt.detail.elt === form && !editor.read().valid) {
+      evt.preventDefault();
+    }
+  });
+
+  return {active: jsonViewActive, text: editor.getText};
+}

--- a/src/main/resources/static/js/shared/components/json-editor.component.js
+++ b/src/main/resources/static/js/shared/components/json-editor.component.js
@@ -1,0 +1,197 @@
+import { CodeJar } from 'codejar';
+import Prism from 'prismjs/components/prism-core';
+import 'prismjs/components/prism-json';
+import { debounce } from '../debounce.js';
+
+Prism.manual = true;
+
+/**
+ * Renders Prism JSON highlighting into the editor element.
+ *
+ * @param {HTMLElement} editor - The element whose text content is highlighted.
+ */
+function highlightJson(editor) {
+  const code = editor.textContent;
+
+  editor.innerHTML = Prism.highlight(code, Prism.languages.json, 'json');
+}
+
+/**
+ * Pretty-prints JSON text, returning it unchanged when it does not parse.
+ *
+ * @param {string} text - The raw JSON text.
+ *
+ * @returns {string} The formatted text.
+ */
+function prettyText(text) {
+  try {
+    return JSON.stringify(JSON.parse(text), null, 2);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Shows a message in the error strip and marks the code surface invalid.
+ *
+ * @param {HTMLElement} code - The code surface element.
+ * @param {HTMLElement} error - The error strip element.
+ * @param {string} message - The message to display.
+ */
+function renderError(code, error, message) {
+  error.textContent = message;
+  error.hidden = false;
+  code.setAttribute('aria-invalid', 'true');
+}
+
+/**
+ * Clears the error strip and the invalid mark on the code surface.
+ *
+ * @param {HTMLElement} code - The code surface element.
+ * @param {HTMLElement} error - The error strip element.
+ */
+function clearError(code, error) {
+  error.textContent = '';
+  error.hidden = true;
+  code.removeAttribute('aria-invalid');
+}
+
+/**
+ * Parses editor text as JSON, reflecting the outcome in the error strip.
+ *
+ * @param {string} text - The raw editor text.
+ * @param {HTMLElement} code - The code surface element.
+ * @param {HTMLElement} error - The error strip element.
+ * @param {boolean} allowEmpty - When true, blank text is valid with no value.
+ *
+ * @returns {{valid: boolean, value: (*|undefined)}} The parse outcome.
+ */
+function parseText(text, code, error, allowEmpty) {
+  if (allowEmpty && text.trim() === '') {
+    clearError(code, error);
+
+    return {valid: true, value: undefined};
+  }
+
+  try {
+    const value = JSON.parse(text);
+
+    clearError(code, error);
+
+    return {valid: true, value};
+  } catch (e) {
+    renderError(code, error, e.message);
+
+    return {valid: false};
+  }
+}
+
+/**
+ * Creates the editor's code surface, named after the nearest `.field`
+ * label when present.
+ *
+ * @param {HTMLElement} element - The element hosting the editor.
+ *
+ * @returns {HTMLElement} The code surface element.
+ */
+function createCodeSurface(element) {
+  const code = document.createElement('pre');
+  const label = element.closest('.field')?.querySelector('label');
+
+  code.className = 'json-editor-code';
+  code.setAttribute('aria-label', label?.textContent.trim() || 'JSON editor');
+  code.spellcheck = false;
+
+  return code;
+}
+
+/**
+ * Creates the editor's error strip.
+ *
+ * @returns {HTMLElement} The error strip element.
+ */
+function createErrorStrip() {
+  const error = document.createElement('p');
+
+  error.className = 'json-editor-error';
+  error.setAttribute('role', 'alert');
+  error.hidden = true;
+
+  return error;
+}
+
+/**
+ * Creates the hidden form input mirroring the editor content.
+ *
+ * @param {string|null} name - The input name, or null for no form binding.
+ *
+ * @returns {HTMLInputElement|null} The created input, or null.
+ */
+function createInput(name) {
+  if (!name) return null;
+
+  const input = document.createElement('input');
+
+  input.type = 'text';
+  input.hidden = true;
+  input.id = name;
+  input.name = name;
+  input.setAttribute('data-type', 'json');
+
+  return input;
+}
+
+/**
+ * Creates a syntax-highlighted JSON editor inside the element, seeded
+ * from its text content. The code surface takes its accessible name from
+ * the nearest `.field` label, falling back to a generic one.
+ *
+ * @param {HTMLElement} element - The element to build the editor in.
+ * @param {string} [name] - Form input name; when set, the editor creates
+ *   and syncs a hidden input carrying its content.
+ * @param {number} [revalidationDebounce] - Quiet period in ms before
+ *   re-validating edits.
+ *
+ * @returns {{setText: Function, getText: Function, read: Function}} The editor API.
+ */
+export function createJsonEditor(
+  element,
+  name = null,
+  revalidationDebounce = 400,
+) {
+  const text = prettyText(element.textContent.trim());
+  const input = createInput(name);
+  const code = createCodeSurface(element);
+  const error = createErrorStrip();
+
+  element.replaceChildren(...[input, code, error].filter(Boolean));
+
+  const jar = CodeJar(code, highlightJson, {tab: '  '});
+
+  jar.onUpdate(debounce(content => {
+    if (input) input.value = content;
+
+    const {valid} = parseText(jar.toString(), code, error, Boolean(input));
+
+    input?.setCustomValidity(valid ? '' : 'Invalid JSON');
+  }, revalidationDebounce));
+  jar.updateCode(text);
+
+  return {
+    /**
+     * Replaces the editor content with the given JSON text.
+     * @param {string} value - The JSON text to display.
+     */
+    setText: (value) => { jar.updateCode(value); clearError(code, error); },
+    /**
+     * Returns the raw editor text.
+     * @returns {string} The current editor content.
+     */
+    getText: () => jar.toString(),
+    /**
+     * Parses the editor content, reporting the outcome in the error strip.
+     * @returns {{valid: boolean, value: (*|undefined)}} The parse outcome.
+     */
+    read: () => parseText(jar.toString(), code, error, Boolean(input)),
+  };
+}

--- a/src/main/resources/static/js/shared/debounce.js
+++ b/src/main/resources/static/js/shared/debounce.js
@@ -1,0 +1,15 @@
+/**
+ * Returns a wrapper that delays calls to fn until the given quiet period
+ * has elapsed since the last invocation.
+ * @param {Function} fn - The function to debounce.
+ * @param {number} delayMs - The quiet period in milliseconds.
+ * @returns {Function} The debounced wrapper.
+ */
+export function debounce(fn, delayMs) {
+  let timeout = null;
+
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => fn(...args), delayMs);
+  };
+}

--- a/src/main/resources/templates/modules/editor/editor.page.peb
+++ b/src/main/resources/templates/modules/editor/editor.page.peb
@@ -21,6 +21,9 @@
       <span class="editor-title">
         {% if exists %}{{ item.metadata.title | default(item.id) }}{% else %}New Media{% endif %}
       </span>
+      <button type="button" id="view-toggle" class="btn-icon" aria-pressed="false">
+        <span class="material-symbols-outlined">data_object</span><span class="view-toggle-label">JSON</span>
+      </button>
       <button type="submit" class="btn-primary">{{ exists ? "Save Changes" : "Publish" }}</button>
     </header>
 
@@ -159,8 +162,17 @@
     {# ── Custom Data ─────────────────────────────────────────── #}
     <div class="tab-panel" id="panel-customdata" role="tabpanel" aria-labelledby="tab-btn-customdata" hidden>
       <article class="tab-section">
-        {{ inputJson("metadata.customData", "Custom Data", item.metadata.customData, rows=12) }}
+        <div class="field">
+          <label for="metadata.customData">Custom Data</label>
+          {% include "../../shared/components/json-editor.component.peb" with {"value": item.metadata.customData} %}
+        </div>
       </article>
+    </div>
+
+    {# ── JSON view ────────────────────────────────────────────── #}
+    <div class="json-view" hidden>
+      <p>Edit the JSON payload. Switching back to the form view will discard the current changes.</p>
+      {% include "../../shared/components/json-editor.component.peb" %}
     </div>
 
     {# ── Datalists ────────────────────────────────────────────── #}
@@ -229,4 +241,15 @@
 
   </form>
 </main>
+
+<dialog closedby="any" id="json-discard-dialog" class="json-discard-dialog">
+  <form method="dialog">
+    <h3>Discard JSON changes?</h3>
+    <p>Changes made in the JSON view are not applied to the form. Save from the JSON view to keep them.</p>
+    <footer>
+      <button value="cancel" class="btn">Cancel</button>
+      <button value="discard" class="btn btn-danger">Discard</button>
+    </footer>
+  </form>
+</dialog>
 {% endblock %}

--- a/src/main/resources/templates/shared/components/json-editor.component.peb
+++ b/src/main/resources/templates/shared/components/json-editor.component.peb
@@ -1,0 +1,2 @@
+{# @pebvariable name="value" type="java.lang.Object" #}
+<div class="json-editor">{{ value }}</div>

--- a/src/main/resources/templates/shared/macros/forms.macros.peb
+++ b/src/main/resources/templates/shared/macros/forms.macros.peb
@@ -39,14 +39,6 @@
 </div>
 {% endmacro %}
 
-{% macro inputJson(name, label, value, rows=3, required=false) %}
-<div class="field">
-  <label for="{{ name }}">{{ label }}</label>
-  <textarea id="{{ name }}" name="{{ name }}" rows="{{ rows }}"
-            {% if required %}required{% endif %} data-type="json">{{ value }}</textarea>
-</div>
-{% endmacro %}
-
 {% macro inputCheckbox(name, label, checked=false) %}
 <div class="field">
     <label class="checkbox">


### PR DESCRIPTION
## Description

Resolves #24 by adding raw JSON editing to the media editor page.

## Changes Made

- New shared json editor component using CodeJar and Prism JSON highlighting.
- Adds a JSON / Form toggle to th editor page.
- Invalid JSON blocks saving from the JSON view.
- For simplicity JSON edits are not applied back to the form, a confirmation dialog alerts about the potential discarded changes.
- The Custom Data tab also uses the json editor component.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
