### PR TITLE
feat(integrationlayer): map validTo to the media expiration date

### DIFF
--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerModels.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/IntegrationLayerModels.kt
@@ -1,6 +1,7 @@
 package ch.srgssr.pillarbox.backend.integrationlayer
 
 import kotlinx.serialization.Serializable
+import kotlin.time.Instant
 
 /**
  * The Integration Layer media composition returned for a URN lookup.
@@ -38,6 +39,8 @@ data class MediaComposition(
  * @property description A detailed description of the content.
  * @property imageUrl URL to an image representing the chapter.
  * @property mediaType The kind of media, either `VIDEO` or `AUDIO`.
+ * @property validFrom The start of the validity period for this chapter.
+ * @property validTo The end of the validity period for this chapter.
  * @property subtitleList The external subtitle tracks available for the chapter.
  * @property resourceList The playable stream resources, best variants first.
  * @property segmentList The logical segments contained in the chapter.
@@ -50,6 +53,8 @@ data class CompositionChapter(
   val description: String? = null,
   val imageUrl: String? = null,
   val mediaType: String? = null,
+  val validFrom: Instant? = null,
+  val validTo: Instant? = null,
   val subtitleList: List<Subtitle> = emptyList(),
   val resourceList: List<Resource> = emptyList(),
   val segmentList: List<Segment> = emptyList(),

--- a/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapper.kt
+++ b/src/main/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapper.kt
@@ -44,6 +44,7 @@ fun MediaComposition.toMedia(): Media? {
         subtitles = chapter.toSubtitleTracks().ifEmpty { null },
         chapters = chapter.toChapters().ifEmpty { null },
       ),
+    expiresAt = chapter.validTo,
   )
 }
 

--- a/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapperTest.kt
+++ b/src/test/kotlin/ch/srgssr/pillarbox/backend/integrationlayer/MediaCompositionMapperTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.json.Json
+import kotlin.time.Instant
 
 private val json = Json { ignoreUnknownKeys = true }
 
@@ -27,6 +28,7 @@ class MediaCompositionMapperTest :
         media.metadata.seasonNumber shouldBe 2
         media.metadata.episodeNumber shouldBe 7
         media.tags shouldBe emptyList()
+        media.expiresAt.shouldBeNull()
       }
 
       should("fall back to the lead when the description is blank") {
@@ -100,6 +102,10 @@ class MediaCompositionMapperTest :
         media.metadata.episodeNumber.shouldBeNull()
         media.metadata.chapters.shouldBeNull()
         media.metadata.subtitles.shouldBeNull()
+      }
+
+      should("map the chapter validity end to the expiration date") {
+        media.expiresAt shouldBe Instant.parse("2026-07-15T00:00:00+02:00")
       }
     }
 

--- a/src/test/resources/integrationlayer/media-composition-live-drm.json
+++ b/src/test/resources/integrationlayer/media-composition-live-drm.json
@@ -19,6 +19,8 @@
       "imageTitle": "RTS 1",
       "type": "LIVESTREAM",
       "date": "2026-07-08T00:00:00+02:00",
+      "validFrom": "2026-07-08T00:00:00+02:00",
+      "validTo": "2026-07-15T00:00:00+02:00",
       "duration": 0,
       "playableAbroad": false,
       "displayable": true,


### PR DESCRIPTION
## Description

Resolves #146 by exporting the Integration Layer chapter validity window into the backend media model. The main chapter's `validTo` becomes the media `expiresAt`.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
