### PR TITLE
feat(media): add an expiration date to media

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ AUTH_SCOPES=openid,profile,email
 # The base URL of the SRG SSR Integration Layer, used to import media by URN.
 INTEGRATION_LAYER_BASE_URL=https://il.srgssr.ch
 
+# --- Display Configuration ---
+
+# The IANA time zone the console renders and reads.
+DISPLAY_TIME_ZONE=Europe/Zurich
+
 # --- Session Configuration ---
 
 # The secret key used to sign the session cookie.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "dot-object": "^2.1.5",
         "htmx.org": "^2.0.10",
         "open-props": "^1.7.23",
-        "prismjs": "^1.30.0"
+        "prismjs": "^1.30.0",
+        "temporal-polyfill": "^1.0.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.6",
@@ -8088,6 +8089,28 @@
       "engines": {
         "node": ">=14.16"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-1.0.4.tgz",
+      "integrity": "sha512-MLEU0qOD2uXlz24oINNtdLZQl8RgmMxSnRtKEGZGGetTJjlRwQJjk+VsJ4EREaUoiaTb8NJOcUiKtoAiWn9EBg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "1.0.1",
+        "temporal-utils": "1.0.2"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.1.tgz",
+      "integrity": "sha512-wxVoanmDeavXie1vu2JaQ3WIc3JZnWAOYFBsJyATaVsXsycKYUflGsyBmrRSnoCpZJpwPyr38VpgSUlQ8CbFxg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/temporal-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/temporal-utils/-/temporal-utils-1.0.2.tgz",
+      "integrity": "sha512-1B8Dl4KzrOvsNUlpoWGno2VLQlxroLjDgc5NBjVC9ax9ymdo+ezfyvhyjEMx+IVfhINr6CIG2gcnlP95iRrybQ==",
+      "license": "MIT"
     },
     "node_modules/tempy": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dot-object": "^2.1.5",
     "htmx.org": "^2.0.10",
     "open-props": "^1.7.23",
-    "prismjs": "^1.30.0"
+    "prismjs": "^1.30.0",
+    "temporal-polyfill": "^1.0.4"
   }
 }

--- a/scripts/esbuild.mjs
+++ b/scripts/esbuild.mjs
@@ -32,7 +32,7 @@ await esbuild.build({
   format: 'esm',
   chunkNames: 'js/chunks/[name]-[hash]',
   platform: 'browser',
-  target: ['es2020'],
+  target: ['es2022'],
   logLevel: 'info',
   plugins: [ktorStaticUrlPlugin]
 });

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/Application.kt
@@ -13,6 +13,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.api.team
 import ch.srgssr.pillarbox.backend.entrypoint.web.api.user
 import ch.srgssr.pillarbox.backend.entrypoint.web.console.console
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.PillarboxPebbleExtension
+import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toDisplayConfig
 import ch.srgssr.pillarbox.backend.integrationlayer.integrationLayerModule
 import ch.srgssr.pillarbox.backend.io.httpClientModule
 import ch.srgssr.pillarbox.backend.io.jsonModule
@@ -55,13 +56,15 @@ fun Application.module() {
     gzip()
   }
 
