### PR TITLE
feat(build): bump JDK to 26

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ matrix.language == 'java-kotlin' }}
         uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '26'
           distribution: 'temurin'
           cache: 'gradle'
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '26'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '24'
+          java-version: '26'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=24
 FROM node:${NODE_VERSION}-alpine AS node
 
-FROM eclipse-temurin:24-jdk-alpine AS build
+FROM eclipse-temurin:26-jdk-alpine AS build
 WORKDIR /app
 
 COPY --from=node /usr/local /usr/local
@@ -21,7 +21,7 @@ COPY scripts ./scripts
 
 RUN ./gradlew build -x test -x check
 
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:26-jre-alpine
 VOLUME /tmp
 COPY --from=build /app/build/libs/app.jar app.jar
-ENTRYPOINT ["sh", "-c", "java -Dsun.net.inetaddr.ttl=5 -Dsun.net.inetaddr.negative.ttl=10 -jar /app.jar"]
+ENTRYPOINT ["sh", "-c", "java --enable-native-access=ALL-UNNAMED -Dsun.net.inetaddr.ttl=5 -Dsun.net.inetaddr.negative.ttl=10 -jar /app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ group = "ch.srgssr.pillarbox"
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(24)
+    languageVersion = JavaLanguageVersion.of(26)
   }
 }
 
@@ -174,6 +174,13 @@ tasks.shadowJar {
 tasks.withType<Test> {
   useJUnitPlatform()
   finalizedBy("koverXmlReport")
+
+  // Guava (via Testcontainers) calls sun.misc.Unsafe, and Netty loads a native
+  // library. Both warn on JDK 24+.
+  jvmArgs(
+    "--sun-misc-unsafe-memory-access=allow",
+    "--enable-native-access=ALL-UNNAMED",
+  )
 }
 
 // ==============================================================================
@@ -195,6 +202,9 @@ tasks.named<JavaExec>("run") {
   ): String = System.getenv(key) ?: localEnv.getProperty(key) ?: default
 
   val isDev = getEnv("DEVELOPMENT", "true").toBoolean()
+
+  // Netty loads a native library, which warns on JDK 24+.
+  jvmArgs("--enable-native-access=ALL-UNNAMED")
 
   // --- Ktor ---
   systemProperty("io.ktor.development", isDev)

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,14 @@ version=dev
 # https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
 org.gradle.caching=true
 
-# Let Detekt use Gradle's Worker API
+# Run Detekt in the Gradle daemon. Its Worker API forks a JVM that does not
+# inherit org.gradle.jvmargs, which reintroduces the sun.misc.Unsafe warning.
 # https://detekt.dev/docs/gettingstarted/gradle/#options-for-detekt-gradle-properties
-detekt.use.worker.api=true
+detekt.use.worker.api=false
+
+# Silence the sun.misc.Unsafe deprecation warning that the Kotlin compiler emits
+# on JDK 24+. JDK 26 still only warns; the flag opts out of the warning, not out
+# of a removal.
+# https://openjdk.org/jeps/498
+org.gradle.jvmargs=-Xms256m -Xmx512m -XX:MaxMetaspaceSize=384m -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseCodeCacheFlushing -XX:+UseParallelGC --sun-misc-unsafe-memory-access=allow
+kotlin.daemon.jvmargs=--sun-misc-unsafe-memory-access=allow

--- a/src/main/resources/static/css/shared/components/json-editor.component.css
+++ b/src/main/resources/static/css/shared/components/json-editor.component.css
@@ -60,10 +60,10 @@
 }
 
 .json-editor-error {
+  max-inline-size: none;
   margin: 0;
   font-size: var(--font-size-0);
   color: var(--red-5);
-  max-inline-size: none;
 }
 
 /* ── Syntax tokens ── */


### PR DESCRIPTION
## Description

Bump the JVM version from 24 to 26 on all workflows, Gradle configuration and the produces docker image.

## Changes Made

Silence the JVM warnings:

- Add `--sun-misc-unsafe-memory-access=allow` to the Gradle daemon and the Kotlin daemon (Kotlin compiler), and to the test JVM (Guava, pulled in by Testcontainers).
- Add `--enable-native-access=ALL-UNNAMED` to the test JVM, the run task, and the Docker entrypoint.
- Set `detekt.use.worker.api=false` so Detekt runs in the Gradle daemon.

## Checklist

- [x] I have followed the project's style and contribution guidelines.
- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