+  val displayConfig = environment.config.toDisplayConfig()
+
   install(Pebble) {
     loader(
       ClasspathLoader().apply {
         prefix = "templates"
       },
     )
-    extension(PillarboxPebbleExtension())
+    extension(PillarboxPebbleExtension(displayConfig.timeZone))
   }
 
   install(Koin) {

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Media.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/domain/model/Media.kt
@@ -17,6 +17,7 @@ import kotlin.uuid.Uuid
  * @property deleted Whether the media has been deleted or not.
  * @property createdAt The time when the media was created.
  * @property lastModified The time when the media was last modified.
+ * @property expiresAt The [Instant] representing expiration time of the media.
  */
 @Serializable
 @OptIn(ExperimentalUuidApi::class)
@@ -28,7 +29,13 @@ data class Media(
   val deleted: Boolean = false,
   val createdAt: Instant = Clock.System.now(),
   val lastModified: Instant = Clock.System.now(),
-)
+  val expiresAt: Instant? = null,
+) {
+  /**
+   * Returns `true` if the current system time has surpassed the [expiresAt] threshold.
+   */
+  val expired: Boolean get() = expiresAt?.let { it <= Clock.System.now() } ?: false
+}
 
 /**
  * Information about a specific streamable source.

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/FolderRoute.kt
@@ -18,7 +18,7 @@ import ch.srgssr.pillarbox.backend.persistence.folder.FolderPermissionRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderTable
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
-import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaVisibility
 import ch.srgssr.pillarbox.backend.persistence.team.TeamRepository
 import ch.srgssr.pillarbox.backend.persistence.user.UserRepository
 import io.ktor.http.HttpStatusCode
@@ -100,7 +100,7 @@ fun Route.folder(
                 folderId = id,
                 limit,
                 offset,
-                filter = { MediaTable.deleted eq false },
+                filter = { MediaVisibility.ACTIVE },
               ).map { it.toMediaResponseV1() }
               .items
               .toList(),

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRoute.kt
@@ -10,6 +10,7 @@ import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toMediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.utils.toQuerySlice
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaVisibility
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.auth.authenticate
 import io.ktor.server.request.receive
@@ -43,7 +44,7 @@ fun Route.media(mediaRepository: MediaRepository) {
           val query = call.request.queryParameters["q"]
           call.respond(
             mediaRepository
-              .findActiveMedia(query, limit, offset)
+              .findMedia(query, limit, offset, filter = { MediaVisibility.ACTIVE })
               .map { it.toMediaResponseV1() },
           )
         }
@@ -54,7 +55,7 @@ fun Route.media(mediaRepository: MediaRepository) {
 
         val media =
           mediaRepository.findOne {
-            (MediaTable.id eq id) and (MediaTable.deleted eq false)
+            (MediaTable.id eq id) and MediaVisibility.ACTIVE
           } ?: return@get call.respond(HttpStatusCode.NotFound)
 
         call.respond(media.toMediaResponseV1())

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRoute.kt
@@ -11,6 +11,7 @@ import ch.srgssr.pillarbox.backend.io.parseParamList
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaVisibility
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.request.ApplicationRequest
 import io.ktor.server.response.respond
@@ -44,7 +45,7 @@ fun Route.playerMedia(
           val query = call.request.queryParameters["q"]
           call.respond(
             mediaRepository
-              .findActiveMedia(query, limit, offset)
+              .findMedia(query, limit, offset, filter = { MediaVisibility.PLAYABLE })
               .map { it.toPlayerResponse(mediaSourceSelector) },
           )
         }
@@ -57,7 +58,7 @@ fun Route.playerMedia(
 
         val media =
           mediaRepository.findOne {
-            (MediaTable.id eq id) and (MediaTable.deleted eq false)
+            (MediaTable.id eq id) and MediaVisibility.PLAYABLE
           } ?: return@get call.respond(HttpStatusCode.NotFound)
 
         call.respond(media.toPlayerResponse(call.request.toMediaSourceSelector()))
@@ -79,7 +80,7 @@ fun Route.playerMedia(
                 folderId = id,
                 limit,
                 offset,
-                filter = { MediaTable.deleted eq false },
+                filter = { MediaVisibility.PLAYABLE },
               ).items
               .map { it.toPlayerResponse(mediaSourceSelector) },
           )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRoute.kt
@@ -12,6 +12,7 @@ import ch.srgssr.pillarbox.backend.log.info
 import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaVisibility
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.htmx.hx
 import io.ktor.server.response.respond
@@ -45,7 +46,7 @@ fun Route.mediaGridFragments(mediaRepository: MediaRepository) {
       val result =
         when {
           query != null -> mediaRepository.search(query, limit, offset, filter = { MediaTable.deleted eq deleted })
-          deleted -> mediaRepository.getAllPaginated(limit, offset, filter = { MediaTable.deleted eq true })
+          deleted -> mediaRepository.getAllPaginated(limit, offset, filter = { MediaVisibility.DELETED })
           folderId != null -> mediaRepository.findMediaInFolder(folderId, limit, offset)
           else -> mediaRepository.findMediaWithoutFolder(limit, offset)
         }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaSearchRoute.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaSearchRoute.kt
@@ -7,12 +7,11 @@ import ch.srgssr.pillarbox.backend.log.debug
 import ch.srgssr.pillarbox.backend.log.logger
 import ch.srgssr.pillarbox.backend.persistence.folder.FolderRepository
 import ch.srgssr.pillarbox.backend.persistence.media.MediaRepository
-import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaVisibility
 import io.ktor.server.htmx.hx
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
 import io.ktor.utils.io.ExperimentalKtorApi
-import org.jetbrains.exposed.v1.core.eq
 
 private object MediaSearchRoute
 
@@ -45,7 +44,7 @@ fun Route.mediaSearchFragments(
             buildMap { folderId?.let { put("folderId", it) } },
           )
 
-      val result = mediaRepository.search(query, limit, offset, filter = { MediaTable.deleted eq false })
+      val result = mediaRepository.search(query, limit, offset, filter = { MediaVisibility.ACTIVE })
       val mediaIds = result.items.map { it.id }
       val foldersByMedia = folderRepository.findFoldersOf(mediaIds)
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaRequestV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaRequestV1.kt
@@ -4,6 +4,7 @@ import ch.srgssr.pillarbox.backend.domain.model.Media
 import ch.srgssr.pillarbox.backend.domain.model.MediaMetadata
 import ch.srgssr.pillarbox.backend.domain.model.MediaSource
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 /**
  * Data Transfer Object (V1) representing a media request from the admin web entry point.
@@ -23,6 +24,7 @@ data class MediaRequestV1(
   val tags: List<String> = emptyList(),
   val sources: List<MediaSource> = emptyList(),
   val metadata: MediaMetadata,
+  val expiresAt: Instant? = null,
 ) {
   /**
    * Maps the [MediaRequestV1] DTO to the internal [Media] domain model.
@@ -38,5 +40,6 @@ data class MediaRequestV1(
       tags = tags,
       sources = sources,
       metadata = metadata,
+      expiresAt = expiresAt,
     )
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/MediaResponseV1.kt
@@ -33,6 +33,7 @@ data class MediaResponseV1(
   val deleted: Boolean,
   val createdAt: Instant,
   val lastModified: Instant,
+  val expiresAt: Instant?,
 )
 
 /**
@@ -51,4 +52,5 @@ fun Media.toMediaResponseV1() =
     deleted = this.deleted,
     createdAt = this.createdAt,
     lastModified = this.lastModified,
+    expiresAt = this.expiresAt,
   )

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1.kt
@@ -9,6 +9,8 @@ import ch.srgssr.pillarbox.backend.domain.model.TimeRange
 import ch.srgssr.pillarbox.backend.entrypoint.web.service.MediaSourceSelector
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 
 /**
  * Data Transfer Object (V1) optimized for media playback.
@@ -87,7 +89,11 @@ fun Media.toPlayerResponse(selector: MediaSourceSelector): PlayerMediaResponseV1
     subtitles = metadata.subtitles,
     chapters = metadata.chapters,
     timeRanges = metadata.timeRanges,
-    customData = metadata.customData,
+    customData =
+      buildJsonObject {
+        metadata.customData?.forEach { (k, v) -> put(k, v) }
+        expiresAt?.let { put("expiresAt", JsonPrimitive(it.toEpochMilliseconds())) }
+      }.takeIf { it.isNotEmpty() },
   )
 }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/DisplayConfig.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/DisplayConfig.kt
@@ -1,0 +1,31 @@
+package ch.srgssr.pillarbox.backend.entrypoint.web.utils
+
+import io.ktor.server.config.ApplicationConfig
+import java.time.ZoneId
+
+/**
+ * Configuration parameters for how the console renders values.
+ *
+ * @property timeZone The time zone dates are rendered and read in. Defaults to `Europe/Zurich`.
+ */
+data class DisplayConfig(
+  val timeZone: ZoneId = ZoneId.of("Europe/Zurich"),
+)
+
+/**
+ * Extracts [DisplayConfig] from the application's configuration file.
+ *
+ * @return A populated [DisplayConfig] instance.
+ */
+fun ApplicationConfig.toDisplayConfig(): DisplayConfig {
+  val display = config("display")
+
+  return DisplayConfig(
+    timeZone =
+      display
+        .propertyOrNull("timeZone")
+        ?.getString()
+        ?.let(ZoneId::of)
+        ?: ZoneId.of("Europe/Zurich"),
+  )
+}

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/PillarboxPebbleExtension.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/utils/PillarboxPebbleExtension.kt
@@ -1,26 +1,41 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.utils
 
-import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import ch.srgssr.pillarbox.backend.time.toZonedDateTime
 import io.pebbletemplates.pebble.extension.AbstractExtension
 import io.pebbletemplates.pebble.extension.Filter
 import io.pebbletemplates.pebble.template.EvaluationContext
 import io.pebbletemplates.pebble.template.PebbleTemplate
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.time.Instant
 
 /**
  * Pebble extension registering the console's custom template filters.
+ *
+ * @param zone The time zone dates are rendered in, exposed to templates as `timeZone`.
  */
-class PillarboxPebbleExtension : AbstractExtension() {
-  override fun getFilters(): Map<String, Filter> = mapOf("datetime" to DateTimeFilter())
+class PillarboxPebbleExtension(
+  private val zone: ZoneId,
+) : AbstractExtension() {
+  override fun getFilters(): Map<String, Filter> =
+    mapOf(
+      "datetime" to DateTimeFilter(zone),
+      "datetimeInput" to DateTimeInputFilter(zone),
+    )
+
+  override fun getGlobalVariables(): Map<String, Any> = mapOf("timeZone" to zone.id)
 }
 
 /**
- * Formats a Kotlin [Instant] as a human-readable UTC date and time, e.g. `6 Jun 2026, 14:32`.
+ * Formats a Kotlin [Instant] as a human-readable date and time, e.g. `6 Jun 2026, 14:32`.
  * Any other input is returned unchanged.
+ *
+ * @param zone The time zone the instant is read in.
  */
-private class DateTimeFilter : Filter {
+private class DateTimeFilter(
+  private val zone: ZoneId,
+) : Filter {
   private val formatter = DateTimeFormatter.ofPattern("d MMM yyyy, HH:mm", Locale.ENGLISH)
 
   override fun getArgumentNames(): List<String>? = null
@@ -31,5 +46,28 @@ private class DateTimeFilter : Filter {
     self: PebbleTemplate?,
     context: EvaluationContext?,
     lineNumber: Int,
-  ): Any? = (input as? Instant)?.toUtcOffsetDateTime()?.format(formatter) ?: input
+  ): Any? = (input as? Instant)?.toZonedDateTime(zone)?.format(formatter) ?: input
+}
+
+/**
+ * Formats a Kotlin [Instant] as the value of an `input[type=datetime-local]`, e.g.
+ * `2026-06-06T14:32`. Seconds are dropped, as the control does not accept them by default.
+ * Any other input is returned unchanged.
+ *
+ * @param zone The time zone the instant is read in.
+ */
+private class DateTimeInputFilter(
+  private val zone: ZoneId,
+) : Filter {
+  private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.ENGLISH)
+
+  override fun getArgumentNames(): List<String>? = null
+
+  override fun apply(
+    input: Any?,
+    args: Map<String, Any>?,
+    self: PebbleTemplate?,
+    context: EvaluationContext?,
+    lineNumber: Int,
+  ): Any? = (input as? Instant)?.toZonedDateTime(zone)?.format(formatter) ?: input
 }

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/folder/FolderRepository.kt
@@ -3,6 +3,7 @@ package ch.srgssr.pillarbox.backend.persistence.folder
 import ch.srgssr.pillarbox.backend.db.ExposedRepository
 import ch.srgssr.pillarbox.backend.domain.model.Folder
 import ch.srgssr.pillarbox.backend.persistence.media.MediaTable
+import ch.srgssr.pillarbox.backend.persistence.media.MediaVisibility
 import ch.srgssr.pillarbox.backend.time.toKotlinInstant
 import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -193,12 +194,12 @@ class FolderRepository(
       if (folderId != null) {
         (MediaTable leftJoin FolderMediaTable)
           .selectAll()
-          .where { (MediaTable.deleted eq false) and (FolderMediaTable.folderId eq folderId) }
+          .where { MediaVisibility.ACTIVE and (FolderMediaTable.folderId eq folderId) }
           .count()
       } else {
         (MediaTable leftJoin FolderMediaTable)
           .selectAll()
-          .where { (MediaTable.deleted eq false) and FolderMediaTable.mediaId.isNull() }
+          .where { MediaVisibility.ACTIVE and FolderMediaTable.mediaId.isNull() }
           .count()
       }
     }
@@ -218,7 +219,7 @@ class FolderRepository(
         val mediaCount = FolderMediaTable.mediaId.count()
         (MediaTable innerJoin FolderMediaTable)
           .select(FolderMediaTable.folderId, mediaCount)
-          .where { (MediaTable.deleted eq false) and (FolderMediaTable.folderId inList named) }
+          .where { MediaVisibility.ACTIVE and (FolderMediaTable.folderId inList named) }
           .groupBy(FolderMediaTable.folderId)
           .forEach { row ->
             results[row[FolderMediaTable.folderId]] = row[mediaCount]
@@ -229,7 +230,7 @@ class FolderRepository(
         results[null] =
           (MediaTable leftJoin FolderMediaTable)
             .selectAll()
-            .where { (MediaTable.deleted eq false) and FolderMediaTable.mediaId.isNull() }
+            .where { MediaVisibility.ACTIVE and FolderMediaTable.mediaId.isNull() }
             .count()
       }
 

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepository.kt
@@ -57,6 +57,7 @@ class MediaRepository(
       deleted = this[MediaTable.deleted],
       createdAt = this[MediaTable.createdAt].toKotlinInstant(),
       lastModified = this[MediaTable.lastModified].toKotlinInstant(),
+      expiresAt = this[MediaTable.expiresAt]?.toKotlinInstant(),
     )
 
   /**
@@ -73,6 +74,7 @@ class MediaRepository(
     builder[MediaTable.deleted] = item.deleted
     builder[MediaTable.createdAt] = Clock.System.now().toUtcOffsetDateTime()
     builder[MediaTable.lastModified] = Clock.System.now().toUtcOffsetDateTime()
+    builder[MediaTable.expiresAt] = item.expiresAt?.toUtcOffsetDateTime()
   }
 
   /**
@@ -84,6 +86,7 @@ class MediaRepository(
       it[MediaTable.sources] = item.sources
       it[MediaTable.metadata] = item.metadata
       it[MediaTable.lastModified] = Clock.System.now().toUtcOffsetDateTime()
+      it[MediaTable.expiresAt] = item.expiresAt?.toUtcOffsetDateTime()
     }
 
   /**
@@ -127,7 +130,7 @@ class MediaRepository(
    */
   suspend fun softDelete(id: String): Boolean =
     query {
-      MediaTable.update({ (MediaTable.id eq id) and (MediaTable.deleted eq false) }) {
+      MediaTable.update({ (MediaTable.id eq id) and MediaVisibility.ACTIVE }) {
         it[deleted] = true
         it[lastModified] = Clock.System.now().toUtcOffsetDateTime()
       } > 0
@@ -141,7 +144,7 @@ class MediaRepository(
    */
   suspend fun restore(id: String): Boolean =
     query {
-      MediaTable.update({ (MediaTable.id eq id) and (MediaTable.deleted eq true) }) {
+      MediaTable.update({ (MediaTable.id eq id) and MediaVisibility.DELETED }) {
         it[deleted] = false
         it[lastModified] = Clock.System.now().toUtcOffsetDateTime()
       } > 0
@@ -168,7 +171,7 @@ class MediaRepository(
       MediaTable
         .join(FolderMediaTable, JoinType.INNER, MediaTable.id, FolderMediaTable.mediaId)
         .selectAll()
-        .where { (FolderMediaTable.folderId eq folderId) and (MediaTable.deleted eq false) }
+        .where { (FolderMediaTable.folderId eq folderId) and MediaVisibility.ACTIVE }
         .apply { filter?.let { andWhere(it) } }
         .apply { sort?.let { orderBy(*it.toTypedArray()) } }
         .paginated(limit, offset)
@@ -176,21 +179,23 @@ class MediaRepository(
     }
 
   /**
-   * Retrieves a page of active (non-deleted) media, narrowed by an optional full-text [query].
+   * Retrieves a page of media, narrowed by an optional full-text [query] and [filter].
    *
    * @param query Optional search text; blank or `null` lists the page unfiltered.
    * @param limit The maximum number of items to return.
    * @param offset The number of items to skip before returning results.
+   * @param filter An optional filter predicate.
    * @return The matching [Media] items, most relevant first when searching.
    */
-  suspend fun findActiveMedia(
+  suspend fun findMedia(
     query: String?,
     limit: Int = 100,
     offset: Long = 0,
+    filter: (() -> Op<Boolean>)? = null,
   ): List<Media> =
     when {
-      query.isNullOrBlank() -> getAll(limit, offset, filter = { MediaTable.deleted eq false }).toList()
-      else -> search(query, limit, offset, filter = { MediaTable.deleted eq false }).items
+      query.isNullOrBlank() -> getAll(limit, offset, filter).toList()
+      else -> search(query, limit, offset, filter).items
     }
 
   /**
@@ -212,7 +217,7 @@ class MediaRepository(
       MediaTable
         .join(FolderMediaTable, JoinType.LEFT, MediaTable.id, FolderMediaTable.mediaId)
         .selectAll()
-        .where { FolderMediaTable.mediaId.isNull() and (MediaTable.deleted eq false) }
+        .where { FolderMediaTable.mediaId.isNull() and MediaVisibility.ACTIVE }
         .apply { filter?.let { andWhere(it) } }
         .apply { sort?.let { orderBy(*it.toTypedArray()) } }
         .paginated(limit, offset)

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaTable.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaTable.kt
@@ -40,6 +40,11 @@ object MediaTable : Table("pb_media") {
   val lastModified = timestampWithTimeZone("last_modified")
 
   /**
+   * The time when this media will expire.
+   */
+  val expiresAt = timestampWithTimeZone("expires_at").nullable()
+
+  /**
    * List of available delivery sources.
    * Stored as a JSONB list of [MediaSource] objects.
    */

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaVisibility.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaVisibility.kt
@@ -1,0 +1,27 @@
+package ch.srgssr.pillarbox.backend.persistence.media
+
+import ch.srgssr.pillarbox.backend.time.toUtcOffsetDateTime
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.or
+import kotlin.time.Clock
+
+/**
+ * A convenient set of predicates to filter media by visibility.
+ */
+object MediaVisibility {
+  /** Filters out media that is expired or deleted. */
+  val PLAYABLE get() = ACTIVE and notExpired()
+
+  /** Filters out not deleted media, expired media might appear. */
+  val ACTIVE = MediaTable.deleted eq false
+
+  /** Shows only deleted media. */
+  val DELETED = MediaTable.deleted eq true
+}
+
+private fun notExpired(): Op<Boolean> =
+  MediaTable.expiresAt.isNull() or (MediaTable.expiresAt greater Clock.System.now().toUtcOffsetDateTime())

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/time/OffsetDateTime.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/time/OffsetDateTime.kt
@@ -1,7 +1,9 @@
 package ch.srgssr.pillarbox.backend.time
 
 import java.time.OffsetDateTime
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 import kotlin.time.toKotlinInstant
@@ -19,3 +21,11 @@ fun OffsetDateTime.toKotlinInstant() = this.toInstant().toKotlinInstant()
  * @return An [OffsetDateTime] set to the UTC (+00:00) offset.
  */
 fun Instant.toUtcOffsetDateTime(): OffsetDateTime = this.toJavaInstant().atOffset(ZoneOffset.UTC)
+
+/**
+ * Converts a Kotlin [Instant] to a Java [ZonedDateTime] in the given [zone].
+ *
+ * @param zone The time zone to read this instant in.
+ * @return A [ZonedDateTime] at the same instant, in [zone].
+ */
+fun Instant.toZonedDateTime(zone: ZoneId): ZonedDateTime = this.toJavaInstant().atZone(zone)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -47,6 +47,11 @@ integrationLayer {
   baseUrl = ${?INTEGRATION_LAYER_BASE_URL}
 }
 
+display {
+  timeZone = "Europe/Zurich"
+  timeZone = ${?DISPLAY_TIME_ZONE}
+}
+
 session {
   cookieSecret = ${?SESSION_COOKIE_SECRET}
   timeoutSeconds = 28800

--- a/src/main/resources/db/migration/V9__Add_Media_Expires_At.sql
+++ b/src/main/resources/db/migration/V9__Add_Media_Expires_At.sql
@@ -1,0 +1,3 @@
+ALTER TABLE pb_media ADD COLUMN expires_at TIMESTAMPTZ;
+
+CREATE INDEX pb_media_expires_at_idx ON pb_media (expires_at);

--- a/src/main/resources/static/css/layouts/_forms.css
+++ b/src/main/resources/static/css/layouts/_forms.css
@@ -175,6 +175,7 @@ form[data-submitted] .field:has(:invalid) label {
   .form-row,
   .form-row-half,
   .form-row-two-one,
+  .form-row-two-one-one,
   .form-row-three-one,
   .form-row-one-two,
   .form-row-compact,

--- a/src/main/resources/static/css/shared/fragments/media-grid.fragment.css
+++ b/src/main/resources/static/css/shared/fragments/media-grid.fragment.css
@@ -139,6 +139,11 @@
   background: var(--surface-3);
 }
 
+.media-card > header ul.tag-list li.expired {
+  color: var(--accent-text);
+  background: var(--accent-softer);
+}
+
 /* ── Action bar ── */
 .media-card > footer.actions {
   display: flex;

--- a/src/main/resources/static/js/modules/editor/editor.page.js
+++ b/src/main/resources/static/js/modules/editor/editor.page.js
@@ -3,6 +3,8 @@ import htmx from "htmx.org";
 import dot from 'dot-object';
 import { initJsonView } from "./json-view.js";
 import { createJsonEditor } from "../../shared/components/json-editor.component.js";
+import { parseJsonValue } from "../../shared/parseJsonValue.js";
+import { toInstant } from "../../shared/toInstant.js";
 
 /**
  * Maps input[type] values to their corresponding coercion functions.
@@ -15,11 +17,12 @@ const TYPE_COERCERS = {
 
 /**
  * Maps data-type attribute values to their corresponding coercion functions.
- * @type {Record<string, function(string): *>}
+ * @type {Record<string, function(HTMLInputElement): *>}
  */
 const DATA_TYPE_COERCERS = {
-  json: (value) => parseJsonValue(value),
-  array: (value) => value.split(',').map(v => v.trim()),
+  json: (input) => parseJsonValue(input.value),
+  array: (input) => input.value.split(',').map(v => v.trim()),
+  instant: (input) => toInstant(input.value, input.dataset.timeZone),
 };
 
 /**
@@ -37,22 +40,7 @@ function coerceValue(input) {
 
   const dataCoercer = DATA_TYPE_COERCERS[input.getAttribute('data-type')];
 
-  return dataCoercer ? dataCoercer(input.value) : input.value;
-}
-
-/**
- * Safely parses a JSON string, returning null if parsing fails.
- * @param {string} value - The JSON string to parse.
- * @returns {*|null} The parsed value, or null if parsing fails.
- */
-function parseJsonValue(value) {
-  try {
-    return JSON.parse(value);
-  } catch (e) {
-    console.error(e);
-
-    return null;
-  }
+  return dataCoercer ? dataCoercer(input) : input.value;
 }
 
 /**

--- a/src/main/resources/static/js/shared/parseJsonValue.js
+++ b/src/main/resources/static/js/shared/parseJsonValue.js
@@ -1,0 +1,14 @@
+/**
+ * Safely parses a JSON string, returning null if parsing fails.
+ * @param {string} value - The JSON string to parse.
+ * @returns {*|null} The parsed value, or null if parsing fails.
+ */
+export function parseJsonValue(value) {
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    console.error(e);
+
+    return null;
+  }
+}

--- a/src/main/resources/static/js/shared/toInstant.js
+++ b/src/main/resources/static/js/shared/toInstant.js
@@ -1,0 +1,21 @@
+if (!globalThis.Temporal) await import('temporal-polyfill/global');
+
+/**
+ * Converts a datetime-local value, read in the given zone, into an ISO instant.
+ * @param {string} value - The control's value, e.g. `2026-06-06T14:32`.
+ * @param {string} timeZone - The IANA time zone the value is read in.
+ * @returns {string|null} The ISO instant, or null when the value is not a date.
+ */
+export function toInstant(value, timeZone) {
+  try {
+    return globalThis.Temporal.PlainDateTime
+      .from(value)
+      .toZonedDateTime(timeZone)
+      .toInstant()
+      .toString();
+  } catch (e) {
+    console.error(e);
+
+    return null;
+  }
+}

--- a/src/main/resources/templates/modules/editor/editor.page.peb
+++ b/src/main/resources/templates/modules/editor/editor.page.peb
@@ -61,8 +61,9 @@
       <article class="tab-section">
         <div class="form-row form-row-two-one">
           {{ inputText("id", "Media ID", item.id, placeholder = "e.g. urn:pillarbox:12345") }}
-          {{ inputArray("tags", "Tags", item.tags | join(","), placeholder = "Comma-separated, e.g. hls, block-segment, live") }}
+          {{ inputDateTime("expiresAt", "Expires", item.expiresAt | datetimeInput, timeZone) }}
         </div>
+        {{ inputArray("tags", "Tags", item.tags | join(","), placeholder = "Comma-separated, e.g. hls, block-segment, live") }}
         <div class="form-row form-row-half">
           {{ inputText("metadata.title", "Title", item.metadata.title, required=true) }}
           {{ inputText("metadata.subtitle", "Subtitle", item.metadata.subtitle) }}

--- a/src/main/resources/templates/shared/macros/forms.macros.peb
+++ b/src/main/resources/templates/shared/macros/forms.macros.peb
@@ -15,6 +15,15 @@
 </div>
 {% endmacro %}
 
+{% macro inputDateTime(name, label, value, timeZone, required=false) %}
+<div class="field">
+  <label for="{{ name }}">{{ label }}</label>
+  <input type="datetime-local" id="{{ name }}" name="{{ name }}" value="{{ value }}"
+         {% if required %}required{% endif %}
+         data-type="instant" data-time-zone="{{ timeZone }}">
+</div>
+{% endmacro %}
+
 {% macro inputNumber(name, label, value, min=0, required=false, list="") %}
 <div class="field">
     <label for="{{ name }}">{{ label }}</label>

--- a/src/main/resources/templates/shared/macros/media-card.macros.peb
+++ b/src/main/resources/templates/shared/macros/media-card.macros.peb
@@ -28,7 +28,7 @@
     {% endif %}
     <h3>{{ media.metadata.title | default('Untitled Asset') }}</h3>
     <p>
-      {% if not media.deleted %}
+      {% if not media.deleted and not media.expired %}
       <button class="btn-icon"
               data-copy-url="/v1/player/media/{{ media.id }}"
               title="Copy Player API URL">
@@ -38,6 +38,9 @@
       {{ media.id }}
     </p>
     <ul class="tag-list">
+      {% if media.expired %}
+      <li class="expired">Expired</li>
+      {% endif %}
       {% for tag in media.tags %}
       <li>{{ tag }}</li>
       {% endfor %}

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/MediaRouteTest.kt
@@ -14,6 +14,7 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -28,6 +29,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import kotlin.time.Instant
 
 class MediaRouteTest :
   ShouldSpec({
@@ -153,6 +155,29 @@ class MediaRouteTest :
         client.post("/v1/media/does-not-exist/restore") {
           bearerAuth(tokenWithRoles(setOf(Role.ADMIN)))
         } shouldHaveStatus HttpStatusCode.NotFound
+      }
+    }
+
+    should("round-trip the expiry and keep serving expired media") {
+      testApplicationContext {
+        val expiresAt = Instant.parse("2020-06-06T12:32:00Z")
+        val media = mediaFixture { this.expiresAt = expiresAt }
+
+        client.post("/v1/media") {
+          bearerAuth(token)
+          contentType(ContentType.Application.Json)
+          setBody(media.toMediaRequestV1())
+        } shouldHaveStatus HttpStatusCode.Created
+
+        client
+          .get("/v1/media/${media.id}") { bearerAuth(token) }
+          .body<MediaResponseV1>()
+          .expiresAt shouldBe expiresAt
+
+        client
+          .get("/v1/media") { bearerAuth(token) }
+          .body<List<MediaResponseV1>>()
+          .map { it.id } shouldContainExactly listOf(media.id)
       }
     }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/api/PlayerMediaRouteTest.kt
@@ -1,5 +1,8 @@
 package ch.srgssr.pillarbox.backend.entrypoint.web.api
 
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.AssignMediaRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderRequestV1
+import ch.srgssr.pillarbox.backend.entrypoint.web.dto.FolderResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.PlayerMediaResponseV1
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.toPlayerMediaSourceV1
@@ -12,6 +15,7 @@ import ch.srgssr.pillarbox.backend.test.token
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -23,6 +27,8 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 class PlayerMediaRouteTest :
   ShouldSpec({
@@ -94,6 +100,74 @@ class PlayerMediaRouteTest :
         }
 
         client.getPlayerMediaPageV1(limit = 1, offset = 20).size shouldBe 0
+      }
+    }
+
+    should("hide expired media from the player API") {
+      testApplicationContext {
+        val expired =
+          mediaFixture {
+            id = "expired"
+            expiresAt = Clock.System.now() - 1.hours
+          }
+        val live =
+          mediaFixture {
+            id = "live"
+            expiresAt = Clock.System.now() + 1.hours
+          }
+
+        for (media in listOf(expired, live)) {
+          client.post("/v1/media") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(media.toMediaRequestV1())
+          } shouldHaveStatus HttpStatusCode.Created
+        }
+
+        client.get("/v1/player/media/${expired.id}") shouldHaveStatus HttpStatusCode.NotFound
+        client.get("/v1/player/media/${live.id}") shouldHaveStatus HttpStatusCode.OK
+
+        client
+          .getPlayerMediaPageV1(limit = 10, offset = 0)
+          .map { it.identifier } shouldContainExactly listOf(live.id)
+      }
+    }
+
+    should("hide expired media from a player folder listing") {
+      testApplicationContext {
+        val expired =
+          mediaFixture {
+            id = "expired"
+            expiresAt = Clock.System.now() - 1.hours
+          }
+        val live = mediaFixture { id = "live" }
+
+        val folder =
+          client
+            .post("/v1/folder") {
+              bearerAuth(token)
+              contentType(ContentType.Application.Json)
+              setBody(FolderRequestV1(name = "Season 1"))
+            }.body<FolderResponseV1>()
+
+        for (media in listOf(expired, live)) {
+          client.post("/v1/media") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(media.toMediaRequestV1())
+          } shouldHaveStatus HttpStatusCode.Created
+
+          client.post("/v1/folder/${folder.id}/media") {
+            bearerAuth(token)
+            contentType(ContentType.Application.Json)
+            setBody(AssignMediaRequestV1(mediaId = media.id))
+          } shouldHaveStatus HttpStatusCode.Created
+        }
+
+        client
+          .get("/v1/player/folder/${folder.id}/media")
+          .body<List<PlayerMediaResponseV1>>()
+          .map { it.identifier } shouldContainExactly listOf(live.id)
       }
     }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/EditorRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/EditorRouteTest.kt
@@ -23,6 +23,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import org.jsoup.Jsoup
+import kotlin.time.Instant
 
 class EditorRouteTest :
   ShouldSpec({
@@ -67,6 +68,29 @@ class EditorRouteTest :
         doc["input[name='metadata.title']"].first()?.attributes()["value"] shouldBe media.metadata.title
         doc["input[name='metadata.subtitle']"].first()?.attributes()["value"] shouldBe media.metadata.subtitle
         doc["input[name='id']"].first()?.attributes()["value"] shouldBe media.id
+      }
+    }
+
+    should("populate the expiry field in the display time zone") {
+      testApplicationContext {
+        login()
+        // 12:32 UTC in June is 14:32 in Zurich, which is what the control must show.
+        val media = mediaFixture { expiresAt = Instant.parse("2026-06-06T12:32:00Z") }
+
+        client.hxPost("${Navigation.CONSOLE}/actions/media") {
+          contentType(ContentType.Application.Json)
+          setBody(media)
+        }
+
+        val response = client.get("${Navigation.CONSOLE}/editor/${media.id}")
+        response shouldHaveStatus HttpStatusCode.OK
+
+        val doc = Jsoup.parse(response.bodyAsText())
+        val expiresAt = doc["input[name='expiresAt']"].first()
+
+        expiresAt?.attributes()?.get("type") shouldBe "datetime-local"
+        expiresAt?.attributes()?.get("value") shouldBe "2026-06-06T14:32"
+        expiresAt?.attributes()?.get("data-time-zone") shouldBe "Europe/Zurich"
       }
     }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRouteTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/console/MediaGridRouteTest.kt
@@ -29,6 +29,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import org.jsoup.Jsoup
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 class MediaGridRouteTest :
   ShouldSpec({
@@ -52,6 +54,30 @@ class MediaGridRouteTest :
         val doc = Jsoup.parse(response.bodyAsText())
 
         doc.count(".media-card") shouldBe 5
+      }
+    }
+
+    should("mark expired media and hide its player URL") {
+      testApplicationContext {
+        login()
+
+        val expired = mediaFixture { expiresAt = Clock.System.now() - 1.hours }
+        val live = mediaFixture { expiresAt = Clock.System.now() + 1.hours }
+
+        for (media in listOf(expired, live)) {
+          client.hxPost("${Navigation.CONSOLE}/actions/media") {
+            contentType(ContentType.Application.Json)
+            setBody(media)
+          }
+        }
+
+        val doc = Jsoup.parse(client.hxGet("${Navigation.CONSOLE}/fragments/media-grid").bodyAsText())
+
+        doc.count(".media-card") shouldBe 2
+        doc.count("#media-card-${expired.id} .tag-list li.expired") shouldBe 1
+        doc.count("#media-card-${expired.id} [data-copy-url]") shouldBe 0
+        doc.count("#media-card-${live.id} .tag-list li.expired") shouldBe 0
+        doc.count("#media-card-${live.id} [data-copy-url]") shouldBe 1
       }
     }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1Test.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/entrypoint/web/dto/PlayerMediaResponseV1Test.kt
@@ -9,6 +9,9 @@ import ch.srgssr.pillarbox.backend.test.mediaFixture
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.time.Instant
 
 private data class SourceSelectionCase(
   val name: String,
@@ -345,5 +348,62 @@ class PlayerMediaResponseV1Test :
       response.title shouldBe "Title"
       response.description shouldBe "Description"
       response.episodeNumber shouldBe 1
+    }
+
+    context("expiration in custom data") {
+      val selector = MediaSourceSelector(emptyList(), emptyList())
+
+      should("expose the expiration as epoch milliseconds") {
+        val media = mediaFixture { expiresAt = Instant.parse("2026-06-06T12:32:00Z") }
+
+        val response = media.toPlayerResponse(selector)
+
+        response.customData shouldBe
+          buildJsonObject {
+            put("expiresAt", JsonPrimitive(1780749120000L))
+          }
+      }
+
+      should("keep the custom data defined on the metadata") {
+        val media =
+          mediaFixture {
+            expiresAt = Instant.parse("2026-06-06T12:32:00Z")
+            metadata =
+              metadata.copy(
+                customData =
+                  buildJsonObject {
+                    put("analyticsId", JsonPrimitive("abc"))
+                  },
+              )
+          }
+
+        val response = media.toPlayerResponse(selector)
+
+        response.customData shouldBe
+          buildJsonObject {
+            put("analyticsId", JsonPrimitive("abc"))
+            put("expiresAt", JsonPrimitive(1780749120000L))
+          }
+      }
+
+      should("omit the expiration when the media never expires") {
+        val media =
+          mediaFixture {
+            metadata =
+              metadata.copy(
+                customData =
+                  buildJsonObject {
+                    put("analyticsId", JsonPrimitive("abc"))
+                  },
+              )
+          }
+
+        val response = media.toPlayerResponse(selector)
+
+        response.customData shouldBe
+          buildJsonObject {
+            put("analyticsId", JsonPrimitive("abc"))
+          }
+      }
     }
   })

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepositoryTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/persistence/media/MediaRepositoryTest.kt
@@ -12,6 +12,9 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import org.jetbrains.exposed.v1.core.eq
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 
 private fun media(
   id: String,
@@ -20,12 +23,14 @@ private fun media(
   description: String? = null,
   tags: List<String> = emptyList(),
   deleted: Boolean = false,
+  expiresAt: Instant? = null,
 ) = Media(
   id = id,
   tags = tags,
   sources = listOf(MediaLibrary.Dash),
   metadata = MediaMetadata(title = title, subtitle = subtitle, description = description),
   deleted = deleted,
+  expiresAt = expiresAt,
 )
 
 class MediaRepositoryTest :
@@ -109,6 +114,29 @@ class MediaRepositoryTest :
           .search("glacier", filter = { MediaTable.deleted eq false })
           .items
           .map { it.id } shouldContainExactly listOf("live")
+      }
+    }
+
+    should("keep expired media out of the playable visibility only") {
+      testApplicationContext {
+        startApplication()
+        repository.save(media(id = "undated", title = "Glacier hike"))
+        repository.save(media(id = "future", title = "Glacier walk", expiresAt = Clock.System.now() + 1.hours))
+        repository.save(media(id = "expired", title = "Glacier melt", expiresAt = Clock.System.now() - 1.hours))
+        repository.save(media(id = "binned", title = "Glacier descent", deleted = true))
+
+        // Listing and searching narrow through the same predicate.
+        for (query in listOf(null, "glacier")) {
+          repository
+            .findMedia(query, filter = { MediaVisibility.PLAYABLE })
+            .map { it.id } shouldContainExactlyInAnyOrder listOf("undated", "future")
+          repository
+            .findMedia(query, filter = { MediaVisibility.ACTIVE })
+            .map { it.id } shouldContainExactlyInAnyOrder listOf("undated", "future", "expired")
+          repository
+            .findMedia(query, filter = { MediaVisibility.DELETED })
+            .map { it.id } shouldContainExactly listOf("binned")
+        }
       }
     }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/test/MediaFixtures.kt
@@ -8,6 +8,7 @@ import ch.srgssr.pillarbox.backend.domain.model.MediaSource
 import ch.srgssr.pillarbox.backend.domain.model.SubtitleTrack
 import ch.srgssr.pillarbox.backend.domain.model.TimeRange
 import ch.srgssr.pillarbox.backend.entrypoint.web.dto.MediaRequestV1
+import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -63,6 +64,7 @@ class MediaBuilder {
   private val chapters = mutableListOf<Chapter>()
   private val timeRanges = mutableListOf<TimeRange>()
   var metadata = MediaMetadata(title = "Default Test Title")
+  var expiresAt: Instant? = null
 
   fun withSource(source: MediaSource) =
     apply {
@@ -100,6 +102,7 @@ class MediaBuilder {
           chapters = chapters.ifEmpty { null },
           timeRanges = timeRanges.ifEmpty { null },
         ),
+      expiresAt = expiresAt,
     )
 }
 
@@ -111,4 +114,5 @@ fun Media.toMediaRequestV1() =
     tags = tags,
     sources = sources,
     metadata = metadata,
+    expiresAt = expiresAt,
   )


### PR DESCRIPTION
## Description

Resolves #29 by adding an optional expiration time to the media object.

## Changes Made

- Expired media is hidden from the Player API and shows an "Expired" pill in the console grid.
- Added a configurable time zone for the console display, the editor converts from the configured display time zone to an instant using the Temporal API.
- Raised the esbuild target to es2022 and added a temporal-polyfill.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
